### PR TITLE
Instantiate pipeline components in constructor [Resolves #44]

### DIFF
--- a/tests/test_feature_generators.py
+++ b/tests/test_feature_generators.py
@@ -87,6 +87,7 @@ def test_training_label_generation():
 
         output_tables = FeatureGenerator(
             db_engine=engine,
+            features_schema_name='features'
         ).generate(
             feature_dates=['2013-09-30', '2014-09-30'],
             feature_aggregations=aggregate_config,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -66,10 +66,10 @@ def test_integration():
 
             # instantiate pipeline objects
             trainer = ModelTrainer(
-                project_path,
-                model_storage_engine,
-                train_store,
-                db_engine,
+                project_path=project_path,
+                model_storage_engine=model_storage_engine,
+                matrix_store=None,
+                db_engine=db_engine,
             )
             predictor = Predictor(
                 project_path,
@@ -91,7 +91,8 @@ def test_integration():
             }
             model_ids = trainer.train_models(
                 grid_config=grid_config,
-                misc_db_parameters=dict()
+                misc_db_parameters=dict(),
+                matrix_store=train_store
             )
 
             for model_id in model_ids:

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -13,7 +13,10 @@ from triage.model_trainers import ModelTrainer
 from triage.storage import S3ModelStorageEngine, InMemoryMatrixStore
 
 
-def test_model_trainer():
+# uses the deprecated old call signature
+# when matrix_store is only offered through train_models and
+# generate_trained_models, remove this and only leave the other test
+def test_model_trainer_oldsig():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         ensure_db(engine)
@@ -135,6 +138,151 @@ def test_model_trainer():
             new_model_ids = trainer.generate_trained_models(
                 grid_config=grid_config,
                 misc_db_parameters=dict()
+            )
+            assert expected_model_ids == \
+                sorted([model_id for model_id in new_model_ids])
+
+
+def test_model_trainer():
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        ensure_db(engine)
+
+        grid_config = {
+            'sklearn.linear_model.LogisticRegression': {
+                'C': [0.00001, 0.0001],
+                'penalty': ['l1', 'l2'],
+                'random_state': [2193]
+            }
+        }
+
+        with mock_s3():
+            s3_conn = boto3.resource('s3')
+            s3_conn.create_bucket(Bucket='econ-dev')
+
+            # create training set
+            matrix = pandas.DataFrame.from_dict({
+                'entity_id': [1, 2],
+                'feature_one': [3, 4],
+                'feature_two': [5, 6],
+                'label': ['good', 'bad']
+            })
+            metadata = {
+                'start_time': datetime.date(2012, 12, 20),
+                'end_time': datetime.date(2016, 12, 20),
+                'label_name': 'label',
+                'prediction_window': '1y',
+                'feature_names': ['ft1', 'ft2']
+            }
+            project_path = 'econ-dev/inspections'
+            model_storage_engine = S3ModelStorageEngine(s3_conn, project_path)
+            trainer = ModelTrainer(
+                project_path=project_path,
+                model_storage_engine=model_storage_engine,
+                db_engine=engine,
+                matrix_store=None,
+            )
+            matrix_store = InMemoryMatrixStore(matrix, metadata)
+            model_ids = trainer.train_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict(),
+                matrix_store=matrix_store
+            )
+
+            # assert
+            # 1. that the models and feature importances table entries are present
+            records = [
+                row for row in
+                engine.execute('select * from results.feature_importances')
+            ]
+            assert len(records) == 4 * 3  # maybe exclude entity_id?
+
+            records = [
+                row for row in
+                engine.execute('select model_hash from results.models')
+            ]
+            assert len(records) == 4
+
+            cache_keys = [
+                model_cache_key(project_path, model_row[0], s3_conn)
+                for model_row in records
+            ]
+
+            # 2. that the model groups are distinct
+            records = [
+                row for row in
+                engine.execute('select distinct model_group_id from results.models')
+            ]
+            assert len(records) == 4
+
+            # 3. that all four models are cached
+            model_pickles = [
+                pickle.loads(cache_key.get()['Body'].read())
+                for cache_key in cache_keys
+            ]
+            assert len(model_pickles) == 4
+            assert len([x for x in model_pickles if x is not None]) == 4
+
+            # 4. that their results can have predictions made on it
+            test_matrix = pandas.DataFrame.from_dict({
+                'entity_id': [3, 4],
+                'feature_one': [4, 4],
+                'feature_two': [6, 5],
+            })
+            for model_pickle in model_pickles:
+                predictions = model_pickle.predict(test_matrix)
+                assert len(predictions) == 2
+
+            # 5. when run again, same models are returned
+            new_model_ids = trainer.train_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict(),
+                matrix_store=matrix_store
+            )
+            assert len([
+                row for row in
+                engine.execute('select model_hash from results.models')
+            ]) == 4
+            assert model_ids == new_model_ids
+
+            # 6. if metadata is deleted but the cache is still there,
+            # retrains that one and replaces the feature importance records
+            engine.execute('delete from results.feature_importances where model_id = 3')
+            engine.execute('delete from results.models where model_id = 3')
+            new_model_ids = trainer.train_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict(),
+                matrix_store=matrix_store
+            )
+            expected_model_ids = [1, 2, 4, 5]
+            assert expected_model_ids == sorted(new_model_ids)
+            assert [
+                row['model_id'] for row in
+                engine.execute('select model_id from results.models order by 1 asc')
+            ] == expected_model_ids
+
+            records = [
+                row for row in
+                engine.execute('select * from results.feature_importances')
+            ]
+            assert len(records) == 4 * 3  # maybe exclude entity_id?
+
+            # 7. if the cache is missing but the metadata is still there, reuse the metadata
+            for row in engine.execute('select model_hash from results.models'):
+                model_storage_engine.get_store(row[0]).delete()
+            expected_model_ids = [1, 2, 4, 5]
+            new_model_ids = trainer.train_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict(),
+                matrix_store=matrix_store
+            )
+            assert expected_model_ids == sorted(new_model_ids)
+
+            # 8. that the generator interface works the same way
+            new_model_ids = trainer.generate_trained_models(
+                grid_config=grid_config,
+                misc_db_parameters=dict(),
+                matrix_store=matrix_store
             )
             assert expected_model_ids == \
                 sorted([model_id for model_id in new_model_ids])

