### PR TITLE
Workflow and performance updates [Resolves #45, #93, #99, #111, #112,…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ collate
 click
 inflection
 numpy>=1.12
+sqlalchemy-postgres-copy

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -99,7 +99,7 @@ def test_integration():
 
             for model_id in model_ids:
                 for as_of_date, test_store in zip(as_of_dates, test_stores):
-                    predictions, predictions_proba = predictor.predict(
+                    predictions_proba = predictor.predict(
                         model_id,
                         test_store,
                         misc_db_parameters=dict()
@@ -107,7 +107,6 @@ def test_integration():
 
                     model_scorer.score(
                         predictions_proba,
-                        predictions,
                         test_store.labels(),
                         model_id,
                         as_of_date,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -205,8 +205,6 @@ def test_serial_pipeline():
 
 
 def test_local_parallel_pipeline():
-    import logging
-    logging.basicConfig(level=logging.INFO)
     simple_pipeline_test(LocalParallelPipeline)
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -86,7 +86,7 @@ def populate_source_data(db_engine):
         )
 
 
-def generic_pipeline_test(pipeline_class):
+def simple_pipeline_test(pipeline_class):
     with testing.postgresql.Postgresql() as postgresql:
         db_engine = create_engine(postgresql.url())
         ensure_db(db_engine)
@@ -201,8 +201,87 @@ def generic_pipeline_test(pipeline_class):
 
 
 def test_serial_pipeline():
-    generic_pipeline_test(SerialPipeline)
+    simple_pipeline_test(SerialPipeline)
 
 
 def test_local_parallel_pipeline():
-    generic_pipeline_test(LocalParallelPipeline)
+    import logging
+    logging.basicConfig(level=logging.INFO)
+    simple_pipeline_test(LocalParallelPipeline)
+
+
+def reuse_pipeline_test(pipeline_class):
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        temporal_config = {
+            'beginning_of_time': '2010-01-01',
+            'modeling_start_time': '2011-01-01',
+            'modeling_end_time': '2014-01-01',
+            'update_window': '1y',
+            'prediction_window': '6m',
+            'look_back_durations': ['6m'],
+            'test_durations': ['1m'],
+            'prediction_frequency': '1d'
+        }
+        scoring_config = [
+            {'metrics': ['precision@'], 'thresholds': {'top_n': [2]}}
+        ]
+        grid_config = {
+            'sklearn.linear_model.LogisticRegression': {
+                'C': [0.00001, 0.0001],
+                'penalty': ['l1', 'l2'],
+                'random_state': [2193]
+            }
+        }
+        feature_config = [{
+            'prefix': 'test_features',
+            'from_obj': 'cat_complaints',
+            'knowledge_date_column': 'as_of_date',
+            'aggregates': [{
+                'quantity': 'cat_sightings',
+                'metrics': ['count', 'avg'],
+            }],
+            'intervals': ['1y'],
+            'groups': ['entity_id']
+        }]
+        experiment_config = {
+            'events_table': 'events',
+            'entity_column_name': 'entity_id',
+            'model_comment': 'test2-final-final',
+            'feature_aggregations': feature_config,
+            'temporal_config': temporal_config,
+            'grid_config': grid_config,
+            'scoring': scoring_config,
+        }
+
+        temp_dir = TemporaryDirectory()
+        try:
+            pipeline = pipeline_class(
+                config=experiment_config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir.name, 'inspections'),
+                replace=False
+            )
+
+            pipeline.run()
+
+            # if the second run tries to write any new
+            # matrices or models, it will get permission denied!
+            os.chmod(temp_dir.name, 0o500)
+
+            pipeline.run()
+
+        finally:
+            os.chmod(temp_dir.name, 0o700)
+            temp_dir.cleanup()
+
+
+def test_serial_pipeline_reuse():
+    reuse_pipeline_test(SerialPipeline)
+
+
+def test_localparallel_pipeline_reuse():
+    reuse_pipeline_test(LocalParallelPipeline)

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -3,7 +3,9 @@ import testing.postgresql
 
 from moto import mock_s3
 from sqlalchemy import create_engine
-from triage.db import ensure_db
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import make_transient
+from triage.db import ensure_db, Prediction
 import pandas
 
 from triage.predictors import Predictor
@@ -13,6 +15,9 @@ from triage.storage import \
     S3ModelStorageEngine,\
     InMemoryMatrixStore
 import datetime
+
+from unittest.mock import Mock
+from numpy.testing import assert_array_equal
 
 AS_OF_DATE = datetime.date(2016, 12, 21)
 
@@ -43,11 +48,11 @@ def test_predictor():
             }
 
             matrix_store = InMemoryMatrixStore(matrix, metadata)
-            predictions = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
+            predict_proba = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
 
             # assert
             # 1. that the returned predictions are of the desired length
-            assert len(predictions) == 2
+            assert len(predict_proba) == 2
 
             # 2. that the predictions table entries are present and
             # can be linked to the original models
@@ -119,11 +124,11 @@ def test_predictor_composite_index():
             'end_time': AS_OF_DATE,
         }
         matrix_store = InMemoryMatrixStore(matrix, metadata)
