### PR TITLE
Add leave-one-in feature group mixer strategy [Resolves #88]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -98,7 +98,7 @@ feature_group_definition:
     tables: ['prefix_entity_id']
 
 # strategies for generating combinations of groups
-# available: all, leave-one-out
+# available: all, leave-one-out, leave-one-in
 feature_group_strategies: ['all']
 
 

--- a/tests/test_feature_group_mixer.py
+++ b/tests/test_feature_group_mixer.py
@@ -16,3 +16,31 @@ def test_feature_group_mixer_leave_one_out():
         dict(itertools.chain(english_numbers.items(), letters.items())),
     ]
     assert result == expected
+
+
+def test_feature_group_mixer_leave_one_in():
+    english_numbers = {'one': ['two', 'three'], 'four': ['five', 'six']}
+    letters = {'a': ['b', 'c'], 'd': ['e', 'f']}
+    german_numbers = {'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+    feature_groups = [english_numbers, letters, german_numbers]
+
+    result = FeatureGroupMixer(['leave-one-in']).generate(feature_groups)
+    expected = [
+        english_numbers,
+        letters,
+        german_numbers
+    ]
+    assert result == expected
+
+
+def test_feature_group_mixer_all():
+    english_numbers = {'one': ['two', 'three'], 'four': ['five', 'six']}
+    letters = {'a': ['b', 'c'], 'd': ['e', 'f']}
+    german_numbers = {'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+    feature_groups = [english_numbers, letters, german_numbers]
+
+    result = FeatureGroupMixer(['all']).generate(feature_groups)
+    expected = [
+        dict(itertools.chain(english_numbers.items(), letters.items(), german_numbers.items())),
+    ]
+    assert result == expected

--- a/triage/feature_group_creator.py
+++ b/triage/feature_group_creator.py
@@ -20,6 +20,7 @@ def all_subsetter(config_item, table, features):
 
 
 class FeatureGroupCreator(object):
+    """Divides a feature dictionary into groups based on given criteria"""
     subsetters = {
         'tables': table_subsetter,
         'prefix': prefix_subsetter,
@@ -45,7 +46,15 @@ class FeatureGroupCreator(object):
         Args:
             feature_dictionary (dict) tables and the features contained in each
 
-        Returns: (list) subsets of the feature dictionary
+            The feature dictionary is meant to be keyed on source table. Example:
+
+            {
+                'feature_table_one': ['feature_one', feature_two'],
+                'feature_table_two': ['feature_three', 'feature_four'],
+            }
+
+        Returns: (list) subsets of the feature dictionary, in the same
+            table-based structure
         """
         subsets = []
         for name, config in sorted(self.definition.items()):

--- a/triage/feature_group_mixer.py
+++ b/triage/feature_group_mixer.py
@@ -1,3 +1,14 @@
+def leave_one_in(feature_groups):
+    """For each group, return a copy of just that group
+
+    Args:
+        feature_groups (list) The feature groups to apply the strategy to
+
+    Returns: A list of feature dicts
+    """
+    return feature_groups
+
+
 def leave_one_out(feature_groups):
     """For each group, return a copy of all groups excluding that group
 
@@ -18,7 +29,17 @@ def leave_one_out(feature_groups):
 
 
 def all_features(feature_groups):
-    return feature_groups
+    """Return a combination of all feature groups
+
+    Args:
+        feature_groups (list) The feature groups to apply the strategy to
+
+    Returns: A list of feature dicts
+    """
+    feature_dict = {}
+    for group in feature_groups:
+        feature_dict.update(group)
+    return [feature_dict]
 
 
 class FeatureGroupMixer(object):
@@ -26,10 +47,14 @@ class FeatureGroupMixer(object):
     based on a list of strategies"""
     strategy_lookup = {
         'leave-one-out': leave_one_out,
+        'leave-one-in': leave_one_in,
         'all': all_features,
     }
 
     def __init__(self, strategies):
+        for strategy in strategies:
+            if strategy not in self.strategy_lookup:
+                raise ValueError('Unknown strategy "{}"'.format(strategy))
         self.strategies = strategies
 
     def generate(self, feature_groups):


### PR DESCRIPTION
- Rename 'all' feature group mixer strategy to the more accurate leave-one-in
- Create new 'all' feature group mixer strategy that smashes all groups into one feature dictionary
- Improve message of exception that is thrown when an unknown strategy is given
- Beef up docstrings