### PR TITLE
Support inspections-style evaluation [Resolves #54]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -10,6 +10,7 @@ temporal_config:
     look_back_durations: # length of time included in a model
         - '6m'
         - '3m'
+    prediction_frequency: '1d' # per test set how often to generate predictions
 
 # LABEL GENERATION
 # Information needed to generate labels

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ boto3
 collate
 click
 inflection
+numpy>=1.12

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -107,7 +107,9 @@ def test_integration():
                         predictions,
                         test_store.labels(),
                         model_id,
-                        as_of_date
+                        as_of_date,
+                        as_of_date,
+                        '6month'
                     )
 
             # assert
@@ -134,8 +136,9 @@ def test_integration():
             # that evaluations are there
             records = [
                 row for row in
-                db_engine.execute('''select model_id, as_of_date, metric, parameter
-                from results.evaluations order by 2, 1''')
+                db_engine.execute('''
+                    select model_id, evaluation_start_time, metric, parameter
+                    from results.evaluations order by 2, 1''')
             ]
             assert records == [
                 (1, datetime.datetime(2016, 12, 21), 'precision@', '5_abs'),

--- a/triage/db.py
+++ b/triage/db.py
@@ -3,9 +3,9 @@ from sqlalchemy import \
     BigInteger,\
     Boolean,\
     Integer,\
+    Interval,\
     String,\
     Numeric,\
-    Date,\
     DateTime,\
     JSON,\
     Float,\
@@ -110,7 +110,9 @@ class Prediction(Base):
 class Evaluation(Base):
     __tablename__ = 'evaluations'
     model_id = Column(Integer, ForeignKey('models.model_id'), primary_key=True)
-    as_of_date = Column(DateTime, primary_key=True)
+    evaluation_start_time = Column(DateTime, primary_key=True)
+    evaluation_end_time = Column(DateTime, primary_key=True)
+    prediction_frequency = Column(Interval, primary_key=True)
     metric = Column(String, primary_key=True)
     parameter = Column(String, primary_key=True)
     value = Column(Numeric)


### PR DESCRIPTION
- Remove evaluations.as_of_date and add evaluation_start_time, evaluation_end_time, prediction_frequency
- Save new evaluations fields for each test matrix that is evaluated
- Turn evaluation back on when multiple as-of-dates are present in a test matrix (i.e. inspections-style time splitting)