### PR TITLE
Make triage pipeline importable [Resolves #19]

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 
+include triage/model_group_stored_procedure.sql
+
 include AUTHORS.rst
 
 include CONTRIBUTING.rst

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,45 @@ Risk modeling and prediction
 * Documentation: https://triage.readthedocs.io.
 
 
+Basic Usage
+--------
+
+The simplest usage of triage is to use the Pipeline class. It requires:
+
+
+* An experiment config. This contains time splitting, feature generation, grid search, and model scoring configuration. An up-to-date example is at example_experiment_config.yaml. This is passed in dict format to the Pipeline constructor
+* a SQLAlchemy Postgres db engine. There is a convenience wrapper at triage.db.connect(), that reads from a local database.yaml file, but you supply an engine created however you like.
+* Pick a model storage engine class from the `triage.storage` module. The model storage engines are wrappers around various ways to cache models, and are exclusively used for model caching inside triage components. Currently implemented are InMemoryModelStorageEngine (no caching), FSModelStorageEngine (on local or mounted disk), S3ModelStorageEngine (direct to s3).
+* Pick a project path. This is used by the persistent storage engines.
+
+Pipeline.run() is expected to be called after an ETL step. Given a properly configured experiment config, it will handle label generation, training/test splits, feature generation (using collate), training, testing, and scoring. The model metadata, feature importances, predictions, and model scores are saved to the `results` schema in the given database. The trained model pickles are saved to the storage engine passed into the Pipeline constructor, along with metadata files.
+
+
+.. code-block::
+
+    from triage.db import connect
+    from triage.storage import FSModelStorageEngine
+    from triage.pipeline import Pipeline
+
+
+        with open('example_experiment_config.yaml') as f:
+            experiment_config = yaml.load(f)
+        pipeline = Pipeline(
+            config=experiment_config,
+            db_engine=connect(),
+            model_storage_class=FSModelStorageEngine,
+            project_path='/path/to/cached_models/test_project'
+        )
+
+        pipeline.run()
+
+
+Advanced Usage
+--------
+
+The current method of changing behavior beyond what can be controlled in the experiment config file is to use the inner components (e.g. FeatureGenerator, ModelTrainer, etc). You can copy the Pipeline class at triage/pipeline.py and modify the contents. Support will be added in the future for subclassing the pipeline and/or passing in subclassed components like an alternate label generator.
+
+
 Features
 --------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+SQLAlchemy
+GeoAlchemy2
+PyYAML
+psycopg2
+python-dateutil
+scipy
+sklearn
+tables
+pandas
+boto3
+collate
+click
+inflection

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,18 +1,6 @@
-SQLAlchemy
-GeoAlchemy2
-PyYAML
-click
-inflection
-psycopg2
-python-dateutil
-git+git://github.com/dssg/collate.git
-scipy
-sklearn
-tables
+-r requirements.txt
 
 testing.postgresql
-pandas
-boto3
 moto
 
 pip==8.1.2

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [
-    'Click>=6.0',
-    # TODO: put package requirements here
-]
+with open('requirements.txt') as requirements_file:
+    requirements = requirements_file.readlines()
 
 test_requirements = [
     # TODO: put package test requirements here
@@ -46,9 +44,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',

--- a/triage/db.py
+++ b/triage/db.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.url import URL
 
+import os
 import yaml
 
 
@@ -31,7 +32,11 @@ event.listen(
     DDL("CREATE SCHEMA IF NOT EXISTS results")
 )
 
-with open('triage/model_group_stored_procedure.sql') as f:
+group_proc_filename = os.path.join(
+    os.path.dirname(__file__),
+    'model_group_stored_procedure.sql'
+)
+with open(group_proc_filename) as f:
     stmt = f.read()
 
 event.listen(


### PR DESCRIPTION
- Add stored procedure creation script to manifest
- Use __file__ to import correctly when imported as module
- Include requirements in setup.py
- Use new tagged collate
- Use https for tarball download
- Update README with usage