### PR TITLE
Fix pipelines packaging, use QueuePool

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     url='https://github.com/dssg/triage',
     packages=[
         'triage',
+        'triage.pipelines',
     ],
     package_dir={'triage':
                  'triage'},

--- a/triage/db.py
+++ b/triage/db.py
@@ -18,7 +18,7 @@ from sqlalchemy import \
 from sqlalchemy.types import ARRAY
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from sqlalchemy.pool import NullPool
+from sqlalchemy.pool import QueuePool
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.engine.url import URL
 
@@ -122,7 +122,7 @@ def ensure_db(engine):
     Base.metadata.create_all(engine)
 
 
-def connect(poolclass=NullPool):
+def connect(poolclass=QueuePool):
     with open('database.yaml') as f:
         profile = yaml.load(f)
         dbconfig = {


### PR DESCRIPTION
Two problems: 

1. triage.pipelines is now a subdirectory as of https://github.com/dssg/triage/pull/68 , which means to package it means that it needs its own entry in setup.py

2. We were getting problems with error messages coming from SQLAlchemy when using NullPool in a multi-process environment (ie, after pull 68 above). These seem to go away with QueuePool, so that should be the default in triage.db.connect() but still allow injection