### PR TITLE
Bypass collate aggregate tables [Resolves #76]

### DIFF
--- a/tests/test_feature_dictionary_creator.py
+++ b/tests/test_feature_dictionary_creator.py
@@ -34,7 +34,7 @@ def test_feature_dictionary_creator():
             db_engine=engine
         )
         feature_dictionary = creator.feature_dictionary(
-            ['random_other_table']
+            ['feature_table_one', 'feature_table_two']
         )
         assert feature_dictionary == {
             'feature_table_one': ['feature_one', 'feature_two'],

--- a/tests/test_feature_generators.py
+++ b/tests/test_feature_generators.py
@@ -51,7 +51,7 @@ def test_feature_generation():
     }]
 
     expected_output = {
-        'aprefix_aggregation': [
+        'aprefix_entity_id': [
             {
                 'entity_id': 3,
                 'as_of_date': date(2013, 9, 30),
@@ -126,7 +126,7 @@ def test_dynamic_categoricals():
         'from_obj': 'data'
     }]
     expected_output = {
-        'aprefix_aggregation': [
+        'aprefix_entity_id': [
             {
                 'entity_id': 3,
                 'as_of_date': date(2013, 9, 30),

--- a/triage/feature_dictionary_creator.py
+++ b/triage/feature_dictionary_creator.py
@@ -4,19 +4,13 @@ class FeatureDictionaryCreator(object):
         self.features_schema_name = features_schema_name
         self.db_engine = db_engine
 
-    def feature_dictionary(self, tables_to_exclude):
+    def feature_dictionary(self, feature_table_names):
         """ Create a dictionary of feature names, where keys are feature tables
         and values are lists of feature names.
 
         :return: feature_dictionary
         :rtype: dict
         """
-        # prepare for iteration! get items to iterate over & initialize results
-        feature_table_names = [
-            row[0] for row in
-            self.db_engine.execute(self._build_feature_tables_list_query())
-            if row[0] not in tables_to_exclude
-        ]
         feature_dictionary = {}
 
         # iterate! store each table name + features names as key-value pair
@@ -29,23 +23,6 @@ class FeatureDictionaryCreator(object):
             ]
             feature_dictionary[feature_table_name] = feature_names
         return(feature_dictionary)
-
-    def _build_feature_tables_list_query(self):
-        """ Write a query to get a list of tables in the feature schema.
-
-        :return: query
-        :rtype: str
-        """
-        # format the query that gets table names,
-        feature_table_names_query = """
-            SELECT table_name
-            FROM information_schema.tables
-            WHERE table_schema = '{schema}'
-        """.format(
-            schema=self.features_schema_name
-        )
-
-        return(feature_table_names_query)
 
     def _build_feature_names_query(self, table_name):
         """ For a given feature table, get the names of the feature columns.

--- a/triage/feature_generators.py
+++ b/triage/feature_generators.py
@@ -93,14 +93,16 @@ class FeatureGenerator(object):
 
         tables = []
         for group in aggregation.groups:
+            group_table = self._clean_table_name(
+                aggregation.get_table_name(group=group)
+            )
+            logging.info('Processing group table %s', group_table)
             conn.execute(drops[group])
             conn.execute(creates[group])
             for insert in inserts[group]:
                 conn.execute(insert)
             conn.execute(indexes[group])
-            tables.append(
-                self._clean_table_name(aggregation.get_table_name(group=group))
-            )
+            tables.append(group_table)
 
         trans.commit()
         return tables

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -40,14 +40,13 @@ class LocalParallelPipeline(PipelineBase):
 
         # 3. generate features
         logging.info('Generating features for %s as_of_times', len(all_as_of_times))
-        tables_to_exclude = self.feature_generator.generate(
+        feature_tables = self.feature_generator.generate(
             feature_aggregations=self.config['feature_aggregations'],
             feature_dates=all_as_of_times,
         )
 
-        feature_dict = self.feature_dictionary_creator.feature_dictionary(
-            tables_to_exclude=tables_to_exclude + [self.labels_table_name]
-        )
+        feature_dict = self.feature_dictionary_creator\
+            .feature_dictionary(feature_tables)
 
         # 4. create training and test sets
         logging.info('Creating matrices')

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -34,14 +34,13 @@ class SerialPipeline(PipelineBase):
 
         # 3. generate features
         logging.info('Generating features for %s', all_as_of_times)
-        tables_to_exclude = self.feature_generator.generate(
+        feature_tables = self.feature_generator.generate(
             feature_aggregations=self.config['feature_aggregations'],
             feature_dates=all_as_of_times,
         )
 
-        feature_dict = self.feature_dictionary_creator.feature_dictionary(
-            tables_to_exclude=tables_to_exclude + [self.labels_table_name]
-        )
+        feature_dict = self.feature_dictionary_creator\
+            .feature_dictionary(feature_tables)
 
         # 4. create training and test sets
         logging.info('Creating matrices')


### PR DESCRIPTION
- Implement FeatureGenerator#_create_aggregation_tables, which reimplements SpacetimeAggregation.execute but bypassing aggregation tables for speed
- Return list of created feature tables from FeatureGenerator#generate
- Modify FeatureDictionaryCreator to take in a list of feature tables instead of querying information_schema for tables