### PR TITLE
Fix log split # denominator [Resolves #142]

### DIFF
--- a/triage/pipelines/base.py
+++ b/triage/pipelines/base.py
@@ -245,13 +245,30 @@ class PipelineBase(object):
         Returns: (list) of dicts
         """
         if not self._matrix_build_tasks:
-            updated_split_definitions, self._matrix_build_tasks =\
+            updated_split_definitions, matrix_build_tasks =\
                 self.architect.generate_plans(
                     self.split_definitions,
                     self.feature_dicts
                 )
-            self.update_split_definitions(updated_split_definitions)
+            self._full_matrix_definitions = updated_split_definitions
+            self._matrix_build_tasks = matrix_build_tasks
         return self._matrix_build_tasks
+
+    @property
+    def full_matrix_definitions(self):
+        """Full matrix definitions
+
+        Returns: (list) temporal and feature information for each matrix
+        """
+        if not self._full_matrix_definitions:
+            updated_split_definitions, matrix_build_tasks =\
+                self.architect.generate_plans(
+                    self.split_definitions,
+                    self.feature_dicts
+                )
+            self._full_matrix_definitions = updated_split_definitions
+            self._matrix_build_tasks = matrix_build_tasks
+        return self._full_matrix_definitions
 
     def generate_labels(self):
         """Generate labels based on pipeline configuration
@@ -273,9 +290,9 @@ class PipelineBase(object):
 
     def log_split(self, split_num, split):
         logging.warning(
-            'Starting split %s out of %s: train range: %s to %s',
+            'Starting train/test for %s out of %s: train range: %s to %s',
             split_num+1,
-            len(self._split_definitions),
+            len(self.full_matrix_definitions),
             split['train_matrix']['matrix_start_time'],
             split['train_matrix']['matrix_end_time'],
         )

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -19,12 +19,7 @@ class LocalParallelPipeline(PipelineBase):
             ''')
 
     def catwalk(self):
-        updated_split_definitions, _ = self.architect.generate_plans(
-            self.split_definitions,
-            self.feature_dicts
-        )
-
-        for split_num, split in enumerate(updated_split_definitions):
+        for split_num, split in enumerate(self.full_matrix_definitions):
             self.log_split(split_num, split)
             train_store = MettaCSVMatrixStore(
                 matrix_path=os.path.join(

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -14,11 +14,7 @@ class SerialPipeline(PipelineBase):
         self.architect.build_all_matrices(self.matrix_build_tasks)
 
     def catwalk(self):
-        updated_split_definitions, _ = self.architect.generate_plans(
-            self.split_definitions,
-            self.feature_dicts
-        )
-        for split_num, split in enumerate(updated_split_definitions):
+        for split_num, split in enumerate(self.full_matrix_definitions):
             self.log_split(split_num, split)
             train_store = MettaCSVMatrixStore(
                 matrix_path=os.path.join(


### PR DESCRIPTION
- Introduce Pipeline#full_matrix_definitions to reduce complication when looping through them
- Loop through full_matrix_definitions when logging splits