### PR TITLE
Allow yielding of trained models [Resolves #11]

### DIFF
--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -122,3 +122,11 @@ def test_model_trainer():
                 engine.execute('select * from results.feature_importances')
             ]
             assert len(records) == 4 * 3  # maybe exclude entity_id?
+
+            # 7. that the generator interface works the same way
+            new_model_ids = trainer.generate_trained_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict()
+            )
+            assert expected_model_ids == \
+                sorted([model_id for model_id in new_model_ids])

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -86,3 +86,7 @@ def test_predictor():
                 join results.models using (model_id)''')
             ]
             assert len(records) == 4
+
+            # 6. That we can delete the model when done prediction on it
+            predictor.delete_model(model_id)
+            assert predictor.load_model(model_id) == None

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,4 @@
-from triage.storage import S3Store, FSStore
+from triage.storage import S3Store, FSStore, MemoryStore
 from moto import mock_s3
 import boto3
 import os
@@ -19,6 +19,8 @@ def test_S3Store():
         assert store.exists()
         newVal = store.load()
         assert newVal.val == 'val'
+        store.delete()
+        assert not store.exists()
 
 
 def test_FSStore():
@@ -30,4 +32,16 @@ def test_FSStore():
     assert store.exists()
     newVal = store.load()
     assert newVal.val == 'val'
-    os.remove('tmpfile')
+    store.delete()
+    assert not store.exists()
+
+
+def test_MemoryStore():
+    store = MemoryStore(None)
+    assert not store.exists()
+    store.write(SomeClass('val'))
+    assert store.exists()
+    newVal = store.load()
+    assert newVal.val == 'val'
+    store.delete()
+    assert not store.exists()

--- a/triage/storage.py
+++ b/triage/storage.py
@@ -30,6 +30,9 @@ class S3Store(Store):
     def load(self):
         return download_object(self.path)
 
+    def delete(self):
+        self.path.delete()
+
 
 class FSStore(Store):
     def exists(self):
@@ -43,6 +46,9 @@ class FSStore(Store):
         with open(self.path, 'rb') as f:
             return pickle.load(f)
 
+    def delete(self):
+        os.remove(self.path)
+
 
 class MemoryStore(Store):
     store = None
@@ -55,6 +61,9 @@ class MemoryStore(Store):
 
     def load(self):
         return self.store
+
+    def delete(self):
+        self.store = None
 
 
 class ModelStorageEngine(object):


### PR DESCRIPTION
- Implement ModelTrainer.generate_trained_models as a generator interface for each trained model when grid training
- Implement Store.delete() for enable projects to clean up their stored models, either from storage or the references for garbage collection
- Implement Predictor.delete_model to make Store.delete() available from the model_id rather than the model hash (future: implement id-awareness into storage, or return hashes alongside ids from trainer?)