### PR TITLE
Parallelize Feature Generation [Resolves #83]

### DIFF
--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -67,11 +67,13 @@ class PipelineBase(object):
             features_schema_name=self.features_schema_name,
         )
 
-        self.feature_group_creator = FeatureGroupCreator(
+        self.feature_group_creator_factory = partial(
+            FeatureGroupCreator,
             self.config.get('feature_group_definition', {'all': [True]})
         )
 
-        self.feature_group_mixer = FeatureGroupMixer(
+        self.feature_group_mixer_factory = partial(
+            FeatureGroupMixer,
             self.config.get('feature_group_strategies', ['all'])
         )
 
@@ -112,6 +114,8 @@ class PipelineBase(object):
         self.label_generator = self.label_generator_factory(db_engine=self.db_engine)
         self.feature_generator = self.feature_generator_factory(db_engine=self.db_engine)
         self.feature_dictionary_creator = self.feature_dictionary_creator_factory(db_engine=self.db_engine)
+        self.feature_group_creator = self.feature_group_creator_factory()
+        self.feature_group_mixer = self.feature_group_mixer_factory()
         self.architect = self.architect_factory(engine=self.db_engine)
         self.trainer = self.trainer_factory(db_engine=self.db_engine)
         self.predictor = self.predictor_factory(db_engine=self.db_engine)

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -34,8 +34,8 @@ class SerialPipeline(PipelineBase):
 
         # 3. generate features
         logging.info('Generating features for %s', all_as_of_times)
-        feature_tables = self.feature_generator.generate(
-            feature_aggregations=self.config['feature_aggregations'],
+        feature_tables = self.feature_generator.create_all_tables(
+            feature_aggregation_config=self.config['feature_aggregations'],
             feature_dates=all_as_of_times,
         )
 

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -137,3 +137,32 @@ def filename_friendly_hash(inputs):
         json.dumps(inputs, default=dt_handler, sort_keys=True)
             .encode('utf-8')
     ).hexdigest()
+
+
+class Batch:
+    # modified from
+    # http://codereview.stackexchange.com/questions/118883/split-up-an-iterable-into-batches
+    def __init__(self, iterable, limit=None):
+        self.iterator = iter(iterable)
+        self.limit = limit
+        try:
+            self.current = next(self.iterator)
+        except StopIteration:
+            self.on_going = False
+        else:
+            self.on_going = True
+
+    def group(self):
+        yield self.current
+        # start enumerate at 1 because we already yielded the last saved item
+        for num, item in enumerate(self.iterator, 1):
+            self.current = item
+            if num == self.limit:
+                break
+            yield item
+        else:
+            self.on_going = False
+
+    def __iter__(self):
+        while self.on_going:
+            yield self.group()


### PR DESCRIPTION
- Introduce LocalParallelPipeline#parallelize to encapsulate parallelizing a function and list of tasks
- Rename high-level FeatureGenerator interface from 'generate' to 'create_all_tables'
- Add FeatureGenerator#aggregations for direct access to all collate Aggregations
- Add FeatureGenerator#generate_all_table_tasks to produce a parallelizable list of all tables and their creation/population queries
- Add FeatureGenerator#run_commands to run a list of SQL commands in a transaction
- Switch to multiprocessing.Pool to take advantage of chunksize
- In SerialPipeline, use new FeatureGenerator#create_all_tables
- In LocalParallelPipeline, retrieve all table tasks, and run inserts in parallel batches of 25