### PR TITLE
Log more split info [Resolves #124]

### DIFF
--- a/triage/model_trainers.py
+++ b/triage/model_trainers.py
@@ -217,9 +217,9 @@ class ModelTrainer(object):
              matrix_store.metadata['feature_names'],
              matrix_store.metadata.get('model_config', dict())
         )
-        logging.debug('Trained model')
+        logging.info('Trained model: %s', model_hash)
         model_store.write(trained_model)
-        logging.debug('Cached model')
+        logging.info('Cached model: %s', model_hash)
         model_id = self._write_model_to_db(
             class_path,
             parameters,
@@ -229,7 +229,7 @@ class ModelTrainer(object):
             model_group_id,
             misc_db_parameters
         )
-        logging.info('Wrote model to db')
+        logging.info('Wrote model to db: %s', model_hash)
         return model_id
 
     def _get_model_group_id(

--- a/triage/model_trainers.py
+++ b/triage/model_trainers.py
@@ -364,14 +364,17 @@ class ModelTrainer(object):
         model_store = self.model_storage_engine.get_store(model_hash)
         saved_model_id = retrieve_model_id_from_hash(self.db_engine, model_hash)
         if not self.replace and model_store.exists() and saved_model_id:
-            logging.warning('Skipping %s/%s', class_path, parameters)
+            logging.info('Skipping %s/%s', class_path, parameters)
             return saved_model_id
+
         if self.replace:
-            logging.warning('Training because replace flag has been set')
+            reason = 'replace flag has been set'
         elif not model_store.exists():
-            logging.warning('Training because model pickle not found in store')
+            reason = 'model pickle not found in store'
         elif not saved_model_id:
-            logging.warning('Training because model metadata not found')
+            reason = 'model metadata not found'
+
+        logging.info('Training %s/%s: %s', class_path, parameters, reason)
         model_id = self._train_and_store_model(
             matrix_store,
             class_path,

--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -270,6 +270,15 @@ class PipelineBase(object):
         """
         self._split_definitions = new_split_definitions
 
+    def log_split(self, split_num, split):
+        logging.warning(
+            'Starting split %s out of %s: train range: %s to %s',
+            split_num+1,
+            len(self._split_definitions),
+            split['train_matrix']['matrix_start_time'],
+            split['train_matrix']['matrix_end_time'],
+        )
+
     @abstractmethod
     def build_matrices(self):
         """Generate labels, features, and matrices"""

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -24,8 +24,8 @@ class LocalParallelPipeline(PipelineBase):
             self.feature_dicts
         )
 
-        for split in updated_split_definitions:
-            logging.info('Starting split')
+        for split_num, split in enumerate(updated_split_definitions):
+            self.log_split(split_num, split)
             train_store = MettaCSVMatrixStore(
                 matrix_path=os.path.join(
                     self.matrices_directory,

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -18,7 +18,8 @@ class SerialPipeline(PipelineBase):
             self.split_definitions,
             self.feature_dicts
         )
-        for split in updated_split_definitions:
+        for split_num, split in enumerate(updated_split_definitions):
+            self.log_split(split_num, split)
             train_store = MettaCSVMatrixStore(
                 matrix_path=os.path.join(
                     self.matrices_directory,


### PR DESCRIPTION
Information like lookback durations is tougher to include here because that info doesn't travel with the split, but this level of information is easy to provide.