--- a/triage/feature_generators.py
+++ b/triage/feature_generators.py
@@ -4,8 +4,9 @@ import logging
 
 
 class FeatureGenerator(object):
-    def __init__(self, db_engine):
+    def __init__(self, db_engine, features_schema_name):
         self.db_engine = db_engine
+        self.features_schema_name = features_schema_name
 
     def aggregation(self, aggregation_config, feature_dates):
         aggregates = [
@@ -26,7 +27,7 @@ class FeatureGenerator(object):
             dates=feature_dates,
             date_column=aggregation_config['knowledge_date_column'],
             output_date_column='as_of_date',
-            schema='features',
+            schema=self.features_schema_name,
             prefix=aggregation_config['prefix']
         )
 

--- a/triage/model_trainers.py
+++ b/triage/model_trainers.py
@@ -7,6 +7,7 @@ import logging
 import datetime
 import copy
 import pandas
+import warnings
 from triage.utils import filename_friendly_hash
 
 
@@ -58,7 +59,13 @@ class ModelTrainer(object):
         self.db_engine = db_engine
         self.sessionmaker = sessionmaker(bind=self.db_engine)
 
-    def _model_hash(self, class_path, parameters):
+        if self.matrix_store is not None:
+            warnings.warn('''Passing a matrix_store in the constructor
+            is deprecated and will be removed in a future version.
+            Please pass it in .train_models or .generate_trained_models instead
+            ''', DeprecationWarning)
+
+    def _model_hash(self, matrix_metadata, class_path, parameters):
         """Generates a unique identifier for a trained model
         based on attributes of the model that together define
         equivalence; in other words, if we train a second model with these
@@ -74,7 +81,7 @@ class ModelTrainer(object):
             'className': class_path,
             'parameters': parameters,
             'project_path': self.project_path,
-            'training_metadata': self.matrix_store.metadata
+            'training_metadata': matrix_metadata
         }
         return filename_friendly_hash(unique)
 
@@ -88,7 +95,7 @@ class ModelTrainer(object):
             for parameters in ParameterGrid(parameter_config):
                 yield class_path, parameters
 
-    def _train(self, class_path, parameters):
+    def _train(self, matrix_store, class_path, parameters):
         """Fit a model to a training set. Works on any modeling class that
         is available in this package's environment and implements .fit
 
