### PR TITLE
Separate train/test prediction windows [Resolves #152]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -12,13 +12,12 @@ temporal_config:
     modeling_start_time: '2012-01-01' # earliest date in any model
     modeling_end_time: '2015-01-01' # all dates in any model are < this date
     update_window: '6month' # how frequently to retrain models
-    look_back_durations: # length of time included in a model
-        - '6month'
-        - '3month'
     train_example_frequency: '1day' # time between rows for same entity in train matrix
     test_example_frequency: '3month' # time between rows for same entity in test matrix
-    test_durations: ['1month', '2month']
-    prediction_frequency: '1day' # per test set how often to generate predictions
+    train_durations: ['6month', '3month'] # length of time included in a train matrix
+    test_durations: ['1month', '2month'] # length of time included in a test matrix
+    train_label_windows: ['1month'] # time period across which outcomes are labeled in train matrices
+    test_label_windows: ['7day'] # time period across which outcomes are labeled in test matrices
 
 # LABEL GENERATION
 # Information needed to generate labels

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,10 +33,10 @@ def test_integration():
                 'label': [7, 8]
             }).set_index('entity_id')
             train_metadata = {
-                'start_time': datetime.date(2012, 12, 20),
+                'beginning_of_time': datetime.date(2012, 12, 20),
                 'end_time': datetime.date(2016, 12, 20),
                 'label_name': 'label',
-                'prediction_window': '1y',
+                'label_window': '1y',
                 'feature_names': ['ft1', 'ft2'],
                 'metta-uuid': '1234',
             }
@@ -58,6 +58,7 @@ def test_integration():
                     }).set_index('entity_id'),
                     {
                         'label_name': 'label',
+                        'label_window': '1y',
                         'end_time': as_of_date,
                         'metta-uuid': '1234',
                     }

