### PR TITLE
Fix exclusion of feature aggregation tables [Resolves #66]

### DIFF
--- a/tests/test_feature_generators.py
+++ b/tests/test_feature_generators.py
@@ -29,7 +29,7 @@ aggregate_config = [{
 }]
 
 expected_output = {
-    '"features"."aprefix_aggregation"': [
+    'aprefix_aggregation': [
         {
             'entity_id': 3,
             'as_of_date': date(2013, 9, 30),
@@ -85,9 +85,11 @@ def test_training_label_generation():
                 row
             )
 
+        features_schema_name = 'features'
+
         output_tables = FeatureGenerator(
             db_engine=engine,
-            features_schema_name='features'
+            features_schema_name=features_schema_name
         ).generate(
             feature_dates=['2013-09-30', '2014-09-30'],
             feature_aggregations=aggregate_config,
@@ -95,7 +97,9 @@ def test_training_label_generation():
 
         for output_table in output_tables:
             records = pandas.read_sql(
-                'select * from {} order by as_of_date, entity_id'.format(output_table),
+                'select * from {}.{} order by as_of_date, entity_id'.format(
+                    features_schema_name, output_table
+                ),
                 engine
             ).to_dict('records')
             assert records == expected_output[output_table]

--- a/triage/feature_generators.py
+++ b/triage/feature_generators.py
@@ -31,6 +31,10 @@ class FeatureGenerator(object):
             prefix=aggregation_config['prefix']
         )
 
+    def _clean_table_name(self, table_name):
+        # remove the schema and quotes from the name
+        return table_name.split('.')[1].replace('"', "")
+
     def generate(self, feature_aggregations, feature_dates):
         aggregations = [
             self.aggregation(aggregation_config, feature_dates)
@@ -45,4 +49,7 @@ class FeatureGenerator(object):
                     logging.debug(select)
             aggregation.execute(self.db_engine.connect())
         logging.info('Created %s aggregations', len(aggregations))
-        return [agg.get_table_name() for agg in aggregations]
+        return [
+            self._clean_table_name(agg.get_table_name())
+            for agg in aggregations
+        ]

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -45,14 +45,8 @@ class LocalParallelPipeline(PipelineBase):
             feature_dates=all_as_of_times,
         )
 
-        # remove the schema and quotes from the table names
-        tables_to_exclude = [
-            tbl.split('.')[1].replace('"', "'")
-            for tbl in tables_to_exclude
-        ]
-
         feature_dict = self.feature_dictionary_creator.feature_dictionary(
-            tables_to_exclude + [self.labels_table_name, 'tmp_entity_ids']
+            tables_to_exclude=tables_to_exclude + [self.labels_table_name]
         )
 
         # 4. create training and test sets

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -39,14 +39,8 @@ class SerialPipeline(PipelineBase):
             feature_dates=all_as_of_times,
         )
 
-        # remove the schema and quotes from the table names
-        tables_to_exclude = [
-            tbl.split('.')[1].replace('"', "'")
-            for tbl in tables_to_exclude
-        ]
-
         feature_dict = self.feature_dictionary_creator.feature_dictionary(
-            tables_to_exclude + [self.labels_table_name, 'tmp_entity_ids']
+            tables_to_exclude=tables_to_exclude + [self.labels_table_name]
         )
 
         # 4. create training and test sets


### PR DESCRIPTION
- Refactor stripping of returned collate feature table names into FeatureGenerator
- Change stripping of feature table names to reflect recent changes where exclusion is performed in Python instead of SQL
- Remove tmp_entity_ids from exclusion tables because it doesn't exist at this point in the pipeline