@@ -103,9 +110,9 @@ class ModelTrainer(object):
         module = importlib.import_module(module_name)
         cls = getattr(module, class_name)
         instance = cls(**parameters)
-        y = self.matrix_store.labels()
+        y = matrix_store.labels()
 
-        return instance.fit(self.matrix_store.matrix, y), self.matrix_store.matrix.columns
+        return instance.fit(matrix_store.matrix, y), matrix_store.matrix.columns
 
     def _write_model_to_db(
         self,
@@ -172,6 +179,7 @@ class ModelTrainer(object):
 
     def _train_and_store_model(
         self,
+        matrix_store,
         class_path,
         parameters,
         model_hash,
@@ -191,16 +199,17 @@ class ModelTrainer(object):
         """
         misc_db_parameters['run_time'] = datetime.datetime.now().isoformat()
         trained_model, feature_names = self._train(
+            matrix_store,
             class_path,
             parameters,
         )
-        
+
         model_group_id = self._get_model_group_id(
              class_path,
              parameters,
-             self.matrix_store.metadata['prediction_window'],
-             self.matrix_store.metadata['feature_names']
-        ) 
+             matrix_store.metadata['prediction_window'],
+             matrix_store.metadata['feature_names']
+        )
         logging.debug('Trained model')
         model_store.write(trained_model)
         logging.debug('Cached model')
@@ -267,13 +276,14 @@ class ModelTrainer(object):
         db_conn.close()
 
         logging.debug('Model_group_id = {}'.format(model_group_id))
-        return model_group_id         
+        return model_group_id
 
     def generate_trained_models(
         self,
         grid_config,
         misc_db_parameters,
-        replace=False
+        replace=False,
+        matrix_store=None
     ):
         """Train and store configured models, yielding the ids one by one
 
@@ -290,14 +300,16 @@ class ModelTrainer(object):
 
         Yields: (int) model ids
         """
+        matrix_store = matrix_store or self.matrix_store
         misc_db_parameters = copy.deepcopy(misc_db_parameters)
         misc_db_parameters['batch_run_time'] = datetime.datetime.now().isoformat()
         for class_path, parameters in self._generate_model_configs(grid_config):
-            model_hash = self._model_hash(class_path, parameters)
+            model_hash = self._model_hash(matrix_store.metadata, class_path, parameters)
             model_store = self.model_storage_engine.get_store(model_hash)
             if replace or not model_store.exists():
                 logging.info('Training %s/%s', class_path, parameters)
                 model_id = self._train_and_store_model(
+                    matrix_store,
                     class_path,
                     parameters,
                     model_hash,
@@ -319,6 +331,7 @@ class ModelTrainer(object):
                         parameters
                     )
                     model_id = self._train_and_store_model(
+                        matrix_store,
                         class_path,
                         parameters,
                         model_hash,
@@ -333,7 +346,8 @@ class ModelTrainer(object):
         self,
         grid_config,
         misc_db_parameters,
-        replace=False
+        replace=False,
+        matrix_store=None
     ):
         """Train and store configured models
 
@@ -355,7 +369,8 @@ class ModelTrainer(object):
             model_id for model_id in self.generate_trained_models(
                 grid_config,
                 misc_db_parameters,
-                replace
+                replace,
+                matrix_store or self.matrix_store
             )
         ]
 


### PR DESCRIPTION
- ModelTrainer now takes MatrixStore at runtime, not initialization time
- Pipeline now instantiates all component objects at initialization time, calling them at runtime
- FeatureGenerator now takes in schema name
- Naming consistency changes in Pipeline