### PR TITLE
Support Parallelization of Matrix Creation [Resolves #81]

### DIFF
--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -13,6 +13,7 @@ from timechop.architect import Architect
 import os
 from datetime import datetime
 from abc import ABCMeta, abstractmethod
+from functools import partial
 
 
 def dt_from_str(dt_str):
@@ -71,7 +72,8 @@ class PipelineBase(object):
             self.config.get('feature_group_strategies', ['all'])
         )
 
-        self.architect = Architect(
+        self.architect_factory = partial(
+            Architect,
             beginning_of_time=dt_from_str(split_config['beginning_of_time']),
             label_names=['outcome'],
             label_types=['binary'],
@@ -82,8 +84,9 @@ class PipelineBase(object):
             },
             matrix_directory=self.matrices_directory,
             user_metadata={},
-            engine=self.db_engine
         )
+
+        self.architect = self.architect_factory(engine=self.db_engine)
 
         self.trainer = ModelTrainer(
             project_path=self.project_path,

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -52,10 +52,11 @@ class SerialPipeline(PipelineBase):
         logging.debug('---------MATRIX GENERATION------------')
         logging.debug('---------------------')
 
-        updated_split_definitions = self.architect.chop_data(
+        updated_split_definitions, build_tasks = self.architect.generate_plans(
             split_definitions,
             feature_dicts
         )
+        self.architect.build_all_matrices(build_tasks)
 
         for split in updated_split_definitions:
             train_store = MettaCSVMatrixStore(


### PR DESCRIPTION
- Introduce architect_factory to PipelineBase constructor, pre-binding all serializable parameters. This is to make instantiation of new Architects across process boundaries easier
- Use new Architect#generate_plans interface in both Serial and LocalParallel pipelines
- Run Architect#build_matrix tasks in parallel using concurrent.Futures in the LocalParallel pipeline