### PR TITLE
Fix evaluation of sparsely-labeled test matrices [Resolves #116]

### DIFF
--- a/triage/db.py
+++ b/triage/db.py
@@ -124,6 +124,9 @@ class Evaluation(Base):
     metric = Column(String, primary_key=True)
     parameter = Column(String, primary_key=True)
     value = Column(Numeric)
+    num_labeled_examples = Column(Integer)
+    num_labeled_above_threshold = Column(Integer)
+    num_positive_labels = Column(Integer)
 
 
 def ensure_db(engine):


### PR DESCRIPTION
- Sort and threshold the predictions with NaNs intact, and then remove the NaNs
- Add to the evaluations table the number of labeled examples, number of labeled examples above threshold, and number of positive labels. This will help the researcher make sense of different metrics.
- Add false positive rate metric