--- a/tests/test_label_generators.py
+++ b/tests/test_label_generators.py
@@ -21,7 +21,7 @@ events_data = [
 ]
 
 expected = [
-    # entity_id, as_of_date, prediction_window, name, type, label
+    # entity_id, as_of_date, label_window, name, type, label
     (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
     (3, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', True),
     (4, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
@@ -49,7 +49,7 @@ def test_training_label_generation():
         label_generator._create_labels_table(labels_table_name)
         label_generator.generate(
             start_date='2014-09-30',
-            prediction_window='6month',
+            label_window='6month',
             labels_table=labels_table_name
         )
 

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -38,10 +38,10 @@ def test_model_trainer():
                 'label': ['good', 'bad']
             })
             metadata = {
-                'start_time': datetime.date(2012, 12, 20),
+                'beginning_of_time': datetime.date(2012, 12, 20),
                 'end_time': datetime.date(2016, 12, 20),
                 'label_name': 'label',
-                'prediction_window': '1y',
+                'label_window': '1y',
                 'metta-uuid': '1234',
                 'feature_names': ['ft1', 'ft2']
             }
@@ -195,9 +195,9 @@ def test_n_jobs_not_new_model():
                 grid_config,
                 dict(),
                 InMemoryMatrixStore(matrix, {
-                    'prediction_window': '1d',
+                    'label_window': '1d',
                     'end_time': datetime.datetime.now(),
-                    'start_time': datetime.date(2012, 12, 20),
+                    'beginning_of_time': datetime.date(2012, 12, 20),
                     'label_name': 'label',
                     'metta-uuid': '1234',
                     'feature_names': ['ft1', 'ft2']

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 import os
 from sqlalchemy import create_engine
 from functools import partial
@@ -111,12 +111,12 @@ def simple_pipeline_test(pipeline_class):
             'modeling_start_time': '2011-01-01',
             'modeling_end_time': '2014-01-01',
             'update_window': '1y',
-            'prediction_window': '6months',
-            'look_back_durations': ['6months'],
+            'train_label_windows': ['6months'],
+            'test_label_windows': ['6months'],
             'train_example_frequency': '1day',
             'test_example_frequency': '3months',
+            'train_durations': ['6months'],
             'test_durations': ['1months'],
-            'prediction_frequency': '1d'
         }
         scoring_config = {
             'metric_groups': [
@@ -213,12 +213,15 @@ def simple_pipeline_test(pipeline_class):
         ])
         assert num_models == num_models_with_experiment
 
-        # 7. that models have the train end date, including prediction window
-        train_end_times = [
-            model['train_end_time']
+        # 7. that models have the train end date and label window
+        results = [
+            (model['train_end_time'], model['train_label_window'])
             for model in db_engine.execute('select * from results.models')
         ]
-        assert sorted(set(train_end_times)) == [datetime(2012, 7, 1), datetime(2013, 7, 1)]
+        assert sorted(set(results)) == [
+            (datetime(2012, 1, 1), timedelta(180)),
+            (datetime(2013, 1, 1), timedelta(180))
+        ]
 
 
 def test_serial_pipeline():
@@ -241,12 +244,12 @@ def reuse_pipeline_test(pipeline_class):
             'modeling_start_time': '2011-01-01',
             'modeling_end_time': '2014-01-01',
             'update_window': '1y',
-            'prediction_window': '6months',
-            'look_back_durations': ['6months'],
+            'train_label_windows': ['6months'],
+            'test_label_windows': ['6months'],
             'train_example_frequency': '1day',
             'test_example_frequency': '3months',
+            'train_durations': ['6months'],
             'test_durations': ['1months'],
-            'prediction_frequency': '1d'
         }
         scoring_config = {
             'metric_groups': [

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -45,6 +45,7 @@ def test_predictor():
             metadata = {
                 'label_name': 'label',
                 'end_time': AS_OF_DATE,
+                'label_window': '3month',
                 'metta-uuid': '1234',
             }
 
@@ -84,6 +85,7 @@ def test_predictor():
             new_metadata = {
                 'label_name': 'label',
                 'end_time': AS_OF_DATE + datetime.timedelta(days=1),
+                'label_window': '3month',
                 'metta-uuid': '1234',
             }
             new_matrix_store = InMemoryMatrixStore(new_matrix, new_metadata)
@@ -124,6 +126,7 @@ def test_predictor_composite_index():
         metadata = {
             'label_name': 'label',
             'end_time': AS_OF_DATE,
+            'label_window': '3month',
             'metta-uuid': '1234',
         }
         matrix_store = InMemoryMatrixStore(matrix, metadata)
@@ -167,6 +170,7 @@ def test_predictor_retrieve():
         metadata = {
             'label_name': 'label',
             'end_time': AS_OF_DATE,
+            'label_window': '3month',
             'metta-uuid': '1234',
         }
         matrix_store = InMemoryMatrixStore(matrix, metadata)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -132,14 +132,14 @@ def test_model_scoring_inspections():
         prediction_probas = numpy.array([0.56, 0.4, 0.55, 0.5, 0.3])
         evaluation_start = datetime.datetime(2016, 4, 1)
         evaluation_end = datetime.datetime(2016, 7, 1)
-        prediction_frequency = '1d'
+        example_frequency = '1d'
         model_scorer.score(
             prediction_probas,
             labels,
             model_id,
             evaluation_start,
             evaluation_end,
-            prediction_frequency
+            example_frequency
         )
 
         for record in db_engine.execute(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
-from triage.utils import temporal_splits, \
-    filename_friendly_hash, \
+from triage.utils import filename_friendly_hash, \
     save_experiment_and_get_hash, \
     sort_predictions_and_labels
 from triage.db import ensure_db
@@ -8,58 +7,6 @@ import testing.postgresql
 import datetime
 import logging
 import re
-
-
-def assert_split(output, expected):
-    for output_row, expected_row in zip(output, expected):
-        assert expected_row['train_start'] == output_row['train_start'].date().isoformat()
-        assert expected_row['train_end'] == output_row['train_end'].date().isoformat()
-        assert expected_row['test_start'] == output_row['test_start'].date().isoformat()
-        assert expected_row['test_end'] == output_row['test_end'].date().isoformat()
-        assert len(expected_row['train_as_of_dates']) == len(output_row['train_as_of_dates'])
-        for output_feature_date, expected_feature_date in zip(sorted(output_row['train_as_of_dates']), sorted(expected_row['train_as_of_dates'])):
-            assert expected_feature_date == output_feature_date.date().isoformat()
-        assert len(expected_row['test_as_of_dates']) == len(output_row['test_as_of_dates'])
-        for output_feature_date, expected_feature_date in zip(sorted(output_row['test_as_of_dates']), sorted(expected_row['test_as_of_dates'])):
-            assert expected_feature_date == output_feature_date.date().isoformat()
-
-
-def test_temporal_splits():
-    splits = [split for split in temporal_splits(
-        start_time='2014-04-01',
-        end_time='2016-04-01',
-        update_window=6,
-        prediction_windows=[6],
-        feature_frequency=6,
-        test_frequency=3
-    )]
-    expected = [
-        {
-            'train_start': '2014-09-30',
-            'train_end': '2015-09-30',
-            'test_start': '2015-10-01',
-            'test_end': '2016-04-01',
-            'train_as_of_dates': ['2014-09-30', '2015-03-30'],
-            'test_as_of_dates': ['2015-10-01', '2016-01-01'],
-        },
-        {
-            'train_start': '2014-03-30',
-            'train_end': '2015-09-30',
-            'test_start': '2015-10-01',
-            'test_end': '2016-04-01',
-            'train_as_of_dates': ['2014-03-30', '2014-09-30', '2015-03-30'],
-            'test_as_of_dates': ['2015-10-01', '2016-01-01'],
-        },
-        {
-            'train_start': '2014-03-30',
-            'train_end': '2015-03-31',
-            'test_start': '2015-04-01',
-            'test_end': '2015-10-01',
-            'train_as_of_dates': ['2014-03-30', '2014-09-30'],
-            'test_as_of_dates': ['2015-04-01', '2015-07-01'],
-        }
-    ]
-    assert_split(splits, expected)
 
 
 def test_filename_friendly_hash():

--- a/triage/db.py
+++ b/triage/db.py
@@ -78,6 +78,7 @@ class Model(Base):
     train_end_time = Column(DateTime)
     test = Column(Boolean)
     train_matrix_uuid = Column(Text)
+    train_label_window = Column(Interval)
 
     def delete(self, session):
         # basically implement a cascade, in case cascade is not implemented
@@ -113,6 +114,7 @@ class Prediction(Base):
     rank_abs = Column(Integer)
     rank_pct = Column(Float)
     matrix_uuid = Column(Text)
+    test_label_window = Column(Interval)
 
 
 class Evaluation(Base):
@@ -120,7 +122,7 @@ class Evaluation(Base):
     model_id = Column(Integer, ForeignKey('models.model_id'), primary_key=True)
     evaluation_start_time = Column(DateTime, primary_key=True)
     evaluation_end_time = Column(DateTime, primary_key=True)
-    prediction_frequency = Column(Interval, primary_key=True)
+    example_frequency = Column(Interval, primary_key=True)
     metric = Column(String, primary_key=True)
     parameter = Column(String, primary_key=True)
     value = Column(Numeric)

--- a/triage/label_generators.py
+++ b/triage/label_generators.py
@@ -6,24 +6,24 @@ class BinaryLabelGenerator(object):
         self.events_table = events_table
         self.db_engine = db_engine
 
-    def generate(self, start_date, prediction_window, labels_table):
+    def generate(self, start_date, label_window, labels_table):
         query = """insert into {labels_table} (
             select
                 entity_id,
                 '{start_date}'::date as as_of_date,
-                '{prediction_window}'::interval as prediction_window,
+                '{label_window}'::interval as label_window,
                 'outcome' as label_name,
                 'binary' as label_type,
                 bool_or(outcome::bool)::int as label
             from {events_table}
             where '{start_date}' <= outcome_date
-            and outcome_date < '{start_date}'::timestamp + interval '{prediction_window}'
+            and outcome_date < '{start_date}'::timestamp + interval '{label_window}'
             group by 1, 2, 3, 4, 5
         )""".format(
             events_table=self.events_table,
             labels_table=labels_table,
             start_date=start_date,
-            prediction_window=prediction_window
+            label_window=label_window
         )
         logging.debug(query)
         self.db_engine.execute(query)
@@ -37,18 +37,18 @@ class BinaryLabelGenerator(object):
             create table {} (
             entity_id int,
             as_of_date date,
-            prediction_window interval,
+            label_window interval,
             label_name varchar(30),
             label_type varchar(30),
             label int
         )'''.format(labels_table_name))
 
-    def generate_all_labels(self, labels_table, as_of_times, prediction_window):
+    def generate_all_labels(self, labels_table, as_of_times, label_window):
         self._create_labels_table(labels_table)
         logging.info('Creating labels for %s as of times', len(as_of_times))
         for as_of_time in as_of_times:
             self.generate(
                 start_date=as_of_time,
-                prediction_window=prediction_window,
+                label_window=label_window,
                 labels_table=labels_table
             )

--- a/triage/model_group_stored_procedure.sql
+++ b/triage/model_group_stored_procedure.sql
@@ -6,8 +6,8 @@ CREATE TABLE results.model_groups
   model_group_id    SERIAL PRIMARY KEY,
   model_type        TEXT,
   model_parameters  JSONB,
-  prediction_window TEXT,
   feature_list      TEXT []
+  model_config		JSONB
 );
 -----------
 populates the table and returns the IDs

--- a/triage/model_trainers.py
+++ b/triage/model_trainers.py
@@ -8,7 +8,6 @@ import datetime
 import copy
 import pandas
 import warnings
-from timechop.utils import convert_str_to_relativedelta
 from triage.utils import filename_friendly_hash, retrieve_model_id_from_hash
 
 
@@ -246,7 +245,7 @@ class ModelTrainer(object):
         """
         Returns model group id using store procedure 'get_model_group_id' which will 
         return the same value for models with the same class_path, parameters, 
-        prediction_window and features
+        features, and model_config
 
         Args:
             class_path (string) A full classpath to the model class
@@ -412,9 +411,8 @@ class ModelTrainer(object):
         matrix_store = matrix_store or self.matrix_store
         misc_db_parameters = copy.deepcopy(misc_db_parameters)
         misc_db_parameters['batch_run_time'] = datetime.datetime.now().isoformat()
-        misc_db_parameters['train_end_time'] = \
-            matrix_store.metadata['end_time'] + \
-            convert_str_to_relativedelta(matrix_store.metadata['prediction_window'])
+        misc_db_parameters['train_end_time'] = matrix_store.metadata['end_time']
+        misc_db_parameters['train_label_window'] = matrix_store.metadata['label_window']
         misc_db_parameters['train_matrix_uuid'] = matrix_store.uuid
 
         tasks = []

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -277,7 +277,7 @@ def test_and_score(
                 model_id=model_id,
                 evaluation_start_time=split_def['matrix_start_time'],
                 evaluation_end_time=split_def['matrix_end_time'],
-                prediction_frequency=config['temporal_config']['prediction_frequency']
+                example_frequency=split_def['example_frequency']
             )
         return True
     except Exception:

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -88,5 +88,5 @@ class SerialPipeline(PipelineBase):
                         model_id=model_id,
                         evaluation_start_time=split_def['matrix_start_time'],
                         evaluation_end_time=split_def['matrix_end_time'],
-                        prediction_frequency=self.config['temporal_config']['prediction_frequency']
+                        example_frequency=split_def['example_frequency']
                     )

--- a/triage/scoring.py
+++ b/triage/scoring.py
@@ -241,7 +241,7 @@ class ModelScorer(object):
         model_id,
         evaluation_start_time,
         evaluation_end_time,
-        prediction_frequency
+        example_frequency
     ):
         """Score a model based on predictions, and save the results
 
@@ -251,7 +251,7 @@ class ModelScorer(object):
             model_id (int) The database identifier of the model
             evaluation_start_time (datetime.datetime) The time of the first prediction being evaluated
             evaluation_end_time (datetime.datetime) The time of the last prediction being evaluated
-            prediction_frequency (string) How frequently predictions were generated
+            example_frequency (string) How frequently predictions were generated
         """
         predictions_proba_sorted, labels_sorted = sort_predictions_and_labels(
             predictions_proba,
@@ -319,7 +319,7 @@ class ModelScorer(object):
             model_id,
             evaluation_start_time,
             evaluation_end_time,
-            prediction_frequency,
+            example_frequency,
             evaluations
         )
         logging.info('Done writing metrics to db')
@@ -329,7 +329,7 @@ class ModelScorer(object):
         model_id,
         evaluation_start_time,
         evaluation_end_time,
-        prediction_frequency,
+        example_frequency,
         evaluations
     ):
         """Write evaluation objects to the database
@@ -348,14 +348,14 @@ class ModelScorer(object):
                 model_id=model_id,
                 evaluation_start_time=evaluation_start_time,
                 evaluation_end_time=evaluation_end_time,
-                prediction_frequency=prediction_frequency
+                example_frequency=example_frequency
             ).delete()
 
         for evaluation in evaluations:
             evaluation.model_id = model_id
             evaluation.evaluation_start_time = evaluation_start_time
             evaluation.evaluation_end_time = evaluation_end_time
-            evaluation.prediction_frequency = prediction_frequency
+            evaluation.example_frequency = example_frequency
             session.add(evaluation)
         session.commit()
         session.close()

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -1,5 +1,4 @@
 import datetime
-from dateutil.relativedelta import relativedelta
 import pickle
 import tempfile
 import hashlib
@@ -79,56 +78,6 @@ def get_matrix_and_metadata(matrix_path, metadata_path):
     with open(metadata_path) as f:
         metadata = yaml.load(f)
     return matrix, metadata
-
-
-def temporal_splits(
-    start_time,
-    end_time,
-    update_window,
-    prediction_windows,
-    feature_frequency,
-    test_frequency
-):
-    start_time_date = datetime.datetime.strptime(start_time, '%Y-%m-%d')
-    end_time_date = datetime.datetime.strptime(end_time, '%Y-%m-%d')
-
-    for window in prediction_windows:
-        test_end_time = end_time_date
-        test_end_max = start_time_date + 2 * relativedelta(months=+window)
-        while (test_end_time >= test_end_max):
-            test_start_time = test_end_time - relativedelta(months=+window)
-            train_end_time = test_start_time - relativedelta(days=+1)
-            train_start_time = train_end_time - relativedelta(months=+window)
-            while (train_start_time >= start_time_date):
-                train_start_time -= relativedelta(months=+window)
-                yield {
-                    'train_start': train_start_time,
-                    'train_end': train_end_time,
-                    'train_as_of_dates': generate_as_of_dates(
-                        train_start_time,
-                        train_end_time,
-                        feature_frequency
-                    ),
-                    'test_start': test_start_time,
-                    'test_end': test_end_time,
-                    'test_as_of_dates': generate_as_of_dates(
-                        test_start_time,
-                        test_end_time,
-                        test_frequency
-                    ),
-                    'prediction_window': window
-                }
-            test_end_time -= relativedelta(months=+update_window)
-
-
-def generate_as_of_dates(start_date, end_date, prediction_window):
-    as_of_dates = []
-    as_of_date = start_date
-    while as_of_date <= end_date - relativedelta(months=prediction_window):
-        as_of_dates.append(as_of_date)
-        as_of_date += relativedelta(months=prediction_window)
-
-    return as_of_dates
 
 
 def filename_friendly_hash(inputs):


### PR DESCRIPTION
- Use new name of timechop.Inspections, timechop.Timechop
- Take in train_prediction_windows and test_prediction_windows, remove prediction_window and related hack
- Pass in train and test prediction windows to Timechop
- Generate labels for all prediction windows
- Use name 'train_durations' instead of 'look_back_durations'