### PR TITLE
Support parallelism [Resolves #28]

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,7 @@ import testing.postgresql
 from triage.db import ensure_db
 from triage.storage import InMemoryModelStorageEngine
 
-from triage.pipeline import Pipeline
+from triage.pipelines import LocalParallelPipeline, SerialPipeline
 
 
 def populate_source_data(db_engine):
@@ -85,7 +85,7 @@ def populate_source_data(db_engine):
         )
 
 
-def test_pipeline():
+def generic_pipeline_test(pipeline_class):
     with testing.postgresql.Postgresql() as postgresql:
         db_engine = create_engine(postgresql.url())
         ensure_db(db_engine)
@@ -131,7 +131,7 @@ def test_pipeline():
         }
 
         with TemporaryDirectory() as temp_dir:
-            Pipeline(
+            pipeline_class(
                 config=experiment_config,
                 db_engine=db_engine,
                 model_storage_class=InMemoryModelStorageEngine,
@@ -174,3 +174,11 @@ def test_pipeline():
             ''')
         ])
         assert num_evaluations > 0
+
+
+def test_serial_pipeline():
+    generic_pipeline_test(SerialPipeline)
+
+
+def test_local_parallel_pipeline():
+    generic_pipeline_test(LocalParallelPipeline)

--- a/triage/db.py
+++ b/triage/db.py
@@ -122,7 +122,7 @@ def ensure_db(engine):
     Base.metadata.create_all(engine)
 
 
-def connect():
+def connect(poolclass=NullPool):
     with open('database.yaml') as f:
         profile = yaml.load(f)
         dbconfig = {
@@ -133,4 +133,4 @@ def connect():
             'port': profile['port'],
         }
         dburl = URL('postgres', **dbconfig)
-        return create_engine(dburl, poolclass=NullPool)
+        return create_engine(dburl, poolclass=poolclass)

--- a/triage/pipelines/__init__.py
+++ b/triage/pipelines/__init__.py
@@ -1,0 +1,3 @@
+from .base import PipelineBase
+from .local_parallel import LocalParallelPipeline
+from .serial import SerialPipeline

--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -1,0 +1,96 @@
+from triage.db import ensure_db
+from triage.label_generators import BinaryLabelGenerator
+from triage.features import FeatureGenerator, FeatureDictionaryCreator
+from triage.model_trainers import ModelTrainer
+from triage.predictors import Predictor
+from triage.scoring import ModelScorer
+from timechop.timechop import Inspections
+from timechop.architect import Architect
+import os
+from datetime import datetime
+from abc import ABCMeta, abstractmethod
+
+
+def dt_from_str(dt_str):
+    return datetime.strptime(dt_str, '%Y-%m-%d')
+
+
+class PipelineBase(object):
+    __metaclass__ = ABCMeta
+
+    def __init__(self, config, db_engine, model_storage_class, project_path):
+        self.config = config
+        self.db_engine = db_engine
+        self.model_storage_engine =\
+            model_storage_class(project_path=project_path)
+        self.project_path = project_path
+        ensure_db(self.db_engine)
+
+        self.labels_table_name = 'labels'
+        self.features_schema_name = 'features'
+        self.matrices_directory = os.path.join(self.project_path, 'matrices')
+        if not os.path.exists(self.matrices_directory):
+            os.makedirs(self.matrices_directory)
+        self.initialize_components()
+
+    def initialize_components(self):
+        split_config = self.config['temporal_config']
+        self.chopper = Inspections(
+            beginning_of_time=dt_from_str(split_config['beginning_of_time']),
+            modeling_start_time=dt_from_str(split_config['modeling_start_time']),
+            modeling_end_time=dt_from_str(split_config['modeling_end_time']),
+            update_window=split_config['update_window'],
+            look_back_durations=split_config['look_back_durations'],
+            test_durations=split_config['test_durations'],
+        )
+
+        self.label_generator = BinaryLabelGenerator(
+            events_table=self.config['events_table'],
+            db_engine=self.db_engine
+        )
+
+        self.feature_generator = FeatureGenerator(
+            features_schema_name=self.features_schema_name,
+            db_engine=self.db_engine
+        )
+
+        self.feature_dictionary_creator = FeatureDictionaryCreator(
+            features_schema_name=self.features_schema_name,
+            db_engine=self.db_engine
+        )
+
+        self.architect = Architect(
+            beginning_of_time=dt_from_str(split_config['beginning_of_time']),
+            label_names=['outcome'],
+            label_types=['binary'],
+            db_config={
+                'features_schema_name': self.features_schema_name,
+                'labels_schema_name': 'public',
+                'labels_table_name': self.labels_table_name,
+            },
+            matrix_directory=self.matrices_directory,
+            user_metadata={},
+            engine=self.db_engine
+        )
+
+        self.trainer = ModelTrainer(
+            project_path=self.project_path,
+            model_storage_engine=self.model_storage_engine,
+            db_engine=self.db_engine,
+            matrix_store=None
+        )
+
+        self.predictor = Predictor(
+            project_path=self.project_path,
+            model_storage_engine=self.model_storage_engine,
+            db_engine=self.db_engine
+        )
+
+        self.model_scorer = ModelScorer(
+            metric_groups=self.config['scoring'],
+            db_engine=self.db_engine
+        )
+
+    @abstractmethod
+    def run(self):
+        pass

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -1,0 +1,135 @@
+from triage.storage import MettaCSVMatrixStore
+from triage.pipelines import PipelineBase
+import logging
+import os
+from datetime import datetime
+
+
+class SerialPipeline(PipelineBase):
+    def run(self):
+        # 1. generate temporal splits
+        split_definitions = self.chopper.chop_time()
+
+        # 2. create labels
+        logging.debug('---------------------')
+        logging.debug('---------LABEL GENERATION------------')
+        logging.debug('---------------------')
+
+        all_as_of_times = []
+        for split in split_definitions:
+            all_as_of_times.extend(split['train_matrix']['as_of_times'])
+            for test_matrix in split['test_matrices']:
+                all_as_of_times.extend(test_matrix['as_of_times'])
+        all_as_of_times = list(set(all_as_of_times))
+
+        logging.info(
+            'Found %s distinct as_of_times for label and feature generation',
+            len(all_as_of_times)
+        )
+        self.label_generator.generate_all_labels(
+            self.labels_table_name,
+            all_as_of_times,
+            self.config['temporal_config']['prediction_window']
+        )
+
+        # 3. generate features
+        logging.info('Generating features for %s', all_as_of_times)
+        tables_to_exclude = self.feature_generator.generate(
+            feature_aggregations=self.config['feature_aggregations'],
+            feature_dates=all_as_of_times,
+        )
+
+        # remove the schema and quotes from the table names
+        tables_to_exclude = [
+            tbl.split('.')[1].replace('"', "'")
+            for tbl in tables_to_exclude
+        ]
+
+        feature_dict = self.feature_dictionary_creator.feature_dictionary(
+            tables_to_exclude + [self.labels_table_name, 'tmp_entity_ids']
+        )
+
+        # 4. create training and test sets
+        logging.info('Creating matrices')
+        logging.debug('---------------------')
+        logging.debug('---------MATRIX GENERATION------------')
+        logging.debug('---------------------')
+
+        updated_split_definitions = self.architect.chop_data(
+            split_definitions,
+            feature_dict
+        )
+
+        for split in updated_split_definitions:
+            train_store = MettaCSVMatrixStore(
+                matrix_path=os.path.join(
+                    self.matrices_directory,
+                    '{}.csv'.format(split['train_uuid'])
+                ),
+                metadata_path=os.path.join(
+                    self.matrices_directory,
+                    '{}.yaml'.format(split['train_uuid'])
+                )
+            )
+            if train_store.matrix.empty:
+                logging.warning('''Train matrix for split %s was empty,
+                no point in training this model. Skipping
+                ''', split['train_uuid'])
+                continue
+            if len(train_store.labels().unique()) == 1:
+                logging.warning('''Train Matrix for split %s had only one
+                unique value, no point in training this model. Skipping
+                ''', split['train_uuid'])
+                continue
+
+            logging.info('Training models')
+            model_ids = self.trainer.train_models(
+                grid_config=self.config['grid_config'],
+                misc_db_parameters=dict(test=False),
+                matrix_store=train_store
+            )
+            logging.info('Done training models')
+
+            for split_def, test_uuid in zip(
+                split['test_matrices'],
+                split['test_uuids']
+            ):
+                as_of_times = split_def['as_of_times']
+                logging.info(
+                    'Testing and scoring as_of_times min: %s max: %s num: %s',
+                    min(as_of_times),
+                    max(as_of_times),
+                    len(as_of_times)
+                )
+                test_store = MettaCSVMatrixStore(
+                    matrix_path=os.path.join(
+                        self.matrices_directory,
+                        '{}.csv'.format(test_uuid)
+                    ),
+                    metadata_path=os.path.join(
+                        self.matrices_directory,
+                        '{}.yaml'.format(test_uuid)
+                    )
+                )
+                if test_store.matrix.empty:
+                    logging.warning('''Test matrix for train uuid %s
+                    was empty, no point in training this model. Skipping
+                    ''', split['train_uuid'])
+                    continue
+                for model_id in model_ids:
+                    logging.info('Testing model id %s', model_id)
+                    predictions, predictions_proba = self.predictor.predict(
+                        model_id,
+                        test_store,
+                        misc_db_parameters=dict()
+                    )
+
+                    self.model_scorer.score(
+                        predictions_proba=predictions_proba,
+                        predictions_binary=predictions,
+                        labels=test_store.labels(),
+                        model_id=model_id,
+                        evaluation_start_time=split_def['matrix_start_time'],
+                        evaluation_end_time=split_def['matrix_end_time'],
+                        prediction_frequency=self.config['temporal_config']['prediction_frequency']
+                    )

--- a/triage/storage.py
+++ b/triage/storage.py
@@ -129,10 +129,28 @@ class MettaMatrixStore(MatrixStore):
 
 class MettaCSVMatrixStore(MatrixStore):
     def __init__(self, matrix_path, metadata_path):
-        self.matrix = pandas.read_csv(matrix_path)
-        with open(metadata_path) as f:
-            self.metadata = yaml.load(f)
-        self.matrix.set_index(self.metadata['indices'], inplace=True)
+        self.matrix_path = matrix_path
+        self.metadata_path = metadata_path
+        self._matrix = None
+        self._metadata = None
+
+    @property
+    def matrix(self):
+        if self._matrix is None:
+            self._load()
+        return self._matrix
+
+    @property
+    def metadata(self):
+        if self._metadata is None:
+            self._load()
+        return self._metadata
+
+    def _load(self):
+        self._matrix = pandas.read_csv(self.matrix_path)
+        with open(self.metadata_path) as f:
+            self._metadata = yaml.load(f)
+        self._matrix.set_index(self.metadata['indices'], inplace=True)
 
 
 class InMemoryMatrixStore(MatrixStore):


### PR DESCRIPTION
- Create abstract class PipelineBase, which sets up components and requires subclasses to implement run
- Move current Pipeline to SerialPipeline, subclass of PipelineBase
- Create LocalParallelPipeline subclass of PipelineBase to spawn workers using concurrent.futures.ProcessPoolExecutor. Currently just parallelizing the testing phase
- Make poolclass configurable, as NullPool was giving some problems with multiple processes and QueuePool seems to be more robust
- Modify MettaCSVMatrixStorage to only load data upon use, improving serializability