### PR TITLE
Order prediction matrix columns to match train matrix [Resolves #170]

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -106,7 +106,8 @@ def test_integration():
                     predictions_proba = predictor.predict(
                         model_id,
                         test_store,
-                        misc_db_parameters=dict()
+                        misc_db_parameters=dict(),
+                        train_matrix_columns=['feature_one', 'feature_two']
                     )
 
                     model_scorer.score(

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -192,6 +192,7 @@ def test_predictor_get_train_columns():
                 model_id,
                 test_store,
                 misc_db_parameters=dict(),
+                train_matrix_columns=train_store.columns()
             )
             # assert
             # 1. that we calculated predictions

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -10,7 +10,7 @@ from triage.db import ensure_db
 import pandas
 
 from triage.predictors import Predictor
-from tests.utils import fake_trained_model, sample_metta_csv_train_test
+from tests.utils import fake_trained_model, sample_metta_csv_diff_order
 from triage.storage import \
     InMemoryModelStorageEngine,\
     S3ModelStorageEngine,\
@@ -176,7 +176,7 @@ def test_predictor_get_train_columns():
         ensure_db(db_engine)
         project_path = 'econ-dev/inspections'
         with tempfile.TemporaryDirectory() as temp_dir:
-            train_store, test_store = sample_metta_csv_train_test(temp_dir)
+            train_store, test_store = sample_metta_csv_diff_order(temp_dir)
 
             model_storage_engine = InMemoryModelStorageEngine(project_path)
             _, model_id = \

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,6 @@ from moto import mock_s3
 import tempfile
 import boto3
 import os
-from tests.utils import sample_metta_csv_diff_order
 
 
 class SomeClass(object):
@@ -47,10 +46,3 @@ def test_MemoryStore():
     assert newVal.val == 'val'
     store.delete()
     assert not store.exists()
-
-
-def test_matrix_store_find_related():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        train_store, test_store = sample_metta_csv_diff_order(temp_dir)
-        assert test_store.find_related_matrix(train_store.uuid).columns() ==\
-            train_store.columns()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,7 +3,7 @@ from moto import mock_s3
 import tempfile
 import boto3
 import os
-from tests.utils import sample_metta_csv_train_test
+from tests.utils import sample_metta_csv_diff_order
 
 
 class SomeClass(object):
@@ -51,6 +51,6 @@ def test_MemoryStore():
 
 def test_matrix_store_find_related():
     with tempfile.TemporaryDirectory() as temp_dir:
-        train_store, test_store = sample_metta_csv_train_test(temp_dir)
+        train_store, test_store = sample_metta_csv_diff_order(temp_dir)
         assert test_store.find_related_matrix(train_store.uuid).columns() ==\
             train_store.columns()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -3,6 +3,7 @@ from moto import mock_s3
 import tempfile
 import boto3
 import os
+from tests.utils import sample_metta_csv_train_test
 
 
 class SomeClass(object):
@@ -46,3 +47,10 @@ def test_MemoryStore():
     assert newVal.val == 'val'
     store.delete()
     assert not store.exists()
+
+
+def test_matrix_store_find_related():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        train_store, test_store = sample_metta_csv_train_test(temp_dir)
+        assert test_store.find_related_matrix(train_store.uuid).columns() ==\
+            train_store.columns()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,8 +66,10 @@ def fake_trained_model(project_path, model_storage_engine, db_engine, train_matr
     return trained_model, db_model.model_id
 
 
-def sample_metta_csv_train_test(directory):
+def sample_metta_csv_diff_order(directory):
     """Stores matrix and metadata in a metta-data-like form
+
+    The train and test matrices will have different column orders
 
     Args:
         directory (str)
@@ -90,8 +92,8 @@ def sample_metta_csv_train_test(directory):
 
     test_dict = OrderedDict([
         ('entity_id', [3, 4]),
-        ('k_feature', [0.5, 0.4]),
         ('m_feature', [0.4, 0.5]),
+        ('k_feature', [0.5, 0.4]),
         ('label', [0, 1])
     ])
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,11 @@ import numpy
 import random
 from results_schema import Model
 from sqlalchemy.orm import sessionmaker
+import datetime
+import os
+from triage.storage import MettaCSVMatrixStore
+from metta import metta_io as metta
+from collections import OrderedDict
 
 
 @contextmanager
@@ -41,7 +46,7 @@ class MockTrainedModel(object):
         return numpy.random.rand(len(dataset), len(dataset))
 
 
-def fake_trained_model(project_path, model_storage_engine, db_engine):
+def fake_trained_model(project_path, model_storage_engine, db_engine, train_matrix_uuid='efgh'):
     """Creates and stores a trivial trained model
 
     Args:
@@ -55,7 +60,66 @@ def fake_trained_model(project_path, model_storage_engine, db_engine):
     trained_model = MockTrainedModel()
     model_storage_engine.get_store('abcd').write(trained_model)
     session = sessionmaker(db_engine)()
-    db_model = Model(model_hash='abcd')
+    db_model = Model(model_hash='abcd', train_matrix_uuid=train_matrix_uuid)
     session.add(db_model)
     session.commit()
     return trained_model, db_model.model_id
+
+
+def sample_metta_csv_train_test(directory):
+    """Stores matrix and metadata in a metta-data-like form
+
+    Args:
+        directory (str)
+    """
+    train_dict = OrderedDict([
+        ('entity_id', [1, 2]),
+        ('k_feature', [0.5, 0.4]),
+        ('m_feature', [0.4, 0.5]),
+        ('label', [0, 1])
+    ])
+    train_matrix = pandas.DataFrame.from_dict(train_dict)
+    train_metadata = {
+        'beginning_of_time': datetime.date(2014, 1, 1),
+        'end_time': datetime.date(2015, 1, 1),
+        'matrix_id': 'train_matrix',
+        'label_name': 'label',
+        'label_window': '3month',
+        'indices': ['entity_id'],
+    }
+
+    test_dict = OrderedDict([
+        ('entity_id', [3, 4]),
+        ('k_feature', [0.5, 0.4]),
+        ('m_feature', [0.4, 0.5]),
+        ('label', [0, 1])
+    ])
+
+    test_matrix = pandas.DataFrame.from_dict(test_dict)
+    test_metadata = {
+        'beginning_of_time': datetime.date(2015, 1, 1),
+        'end_time': datetime.date(2016, 1, 1),
+        'matrix_id': 'test_matrix',
+        'label_name': 'label',
+        'label_window': '3month',
+        'indices': ['entity_id'],
+    }
+
+    train_uuid, test_uuid = metta.archive_train_test(
+        train_config=train_metadata,
+        df_train=train_matrix,
+        test_config=test_metadata,
+        df_test=test_matrix,
+        directory=directory,
+        format='csv'
+    )
+
+    train_store = MettaCSVMatrixStore(
+        matrix_path=os.path.join(directory, '{}.csv'.format(train_uuid)),
+        metadata_path=os.path.join(directory, '{}.yaml'.format(train_uuid))
+    )
+    test_store = MettaCSVMatrixStore(
+        matrix_path=os.path.join(directory, '{}.csv'.format(test_uuid)),
+        metadata_path=os.path.join(directory, '{}.yaml'.format(test_uuid))
+    )
+    return train_store, test_store

--- a/triage/pipelines/local_parallel.py
+++ b/triage/pipelines/local_parallel.py
@@ -106,6 +106,7 @@ class LocalParallelPipeline(PipelineBase):
                     test_store=test_store,
                     db_connection_string=self.db_engine.url,
                     split_def=split_def,
+                    train_matrix_columns=train_store.columns(),
                     config=self.config
                 )
                 logging.info(
@@ -260,6 +261,7 @@ def test_and_score(
     test_store,
     db_connection_string,
     split_def,
+    train_matrix_columns,
     config
 ):
     try:
@@ -272,7 +274,8 @@ def test_and_score(
             predictions_proba = predictor.predict(
                 model_id,
                 test_store,
-                misc_db_parameters=dict()
+                misc_db_parameters=dict(),
+                train_matrix_columns=train_matrix_columns
             )
             logging.info('Generating evaluations for model id %s', model_id)
             model_scorer.score(

--- a/triage/pipelines/serial.py
+++ b/triage/pipelines/serial.py
@@ -83,7 +83,8 @@ class SerialPipeline(PipelineBase):
                     predictions_proba = self.predictor.predict(
                         model_id,
                         test_store,
-                        misc_db_parameters=dict()
+                        misc_db_parameters=dict(),
+                        train_matrix_columns=train_store.columns(),
                     )
 
                     self.model_scorer.score(

--- a/triage/predictors.py
+++ b/triage/predictors.py
@@ -8,7 +8,7 @@ import numpy
 import tempfile
 import csv
 import postgres_copy
-from triage.utils import db_retry, retrieve_train_matrix_uuid
+from triage.utils import db_retry
 
 
 class ModelNotFoundError(ValueError):
@@ -206,13 +206,17 @@ class Predictor(object):
             session.close()
 
 
-    def predict(self, model_id, matrix_store, misc_db_parameters, train_matrix_columns=None):
+    def predict(self, model_id, matrix_store, misc_db_parameters, train_matrix_columns):
         """Generate predictions and store them in the database
 
         Args:
             model_id (int) the id of the trained model to predict based off of
             matrix_store (triage.storage.MatrixStore) a wrapper for the
                 prediction matrix and metadata
+            misc_db_parameters (dict): attributes and values to add to each
+                Prediction object in the results schema
+            train_matrix_columns (list): The order of columns that the model
+                was trained on
 
         Returns:
             (numpy.Array) the generated prediction values
@@ -235,17 +239,6 @@ class Predictor(object):
         model = self.load_model(model_id)
         if not model:
             raise ModelNotFoundError('Model id {} not found'.format(model_id))
-
-        if not train_matrix_columns:
-            train_matrix_uuid = retrieve_train_matrix_uuid(
-                self.db_engine,
-                model_id
-            )
-            train_matrix_columns = [
-                col for col in 
-                matrix_store.find_related_matrix(train_matrix_uuid).columns()
-                if col != matrix_store.metadata['label_name']
-            ]
 
         labels = matrix_store.labels()
         predictions_proba = model.predict_proba(

--- a/triage/storage.py
+++ b/triage/storage.py
@@ -139,9 +139,25 @@ class MatrixStore(object):
             ]
 
     def matrix_with_sorted_columns(self, columns):
-        if self.columns() != columns:
-            logging.warning('Column orders not the same, re-ordering')
-        return self.matrix[columns]
+        columnset = set(self.columns())
+        desired_columnset = set(columns)
+        if columnset == desired_columnset:
+            if self.columns() != columns:
+                logging.warning('Column orders not the same, re-ordering')
+            return self.matrix[columns]
+        else:
+            if columnset.issuperset(desired_columnset):
+                raise ValueError('''
+                    Columnset is superset of desired columnset. Extra items: %s
+                ''', columnset - desired_columnset)
+            elif columnset.issubset(desired_columnset):
+                raise ValueError('''
+                    Columnset is subset of desired columnset. Extra items: %s
+                ''', desired_columnset - columnset)
+            else:
+                raise ValueError('''
+                    Columnset and desired columnset mismatch. Unique items: %s
+                ''', columnset ^ desired_columnset)
 
 
 class MettaMatrixStore(MatrixStore):

--- a/triage/storage.py
+++ b/triage/storage.py
@@ -143,9 +143,6 @@ class MatrixStore(object):
             logging.warning('Column orders not the same, re-ordering')
         return self.matrix[columns]
 
-    def find_related_matrix(self, related_matrix_uuid):
-        raise NotImplementedError()
-
 
 class MettaMatrixStore(MatrixStore):
     def __init__(self, matrix_path, metadata_path):
@@ -191,24 +188,6 @@ class MettaCSVMatrixStore(MatrixStore):
                 col for col in columns
                 if col != self.metadata['label_name']
             ]
-
-    def find_related_matrix(self, related_matrix_uuid):
-        related_matrix_path = self.matrix_path.replace(
-            self.uuid,
-            related_matrix_uuid
-        )
-
-        related_metadata_path = self.metadata_path.replace(
-            self.uuid,
-            related_matrix_uuid
-        )
-
-        related_matrix_store = type(self)(
-            matrix_path=related_matrix_path,
-            metadata_path=related_metadata_path
-        )
-
-        return related_matrix_store
 
     def _load(self):
         self._matrix = pandas.read_csv(self.matrix_path)

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -178,3 +178,13 @@ def retrieve_model_id_from_hash(db_engine, model_hash):
         return saved.model_id if saved else None
     finally:
         session.close()
+
+
+@db_retry
+def retrieve_train_matrix_uuid(db_engine, model_id):
+    session = sessionmaker(bind=db_engine)()
+    try:
+        matrix_uuid = session.query(Model).get(model_id).train_matrix_uuid
+    finally:
+        session.close()
+    return matrix_uuid

--- a/triage/utils.py
+++ b/triage/utils.py
@@ -178,13 +178,3 @@ def retrieve_model_id_from_hash(db_engine, model_hash):
         return saved.model_id if saved else None
     finally:
         session.close()
-
-
-@db_retry
-def retrieve_train_matrix_uuid(db_engine, model_id):
-    session = sessionmaker(bind=db_engine)()
-    try:
-        matrix_uuid = session.query(Model).get(model_id).train_matrix_uuid
-    finally:
-        session.close()
-    return matrix_uuid


### PR DESCRIPTION
We want to make sure that when we process a prediction matrix, the columns match up with that of the train matrix. This turned out a bit more complicated than I wanted to, to keep some of the flexibility in triage.Storage (that is being used!).

When the InMemoryMatrixStore is used (example: https://github.com/dssg/police-eis/blob/master/eis/run_models.py#L306 ), it is impossible to infer anything about the train matrix. For that reason, we have to support the passing in of the column list itself. To handle this, we have an if statement in predictor.predict, that uses this when present but otherwise retrieves the column list by retrieving the train uuid, finding the stored matrix, and grabbing the column names from there. I don't love the end result, but I also can't think of a better alternative.

- Add util to retrieve train matrix id given a trained model
- Add method to MatrixStore to return a matrix store of the same class with a different UUID
- Add method to MatrixStore to reorder the matrix's columns
- Add train_matrix_columns optional argument to Predictor#predict, usable when the MatrixStore can't support retrieving the train matrix columns after the fact (e.g. when InMemoryMatrixStore is used)
- Add test utility to create basic metta matrices/metadata