-        predictions, predict_proba = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
+        predict_proba = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
 
         # assert
         # 1. that the returned predictions are of the desired length
-        assert len(predictions) == 4
+        assert len(predict_proba) == 4
 
         # 2. that the predictions table entries are present and
         # can be linked to the original models
@@ -134,3 +139,66 @@ def test_predictor_composite_index():
             join results.models using (model_id)''')
         ]
         assert len(records) == 4
+
+def test_predictor_retrieve():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        project_path = 'econ-dev/inspections'
+        model_storage_engine = InMemoryModelStorageEngine(project_path)
+        _, model_id = \
+            fake_trained_model(project_path, model_storage_engine, db_engine)
+        predictor = Predictor(project_path, model_storage_engine, db_engine, replace=False)
+        dayone = datetime.date(2011, 1, 1).isoformat()
+        daytwo = datetime.date(2011, 1, 2).isoformat()
+        # create prediction set
+        matrix_data = {
+            'entity_id': [1, 2, 1, 2],
+            'as_of_date': [dayone, dayone, daytwo, daytwo],
+            'feature_one': [3, 4, 5, 6],
+            'feature_two': [5, 6, 7, 8],
+            'label': [7, 8, 8, 7]
+        }
+        matrix = pandas.DataFrame.from_dict(matrix_data)\
+            .set_index(['entity_id', 'as_of_date'])
+        metadata = {
+            'label_name': 'label',
+            'end_time': AS_OF_DATE,
+        }
+        matrix_store = InMemoryMatrixStore(matrix, metadata)
+        predict_proba = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
+
+        # When run again, the predictions retrieved from the database
+        # should match.
+        #
+        # Some trickiness here. Let's explain:
+        #
+        # If we are not careful, retrieving predictions from the database and
+        # presenting them as a numpy array can result in a bad ordering,
+        # since the given matrix may not be 'ordered' by some criteria
+        # that can be easily represented by an ORDER BY clause.
+        #
+        # It will sometimes work, because without ORDER BY you will get
+        # it back in the table's physical order, which unless something has
+        # happened to the table will be the order you inserted it,
+        # which could very well be the order in the matrix.
+        # So it's not a bug that would necessarily immediately show itself,
+        # but when it does go wrong your scores will be garbage.
+        #
+        # So we simulate a table order mutation that can happen over time:
+        # Remove the first row and put it at the end.
+        # If the Predictor doesn't explicitly reorder the results, this will fail
+        session = sessionmaker(bind=db_engine)()
+        obj = session.query(Prediction).first()
+        session.delete(obj)
+        session.commit()
+
+        make_transient(obj)
+        session = sessionmaker(bind=db_engine)()
+        session.add(obj)
+        session.commit()
+
+        predictor.load_model = Mock()
+        new_predict_proba = predictor.predict(model_id, matrix_store, misc_db_parameters=dict())
+        assert_array_equal(new_predict_proba, predict_proba)
+        assert not predictor.load_model.called

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -52,7 +52,6 @@ def test_model_scoring_early_warning():
         as_of_date = datetime.date(2016, 5, 5)
         model_scorer.score(
             trained_model.predict_proba(labels)[:, 1],
-            trained_model.predict(labels),
             labels,
             model_id,
             as_of_date,
@@ -133,7 +132,6 @@ def test_model_scoring_inspections():
         prediction_frequency = '1d'
         model_scorer.score(
             trained_model.predict_proba(labels)[:, 1],
-            trained_model.predict(labels),
             labels,
             model_id,
             evaluation_start,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -37,9 +37,6 @@ def fake_labels(length):
 
 
 class MockTrainedModel(object):
-    def predict(self, dataset):
-        return numpy.array([random.choice([True, False]) for i in range(0, len(dataset))])
-
     def predict_proba(self, dataset):
         return numpy.random.rand(len(dataset), len(dataset))
 

--- a/triage/label_generators.py
+++ b/triage/label_generators.py
@@ -45,8 +45,8 @@ class BinaryLabelGenerator(object):
 
     def generate_all_labels(self, labels_table, as_of_times, prediction_window):
         self._create_labels_table(labels_table)
+        logging.info('Creating labels for %s as of times', len(as_of_times))
         for as_of_time in as_of_times:
-            logging.info('Creating labels for %s', as_of_time)
             self.generate(
                 start_date=as_of_time,
                 prediction_window=prediction_window,

--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -15,6 +15,7 @@ import os
 from datetime import datetime
 from abc import ABCMeta, abstractmethod
 from functools import partial
+import logging
 
 
 def dt_from_str(dt_str):
@@ -24,13 +25,21 @@ def dt_from_str(dt_str):
 class PipelineBase(object):
     __metaclass__ = ABCMeta
 
-    def __init__(self, config, db_engine, model_storage_class=None, project_path=None):
+    def __init__(
+        self,
+        config,
+        db_engine,
+        model_storage_class=None,
+        project_path=None,
+        replace=True
+    ):
         self.config = config
         self.db_engine = db_engine
         if model_storage_class:
             self.model_storage_engine =\
                 model_storage_class(project_path=project_path)
         self.project_path = project_path
+        self.replace = replace
         ensure_db(self.db_engine)
 
         self.labels_table_name = 'labels'
@@ -43,6 +52,10 @@ class PipelineBase(object):
             self.config,
             self.db_engine
         )
+        self._split_definitions = None
+        self._matrix_build_tasks = None
+        self._feature_table_tasks = None
+        self._all_as_of_times = None
         self.initialize_factories()
         self.initialize_components()
 
@@ -72,6 +85,7 @@ class PipelineBase(object):
         self.feature_generator_factory = partial(
             FeatureGenerator,
             features_schema_name=self.features_schema_name,
+            replace=self.replace
         )
 
         self.feature_group_creator_factory = partial(
@@ -96,6 +110,7 @@ class PipelineBase(object):
             },
             matrix_directory=self.matrices_directory,
             user_metadata={},
+            replace=self.replace
         )
 
         self.trainer_factory = partial(
@@ -103,12 +118,14 @@ class PipelineBase(object):
             project_path=self.project_path,
             experiment_hash=self.experiment_hash,
             model_storage_engine=self.model_storage_engine,
+            replace=self.replace
         )
 
         self.predictor_factory = partial(
             Predictor,
             model_storage_engine=self.model_storage_engine,
             project_path=self.project_path,
+            replace=self.replace
         )
 
         self.model_scorer_factory = partial(
@@ -139,6 +156,79 @@ class PipelineBase(object):
                 test_matrix['prediction_window'] = prediction_window
         return split_definitions
 
+    @property
+    def split_definitions(self):
+        if not self._split_definitions:
+            self._split_definitions = self.chop_time()
+        return self._split_definitions
+
+    @property
+    def all_as_of_times(self):
+        if not self._all_as_of_times:
+            all_as_of_times = []
+            for split in self.split_definitions:
+                all_as_of_times.extend(split['train_matrix']['as_of_times'])
+                for test_matrix in split['test_matrices']:
+                    all_as_of_times.extend(test_matrix['as_of_times'])
+
+            logging.info(
+                'Found %s distinct as_of_times for label and feature generation',
+                len(all_as_of_times)
+            )
+            self._all_as_of_times = list(set(all_as_of_times))
+        return self._all_as_of_times
+
+    @property
+    def feature_table_tasks(self):
+        if not self._feature_table_tasks:
+            logging.info(
+                'Calculating feature tasks for %s as_of_times',
+                len(self.all_as_of_times)
+            )
+            self._feature_table_tasks = self.feature_generator.generate_all_table_tasks(
+                feature_aggregation_config=self.config['feature_aggregations'],
+                feature_dates=self.all_as_of_times,
+            )
+        return self._feature_table_tasks
+
+    @property
+    def feature_dicts(self):
+        master_feature_dict = self.feature_dictionary_creator\
+            .feature_dictionary(self.feature_table_tasks.keys())
+
+        return self.feature_group_mixer.generate(
+            self.feature_group_creator.subsets(master_feature_dict)
+        )
+
+    @property
+    def matrix_build_tasks(self):
+        if not self._matrix_build_tasks:
+            updated_split_definitions, self._matrix_build_tasks =\
+                self.architect.generate_plans(
+                    self.split_definitions,
+                    self.feature_dicts
+                )
+            self.update_split_definitions(updated_split_definitions)
+        return self._matrix_build_tasks
+
+    def generate_labels(self):
+        self.label_generator.generate_all_labels(
+            self.labels_table_name,
+            self.all_as_of_times,
+            self.config['temporal_config']['prediction_window']
+        )
+
+    def update_split_definitions(self, new_split_definitions):
+        self._split_definitions = new_split_definitions
+
     @abstractmethod
-    def run(self):
+    def build_matrices(self):
         pass
+
+    @abstractmethod
+    def catwalk(self):
+        pass
+
+    def run(self):
+        self.build_matrices()
+        self.catwalk()

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -197,7 +197,6 @@ def insert_into_table(
         logging.info('Beginning insert batch')
         db_engine = create_engine(db_connection_string)
         feature_generator = feature_generator_factory(db_engine)
-        logging.info(insert_statements)
         feature_generator.run_commands(insert_statements)
         return True
     except Exception as e:

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -13,85 +13,15 @@ class LocalParallelPipeline(PipelineBase):
         super(LocalParallelPipeline, self).__init__(*args, **kwargs)
         self.n_processes = n_processes
         if kwargs['model_storage_class'] == InMemoryModelStorageEngine:
-            raise ValueError('InMemoryModelStorageEngine not compatible with LocalParallelPipeline')
+            raise ValueError('''
+                InMemoryModelStorageEngine not compatible with LocalParallelPipeline
+            ''')
 
-    def run(self):
-        # 1. generate temporal splits
-        split_definitions = self.chop_time()
-
-        # 2. create labels
-        logging.debug('---------------------')
-        logging.debug('---------LABEL GENERATION------------')
-        logging.debug('---------------------')
-
-        all_as_of_times = []
-        for split in split_definitions:
-            all_as_of_times.extend(split['train_matrix']['as_of_times'])
-            for test_matrix in split['test_matrices']:
-                all_as_of_times.extend(test_matrix['as_of_times'])
-        all_as_of_times = list(set(all_as_of_times))
-
-        logging.info(
-            'Found %s distinct as_of_times for label and feature generation',
-            len(all_as_of_times)
+    def catwalk(self):
+        updated_split_definitions, _ = self.architect.generate_plans(
+            self.split_definitions,
+            self.feature_dicts
         )
-        self.label_generator.generate_all_labels(
-            self.labels_table_name,
-            all_as_of_times,
-            self.config['temporal_config']['prediction_window']
-        )
-
-        # 3. generate features
-        logging.info(
-            'Generating features for %s as_of_times',
-            len(all_as_of_times)
-        )
-        feature_table_tasks = self.feature_generator.generate_all_table_tasks(
-            feature_aggregation_config=self.config['feature_aggregations'],
-            feature_dates=all_as_of_times,
-        )
-
-        for table_name, tasks in feature_table_tasks.items():
-            logging.info('Generating %s features', table_name)
-            self.feature_generator.run_commands(tasks['prepare'])
-            partial_insert = partial(
-                insert_into_table,
-                feature_generator_factory=self.feature_generator_factory,
-                db_connection_string=self.db_engine.url
-            )
-            self.parallelize_with_success_count(partial_insert, tasks['inserts'], chunksize=25)
-            self.feature_generator.run_commands(tasks['finalize'])
-            logging.info('%s completed', table_name)
-
-        master_feature_dict = self.feature_dictionary_creator\
-            .feature_dictionary(feature_table_tasks.keys())
-
-        feature_dicts = self.feature_group_mixer.generate(
-            self.feature_group_creator.subsets(master_feature_dict)
-        )
-
-        # 4. create training and test sets
-        logging.info('Creating matrices')
-        logging.debug('---------------------')
-        logging.debug('---------MATRIX GENERATION------------')
-        logging.debug('---------------------')
-
-        updated_split_definitions, build_tasks = self.architect.generate_plans(
-            split_definitions,
-            feature_dicts
-        )
-
-        partial_build_matrix = partial(
-            build_matrix,
-            architect_factory=self.architect_factory,
-            db_connection_string=self.db_engine.url
-        )
-        logging.info(
-            'Starting parallel matrix building: %s matrices, %s processes',
-            len(build_tasks.keys()),
-            self.n_processes
-        )
-        self.parallelize_with_success_count(partial_build_matrix, build_tasks.values())
 
         for split in updated_split_definitions:
             logging.info('Starting split')
@@ -106,7 +36,7 @@ class LocalParallelPipeline(PipelineBase):
                 )
             )
             logging.info('Checking out train matrix')
-            if train_store.matrix.empty:
+            if train_store.empty:
                 logging.warning('''Train matrix for split %s was empty,
                 no point in training this model. Skipping
                 ''', split['train_uuid'])
@@ -138,7 +68,10 @@ class LocalParallelPipeline(PipelineBase):
                 self.n_processes
             )
             model_ids = []
-            for batch_model_ids in self.parallelize(partial_train_models, trainer_tasks):
+            for batch_model_ids in self.parallelize(
+                partial_train_models,
+                trainer_tasks
+            ):
                 model_ids += batch_model_ids
             logging.info('Done training models')
 
@@ -163,7 +96,7 @@ class LocalParallelPipeline(PipelineBase):
                         '{}.yaml'.format(test_uuid)
                     )
                 )
-                if test_store.matrix.empty:
+                if test_store.empty:
                     logging.warning('''Test matrix for train uuid %s
                     was empty, no point in training this model. Skipping
                     ''', split['train_uuid'])
@@ -181,15 +114,27 @@ class LocalParallelPipeline(PipelineBase):
                     'Starting parallel testing with %s processes',
                     self.n_processes
                 )
-                self.parallelize_with_success_count(partial_test_and_score, model_ids)
+                self.parallelize_with_success_count(
+                    partial_test_and_score,
+                    model_ids
+                )
                 logging.info('Cleaned up concurrent pool')
             logging.info('Done with test matrix')
         logging.info('Done with split')
 
-    def parallelize_with_success_count(self, partially_bound_function, tasks, chunksize=1):
+    def parallelize_with_success_count(
+        self,
+        partially_bound_function,
+        tasks,
+        chunksize=1
+    ):
         num_successes = 0
         num_failures = 0
-        for successful in self.parallelize(partially_bound_function, tasks, chunksize):
+        for successful in self.parallelize(
+            partially_bound_function,
+            tasks,
+            chunksize
+        ):
             if successful:
                 num_successes += 1
             else:
@@ -200,10 +145,42 @@ class LocalParallelPipeline(PipelineBase):
             num_failures
         )
 
+    def build_matrices(self):
+        self.generate_labels()
+        logging.info('Creating feature tables')
+        for table_name, tasks in self.feature_table_tasks.items():
+            logging.info('Processing features for %s', table_name)
+            self.feature_generator.run_commands(tasks.get('prepare', []))
+            partial_insert = partial(
+                insert_into_table,
+                feature_generator_factory=self.feature_generator_factory,
+                db_connection_string=self.db_engine.url
+            )
+            self.parallelize_with_success_count(
+                partial_insert,
+                tasks.get('inserts', []),
+                chunksize=25
+            )
+            self.feature_generator.run_commands(tasks.get('finalize', []))
+            logging.info('%s completed', table_name)
+
+        partial_build_matrix = partial(
+            build_matrix,
+            architect_factory=self.architect_factory,
+            db_connection_string=self.db_engine.url
+        )
+        logging.info(
+            'Starting parallel matrix building: %s matrices, %s processes',
+            len(self.matrix_build_tasks.keys()),
+            self.n_processes
+        )
+        self.parallelize_with_success_count(
+            partial_build_matrix,
+            self.matrix_build_tasks.values()
+        )
 
     def parallelize(self, partially_bound_function, tasks, chunksize=1):
         with Pool(self.n_processes) as pool:
-            all_results = []
             for result in pool.map(
                 partially_bound_function,
                 [list(task_batch) for task_batch in Batch(tasks, chunksize)]
@@ -220,6 +197,7 @@ def insert_into_table(
         logging.info('Beginning insert batch')
         db_engine = create_engine(db_connection_string)
         feature_generator = feature_generator_factory(db_engine)
+        logging.info(insert_statements)
         feature_generator.run_commands(insert_statements)
         return True
     except Exception as e:
@@ -276,7 +254,7 @@ def test_and_score(
             predictor = predictor_factory(db_engine=db_engine)
             model_scorer = model_scorer_factory(db_engine=db_engine)
 
-            predictions, predictions_proba = predictor.predict(
+            predictions_proba = predictor.predict(
                 model_id,
                 test_store,
                 misc_db_parameters=dict()
@@ -284,7 +262,6 @@ def test_and_score(
             logging.info('Generating evaluations for model id %s', model_id)
             model_scorer.score(
                 predictions_proba=predictions_proba,
-                predictions_binary=predictions,
                 labels=test_store.labels(),
                 model_id=model_id,
                 evaluation_start_time=split_def['matrix_start_time'],

--- a/triage/predictors.py
+++ b/triage/predictors.py
@@ -3,6 +3,10 @@ from sqlalchemy.orm import sessionmaker
 import pandas
 import logging
 import math
+import numpy
+import tempfile
+import csv
+import postgres_copy
 
 
 class ModelNotFoundError(ValueError):
@@ -10,7 +14,13 @@ class ModelNotFoundError(ValueError):
 
 
 class Predictor(object):
-    def __init__(self, project_path, model_storage_engine, db_engine):
+    def __init__(
+        self,
+        project_path,
+        model_storage_engine,
+        db_engine,
+        replace=True
+    ):
         """Encapsulates the task of generating predictions on an arbitrary
         dataset and storing the results
 
@@ -24,6 +34,22 @@ class Predictor(object):
         self.db_engine = db_engine
         if self.db_engine:
             self.sessionmaker = sessionmaker(bind=self.db_engine)
+        self.replace = replace
+
+    def _retrieve_model_hash(self, model_id):
+        """Retrieves the model hash associated with a given model id
+
+        Args:
+            model_id (int) The id of a given model in the database
+
+        Returns: (str) the stored hash of the model
+        """
+        try:
+            session = self.sessionmaker()
+            model_hash = session.query(Model).get(model_id).model_hash
+        finally:
+            session.close()
+        return model_hash
 
     def load_model(self, model_id):
         """Downloads the cached model associated with a given model id
@@ -34,7 +60,8 @@ class Predictor(object):
         Returns:
             A python object which implements .predict()
         """
-        model_hash = self.sessionmaker().query(Model).get(model_id).model_hash
+
+        model_hash = self._retrieve_model_hash(model_id)
         logging.info('Checking for model_hash %s in store', model_hash)
         model_store = self.model_storage_engine.get_store(model_hash)
         if model_store.exists():
@@ -46,15 +73,43 @@ class Predictor(object):
         Args:
             model_id (int) The id of a given model in the database
         """
-        model_hash = self.sessionmaker().query(Model).get(model_id).model_hash
+        model_hash = self._retrieve_model_hash(model_id)
         model_store = self.model_storage_engine.get_store(model_hash)
         model_store.delete()
+
+    def _existing_predictions(self, session, model_id, matrix_store):
+        return session.query(Prediction)\
+            .filter_by(model_id=model_id)\
+            .filter(Prediction.as_of_date.in_(self._as_of_dates(matrix_store)))
+
+    def _as_of_dates(self, matrix_store):
+        matrix = matrix_store.matrix
+        if 'as_of_date' in matrix.index.names:
+            return matrix.index.levels[
+                matrix.index.names.index('as_of_date')
+            ].tolist()
+        else:
+            return [matrix_store.metadata['end_time']]
+
+    def _load_saved_predictions(self, existing_predictions, matrix_store):
+        index = matrix_store.matrix.index
+        score_lookup = {}
+        for prediction in existing_predictions:
+            score_lookup[(
+                prediction.entity_id,
+                prediction.as_of_date.date().isoformat()
+            )] = prediction.score
+        if 'as_of_date' in index.names:
+            score_iterator = (score_lookup[row] for row in index)
+        else:
+            as_of_date = matrix_store.metadata['end_time'].date().isoformat()
+            score_iterator = (score_lookup[(row, as_of_date)] for row in index)
+        return numpy.fromiter(score_iterator, float)
 
     def _write_to_db(
         self,
         model_id,
-        matrix_end_time,
-        matrix,
+        matrix_store,
         predictions,
         labels,
         misc_db_parameters,
@@ -65,46 +120,54 @@ class Predictor(object):
 
         Args:
             model_id (int) the id of the model associated with the given predictions
-            as_of_date (datetime.date) the date the predictions were made 'as of'
+            matrix_store (triage.storage.MatrixStore) the matrix and metadata
             entity_ids (iterable) entity ids that predictions were made on
             predictions (iterable) predicted values
             labels (iterable) labels of prediction set (int) the id of the model to predict based off of
         """
-        if 'as_of_date' in matrix.index.names:
-            as_of_dates = matrix.index.levels[
-                matrix.index.names.index('as_of_date')
-            ].tolist()
-        else:
-            as_of_dates = [matrix_end_time]
         session = self.sessionmaker()
-        session.query(Prediction)\
-            .filter_by(model_id=model_id)\
-            .filter(Prediction.as_of_date.in_(as_of_dates))\
+        self._existing_predictions(session, model_id, matrix_store)\
             .delete(synchronize_session=False)
         session.expire_all()
         db_objects = []
 
-        if 'as_of_date' in matrix.index.names:
-            for index, score, label in zip(
-                matrix.index,
-                predictions,
-                labels
-            ):
-                entity_id, as_of_date = index
-                db_objects.append(Prediction(
-                    model_id=int(model_id),
-                    entity_id=int(entity_id),
-                    as_of_date=as_of_date,
-                    score=float(score),
-                    label_value=int(label) if not math.isnan(label) else None,
-                    **misc_db_parameters
-                ))
+        if 'as_of_date' in matrix_store.matrix.index.names:
+            session.commit()
+            session.close()
+            with tempfile.TemporaryFile(mode='w+') as f:
+                writer = csv.writer(f, quoting=csv.QUOTE_MINIMAL)
+                for index, score, label in zip(
+                    matrix_store.matrix.index,
+                    predictions,
+                    labels
+                ):
+                    entity_id, as_of_date = index
+                    prediction = Prediction(
+                        model_id=int(model_id),
+                        entity_id=int(entity_id),
+                        as_of_date=as_of_date,
+                        score=float(score),
+                        label_value=int(label) if not math.isnan(label) else None,
+                        **misc_db_parameters
+                    )
+                    writer.writerow([
+                        prediction.model_id,
+                        prediction.entity_id,
+                        prediction.as_of_date,
+                        prediction.score,
+                        prediction.label_value,
+                        prediction.rank_abs,
+                        prediction.rank_pct,
+                        prediction.matrix_uuid
+                    ])
+                f.seek(0)
+                postgres_copy.copy_from(f, Prediction, self.db_engine, format='csv')
         else:
             temp_df = pandas.DataFrame({'score': predictions})
             rankings_abs = temp_df['score'].rank(method='dense', ascending=False)
             rankings_pct = temp_df['score'].rank(method='dense', ascending=False, pct=True)
             for entity_id, score, label, rank_abs, rank_pct in zip(
-                matrix.index,
+                matrix_store.matrix.index,
                 predictions,
                 labels,
                 rankings_abs,
@@ -113,16 +176,17 @@ class Predictor(object):
                 db_objects.append(Prediction(
                     model_id=int(model_id),
                     entity_id=int(entity_id),
-                    as_of_date=matrix_end_time,
+                    as_of_date=matrix_store.metadata['end_time'],
                     score=round(float(score), 10),
                     label_value=int(label) if not math.isnan(label) else None,
                     rank_abs=int(rank_abs),
-                    rank_pct=round(float(rank_pct),10),
+                    rank_pct=round(float(rank_pct), 10),
                     **misc_db_parameters
                 ))
 
-        session.bulk_save_objects(db_objects)
-        session.commit()
+            session.bulk_save_objects(db_objects)
+            session.commit()
+            session.close()
 
     def predict(self, model_id, matrix_store, misc_db_parameters):
         """Generate predictions and store them in the database
@@ -135,18 +199,31 @@ class Predictor(object):
         Returns:
             (numpy.Array) the generated prediction values
         """
+        session = self.sessionmaker()
+        if not self.replace:
+            existing_predictions = self._existing_predictions(
+                session,
+                model_id,
+                matrix_store
+            )
+            index = matrix_store.matrix.index
+            if existing_predictions.count() == len(index):
+                logging.info('Found predictions, returning saved versions')
+                return self._load_saved_predictions(
+                    existing_predictions,
+                    matrix_store
+                )
+
         model = self.load_model(model_id)
         if not model:
             raise ModelNotFoundError('Model id {} not found'.format(model_id))
         labels = matrix_store.labels()
-        predictions = model.predict(matrix_store.matrix)
         predictions_proba = model.predict_proba(matrix_store.matrix)
         self._write_to_db(
             model_id,
-            matrix_store.metadata['end_time'],
-            matrix_store.matrix,
+            matrix_store,
             predictions_proba[:,1],
             labels,
             misc_db_parameters
         )
-        return predictions, predictions_proba[:,1]
+        return predictions_proba[:,1]

--- a/triage/scoring.py
+++ b/triage/scoring.py
@@ -220,7 +220,6 @@ class ModelScorer(object):
     def score(
         self,
         predictions_proba,
-        predictions_binary,
         labels,
         model_id,
         evaluation_start_time,
@@ -231,7 +230,6 @@ class ModelScorer(object):
 
         Args:
             predictions_proba (numpy.array) List of prediction probabilities
-            predictions_binary (numpy.array) List of binarized predictions
             labels (numpy.array) The true labels for the prediction set
             model_id (int) The database identifier of the model
             evaluation_start_time (datetime.datetime) The time of the first prediction being evaluated
@@ -240,7 +238,6 @@ class ModelScorer(object):
         """
         nan_mask = numpy.isfinite(labels)
         predictions_proba = (predictions_proba[nan_mask]).tolist()
-        predictions_binary = (predictions_binary[nan_mask]).tolist()
         labels = (labels[nan_mask]).tolist()
 
         predictions_proba_sorted, labels_sorted = \
@@ -254,7 +251,11 @@ class ModelScorer(object):
                     parameters,
                     {},
                     predictions_proba,
-                    predictions_binary,
+                    generate_binary_at_x(
+                        predictions_proba_sorted,
+                        100,
+                        unit='percentile'
+                    ),
                     labels,
                 )
 
@@ -330,3 +331,4 @@ class ModelScorer(object):
             evaluation.prediction_frequency = prediction_frequency
             session.add(evaluation)
         session.commit()
+        session.close()

--- a/triage/storage.py
+++ b/triage/storage.py
@@ -89,6 +89,10 @@ class S3ModelStorageEngine(ModelStorageEngine):
 
 
 class FSModelStorageEngine(ModelStorageEngine):
+    def __init__(self, *args, **kwargs):
+        super(FSModelStorageEngine, self).__init__(*args, **kwargs)
+        os.makedirs(os.path.join(self.project_path, 'trained_models'), exist_ok=True)
+
     def get_store(self, model_hash):
         return FSStore('/'.join([
             self.project_path,
@@ -146,6 +150,13 @@ class MettaCSVMatrixStore(MatrixStore):
         if self._metadata is None:
             self._load()
         return self._metadata
+
+    @property
+    def empty(self):
+        if not os.path.isfile(self.matrix_path):
+            return True
+        else:
+            return pandas.read_csv(self.matrix_path, nrows=1).empty
 
     def _load(self):
         self._matrix = pandas.read_csv(self.matrix_path)

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -182,6 +182,14 @@ class Batch:
             yield self.group()
 
 def retrieve_model_id_from_hash(db_engine, model_hash):
+    """Retrieves a model id from the database that matches the given hash
+
+    Args:
+        db_engine (sqlalchemy.engine) A database engine
+        model_hash (str) The model hash to lookup
+
+    Returns: (int) The model id (if found in DB), None (if not)
+    """
     session = sessionmaker(bind=db_engine)()
     try:
         saved = session.query(Model)\

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -7,7 +7,7 @@ import botocore
 import pandas
 import yaml
 import json
-from triage.db import Experiment
+from triage.db import Experiment, Model
 from sqlalchemy.orm import sessionmaker
 
 
@@ -149,6 +149,7 @@ def save_experiment_and_get_hash(config, db_engine):
         config=config
     ))
     session.commit()
+    session.close()
     return experiment_hash
 
 
@@ -179,3 +180,13 @@ class Batch:
     def __iter__(self):
         while self.on_going:
             yield self.group()
+
+def retrieve_model_id_from_hash(db_engine, model_hash):
+    session = sessionmaker(bind=db_engine)()
+    try:
+        saved = session.query(Model)\
+            .filter_by(model_hash=model_hash)\
+            .one_or_none()
+        return saved.model_id if saved else None
+    finally:
+        session.close()


### PR DESCRIPTION
… #113, #114]

The original goal here was to implement a consistent 'replace' kwarg throughout the pipeline, so it can be restarted later more easily. A few other things made it in here. In general they made this change easier, so they aren't totally unrelated, but are different enough that they are helped by being called out. And some are simple performance updates.

Directly related [#99]:
- Create pipeline test that makes sure skip-if-present functionality works, rename existing generic pipeline test for clarity
- Add retrieve from database functionality to Predictor class that ensures order is the same as the passed-in matrix, call if replace kwarg is False [#112]
- Add replace kwarg to FeatureGenerator constructor that will skip creating table tasks if the feature table exists
- Flip ModelTrainer replace default kwarg to True for conformity
- Add replace kwarg to PipelineBase to pass through to all components

Tangentially or not related:
- Add sqlalchemy-postgres-copy, use in predictions writing for speed upgrade [#111]
- Remove model.predict() [#45]
- Move much functionality in pipelines to smaller methods, to allow both code reuse between them and inspection before running lengthy tasks [Resolves #93]
- Use new matrix_store.empty instead of matrix_store.matrix.empty to allow the empty check without loading the entire matrix into memory [#113]
- Use matrix_store internally in Predictor to reduce number of items that need to be passed around
- Create trained models directory if it isn't there
- Close DB sessions properly [#114]