### PR TITLE
Rename Pipeline to Experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,88 +8,148 @@ Risk modeling and prediction
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
-## Basic Usage
+Predictive analytics projects require the coordination of many different tasks, such as feature generation, classifier training, evaluation, and list generation. These tasks are complicated in their own right, but in addition have to be combined in different ways throughout the course of the project. 
 
-The simplest usage of triage is to use a pipeline. Triage pipelines are aimed at handling label generation, generating features (using [collate](https://github.com/dssg/collate)), creating training/test splits (using [timechop](https://github.com/dssg/timechop)), training models, testing models, and calculating metrics. Triage pipelines are generally run after data is loaded into a Postgres database and cleaned. The model metadata, feature importances, predictions, and model metrics are saved to the `results` schema in the given database.  Different pipelines are available, which control execution in different ways.  The SerialPipeline, for instance, is the simplest but slowest, while the LocalParallelPipeline makes use of multiple cores on the local machine.
+Triage aims to provide interfaces to these different phases of a project, such as an `Experiment`. Each phase is defined by configuration specific to the needs of the project, and an arrangement of core data science components that work together to produce the output of that phase.
+
+## Experiment
+
+The first phase implemented in triage is the `Experiment`. An experiment represents the initial research work of creating design matrices from source data, and training/testing/evaluating a model grid on those matrices. At the end of the experiment, a relational database with results metadata is populated, allowing for evaluation by the researcher.
+
+### Prerequisites
+
+To use a Triage experiment, you first need:
+
+- Python 3+
+- A PostgreSQL database with your source data (events, geographical data, etc) loaded.
+- Ample space on an available disk (or S3) to store the needed matrices and models for your experiment
 
 
-### Construct a Pipeline
+### Experiment Run Example
 
-To construct one of these pipeline objects, you need the following arguments:
-
-- An experiment configuration. This contains time-splitting, feature-generation, grid-search, and model-scoring configurations. An up-to-date example is at [example_experiment_config.yaml](https://github.com/dssg/triage/blob/master/example_experiment_config.yaml); more detailed instructions are located in the example file. This is passed in dict format to the pipeline constructor.
-- A SQLAlchemy Postgres database engine. There is a convenience wrapper at triage.db.connect() that reads from a local database.yaml file, but you can supply an engine created however you like.
-- A model-storage engine class from the `triage.storage` module. The model-storage engines are wrappers around various ways to cache models, and are exclusively used for model caching inside triage components. Current implementations include InMemoryModelStorageEngine (no caching), FSModelStorageEngine (on local or mounted disk), and S3ModelStorageEngine (direct to AWS s3). FSModelStorageEngine is recommended to start.
-- Pick a project path. This is used by the persistent-storage engines.
-
-
-### Run a Pipeline
-
-The pipeline has one main method: `.run()`. This will perform all work, from label generation through model metric creation.
+The basic execution of an experiment looks something like the following:
 
 ```
-    from triage.db import connect
-    from triage.storage import FSModelStorageEngine
-    from triage.pipelines import SerialPipeline
-
-	with open('example_experiment_config.yaml') as f:
-		experiment_config = yaml.load(f)
-	pipeline = SerialPipeline(
+	SingleThreadedExperiment(
 		config=experiment_config,
-		db_engine=connect(),
+		db_engine=sqlalchemy.create_engine(...),
 		model_storage_class=FSModelStorageEngine,
-		project_path='/path/to/cached_models/test_project'
-	)
+		project_path='/path/to/directory/to/save/data'
+	).run()
+```
 
-	pipeline.run()
+These lines are a bit dense: what is happening here?
+
+- `SingleThreadedExperiment`:  There are different Experiment classes available in `triage.experiments` to use, and they each represent a different way of executing the experiment, which we'll talk about in more detail later. The simplest (but slowest) is the SingleThreadedExperiment.
+- `config=experiment_config`: The bulk of the work needed in designing an experiment will be in creating this experiment configuration. An up-to-date example is at [example_experiment_config.yaml](example_experiment_config.yaml); more detailed instructions on each section are located in the example file. Generally these would be easiest to store as a file (or multiple files that you construct together) like that YAML file, but the configuration is passed in dict format to the Experiment constructor and you can store it however you wish.
+- `db_engine=sqlalchemy.create_engine(...)`: A SQLAlchemy database engine. This will be used both for querying your source tables and writing results metadata.
+- `model_storage_class=FSModelStorageEngine`: The path to a model storage engine class. The library that triage uses for model training and evaluation, [catwalk](https://github.com/dssg/catwalk), provides multiple classes that handle storing trained models in different mediums, such as on the local filesystem or Amazon S3. We recommend starting with the `catwalk.storage.FSModelStorageEngine` to save models on the local filesystem.
+- `project_path='/path/to/directory/to/save/data'`: The path to where you would like to store design matrices and trained models.
+
+With that in mind, a more full version of the experiment run script might look like this:
+
+```
+import sqlalchemy
+import yaml
+
+from catwalk.storage import FSModelStorageEngine
+from triage.experiments import SingleThreadedExperiment
+
+with open('my_experiment_config.yaml') as f:
+	experiment_config = yaml.load(f)
+with open('my_database_creds') as f:
+	db_connection_string = yaml.load(f)['db_connection_string']
+
+experiment = SingleThreadedExperiment(
+	config=experiment_config,
+	db_engine=sqlalchemy.create_engine(db_connection_string),
+	model_storage_class=FSModelStorageEngine,
+	project_path='/home/research/myproject'
+)
+
+experiment.run()
 ```
 
 
-### Evaluating results of a pipeline
+### Evaluating results of an Experiment
 
-After the experiment run, a results schema will be created in the configured database with the following tables:
+After the experiment run, a results schema will be created and populated in the configured database with the following tables:
 - experiments - The experiment configuration and a hash
-- model_groups - Definitions of 'model groups'; model groups are defined by all models that share all parameters except for training date
-- models - Each model, including training date
-- feature_importances - The sklearn feature importances results for each model
+- models - A model describes a trained classifier; you'll have one row for each trained file that gets saved.
+- model_groups - A model groups refers to all models that share parameters like classifier type, hyperparameters, etc, but *have different training windows*. Look at these to see how classifiers perform over different training windows.
+- feature_importances - The sklearn feature importances results for each trained model
 - predictions - Prediction probabilities for entities generated against trained models
 - evaluations - Metric scores of trained models over given testing windows
 
+Here's an example query, which returns the top 10 model groups by precision at the top 100 entities:
+```
+select
+	model_groups.model_group_id,
+	model_groups.model_type,
+	model_groups.model_parameters,
+	max(evaluations.value) as max_precision
+from model_groups
+	join models using (model_group_id)
+	join evaluations using (model_id)
+where
+	metric = 'precision@'
+	and parameter = '100_abs'
+group by 1,2,3
+order by 4 desc
+limit 10
+```
 
-## Advanced Use
-
-The current method of changing behavior beyond what can be controlled in the experiment config file is to use the inner components (e.g. FeatureGenerator, ModelTrainer, etc). Each component is instantiated using a certain section of the same configuration that is passed to a pipeline. Support will be added in the future passing in subclassed components like an alternate label generator, and usage in various workflow managers. It can also be useful to copy a pipeline file into your project and tweak to your liking. If you do this to implement a new feature, please submit a [feature request](https://github.com/dssg/triage/blob/60ecb0cc3ab7b1c0aa99917c624f794d20fc9f15/CONTRIBUTING.rst) so others can use it!
-
-## Components
-
-- *Time Choppers* (provided by [Timechop](https://github.com/dssg/timechop)): split user-friendly time configuration into full temporal configuration for matrices.
-- *Label Generators*: define a labels table based on events. For instance, BinaryLabelGenerator defines binary labels based on an events table specified in configuration.
-- *Feature Generators*: generate feature tables based on source tables and configuration. Uses [collate](https://github.com/dssg/collate) to generate aggregate features.
-- *Feature Dictionary Creators*: based on a list of feature tables, store all feature names into a serializable dictionary based on feature table.
-- *Feature Group Creators and Feature Group Mixers*: define groups of feature tables based on configurable criteria (such as source table), and create many subsets of the feature dictionary to test hypotheses (ie, does leaving out certain features affect results?)
-- *Architect* (provided by [Timechop](https://github.com/dssg/timechop)): combine computed features and labels into design matrices. Uses [metta-data](https://github.com/dssg/metta-data) for storing matrices with useful metadata, using the hash of the matrix metadata to avoid an explosion of storage space.
-- *Model Trainers*: train a configured experiment grid on pre-made design matrices, and store each model's metadata and feature importances in a database.
-- *Predictors*: given a trained model and another matrix (ie, a test matrix), generate prediction probabilities and store them in a database.
-- *Model Scorers*: given a set of model prediction probabilities, generate metrics (for instance, precision and recall at various thresholds) and store them in a database.
+The resulting schema is also readable by [Tyra](https://github.com/tyra), our model evaluation webapp.
 
 
-## Pipelines
+### Restarting an Experiment
 
-- *SerialPipeline*: a single-threaded pipeline. Good for simple use on small datasets, or for understanding the general flow of data through a pipeline.
-- *LocalParallelPipeline*: A pipeline that makes use of the multiprocessing library to parallelize various time-consuming steps. Takes an n_processes keyword argument to control how many workers to use.
+If an experiment fails for any reason, you can restart it. Each matrix and each model file is saved with a filename matching a hash of its unique attributes, so when the experiment is rerun, it will by default reuse the matrix or model instead of rebuilding it. If you would like to change this behavior and replace existing versions of matrices and models, set `replace=True` in the Experiment constructor.
+
+
+### Inspecting an Experiment before running
+
+Before you run an experiment, you can inspect properties of the Experiment object to ensure that it is configured in the way you want. Some examples:
+
+- `experiment.all_as_of_times` for debugging temporal config. This will show all dates that features and labels will be calculated at.
+- `experiment.feature_dicts` will output a list of feature dictionaries, representing the feature tables and columns configured in this experiment
+- `experiment.matrix_build_tasks` will output a list representing each matrix that will be built.
+
+
+### Experiment Classes
+
+- *SingleThreadedExperiment*: An experiment that performs all tasks serially in a single thread. Good for simple use on small datasets, or for understanding the general flow of data through a pipeline.
+- *MultiCoreExperiment*: An experiment that makes use of the multiprocessing library to parallelize various time-consuming steps. Takes an `n_processes` keyword argument to control how many workers to use.
+
+
+## Background
+
+Triage is developed at the University of Chicago's [Center For Data Science and Public Policy](http://dsapp.uchicago.edu). We created it in response to commonly occuring challenges we've encountered and patterns we've developed while working on projects for our partners.
+
+## Major Components Used by Triage
+
+Triage makes use of many core data science components developed at DSaPP. These components can be useful in their own right, and are worth checking out if 
+
+- [Architect](https://github.com/dssg/architect): Plan, design and build train and test matrices. Includes feature and label generation.
+- [Collate](https://github.com/dssg/collate): Aggregation SQL Query Builder. This is used by the Architect to build features.
+- [Timechop](https://github.com/dssg/timechop): Generate temporal cross-validation time windows for matrix creation
+- [Metta-Data](https://github.com/dssg/metta-data): Train and test matrix storage
+- [Catwalk](https://github.com/dssg/catwalk): Training, testing, and evaluating machine learning classifier models
+- [Results Schema](https://github.com/dssg/results-schema): Generate a database schema suitable for storing the results of modeling runs
 
 
 ## Design Goals
 
 There are two overarching design goals for Triage:
 
-- All configuration necessary to run the full pipeline from the external interface (ie, Pipeline subclasses) from beginning to end must be serializable. Most of this is common in data science pipelines, but it also means that feature definition must not live in code.
-- All core functionality must be usable outside of a specific pipeline context or workflow manager. There are many good workflow managers, everybody has their favorite, and core functionality should not be designed to work with specific execution expectations.
+- All configuration necessary to run the full experiment from the external interface (ie, Experiment subclasses) from beginning to end must be easily serializable and machine-constructable, to allow the eventual development of tools for users to design experiments. 
+
+- All core functionality must be usable outside of a specific pipeline context or workflow manager. There are many good workflow managers; everybody has their favorite, and core functionality should not be designed to work with specific execution expectations.
 
 
 ## Future Plans
 
 - Generation and Management of lists (ie for inspections) by various criteria
 - Integration of components with various workflow managers, like [Drain](https://github.com/dssg/drain) and [Luigi](https://github.com/spotify/luigi).
-- Comprehensive leakage testing of a pipeline's experiment run
+- Comprehensive leakage testing of an experiment's modeling run
 - Feature Generation Wizard

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -109,7 +109,7 @@ feature_group_strategies: ['all']
 # 1. a dense state table that defines when entities were in specific states
 #   should have columns entity_id/state/start/end
 # 2. a list of state filtering SQL clauses to iterate through. Assuming the
-#   states are boolean columns (the pipeline will convert the one you pass in
+#   states are boolean columns (the experiment will convert the one you pass in
 #   to this format), write a SQL expression for each state
 #   configuration you want, ie '(permitted OR suspended) AND licensed'
 state_config:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://github.com/dssg/triage',
     packages=[
         'triage',
-        'triage.pipelines',
+        'triage.experiments',
     ],
     package_dir={'triage':
                  'triage'},

--- a/triage/experiments/__init__.py
+++ b/triage/experiments/__init__.py
@@ -1,0 +1,3 @@
+from .base import ExperimentBase
+from .multicore import MultiCoreExperiment
+from .singlethreaded import SingleThreadedExperiment

--- a/triage/experiments/base.py
+++ b/triage/experiments/base.py
@@ -23,7 +23,7 @@ def dt_from_str(dt_str):
     return datetime.strptime(dt_str, '%Y-%m-%d')
 
 
-class PipelineBase(object):
+class ExperimentBase(object):
     __metaclass__ = ABCMeta
 
     def __init__(
@@ -165,7 +165,7 @@ class PipelineBase(object):
 
     @property
     def split_definitions(self):
-        """Temporal splits based on the pipeline's configuration
+        """Temporal splits based on the experiment's configuration
 
         Returns (dict) temporal splits
 
@@ -188,7 +188,7 @@ class PipelineBase(object):
 
     @property
     def all_as_of_times(self):
-        """All 'as of times' in pipeline config
+        """All 'as of times' in experiment config
 
         Used for label and feature generation.
 
@@ -210,7 +210,7 @@ class PipelineBase(object):
 
     @property
     def feature_table_tasks(self):
-        """All feature table query tasks specified by this Pipeline
+        """All feature table query tasks specified by this Experiment
 
         Returns: (dict) keys are group table names, values are themselves dicts,
             each with keys for different stages of table creation (prepare, inserts, finalize)
@@ -230,7 +230,7 @@ class PipelineBase(object):
     @property
     def feature_dicts(self):
         """Feature dictionaries, representing the feature tables and columns
-            configured in this pipeline after computing feature groups.
+            configured in this experiment after computing feature groups.
 
         Returns: (list) of dicts, keys being feature table names and values
             being lists of feature names
@@ -284,7 +284,7 @@ class PipelineBase(object):
         ))
 
     def generate_labels(self):
-        """Generate labels based on pipeline configuration
+        """Generate labels based on experiment configuration
 
         Results are stored in the database, not returned
         """

--- a/triage/experiments/multicore.py
+++ b/triage/experiments/multicore.py
@@ -1,6 +1,6 @@
 from catwalk.storage import MettaCSVMatrixStore, InMemoryModelStorageEngine
 from sqlalchemy import create_engine
-from triage.pipelines import PipelineBase
+from triage.experiments import ExperimentBase
 import logging
 from multiprocessing import Pool
 from functools import partial
@@ -9,14 +9,14 @@ import os
 import traceback
 
 
-class LocalParallelPipeline(PipelineBase):
+class MultiCoreExperiment(ExperimentBase):
     def __init__(self, n_processes=1, n_db_processes=1, *args, **kwargs):
-        super(LocalParallelPipeline, self).__init__(*args, **kwargs)
+        super(MultiCoreExperiment, self).__init__(*args, **kwargs)
         self.n_processes = n_processes
         self.n_db_processes = n_db_processes
         if kwargs['model_storage_class'] == InMemoryModelStorageEngine:
             raise ValueError('''
-                InMemoryModelStorageEngine not compatible with LocalParallelPipeline
+                InMemoryModelStorageEngine not compatible with MultiCoreExperiment
             ''')
 
     def catwalk(self):

--- a/triage/experiments/singlethreaded.py
+++ b/triage/experiments/singlethreaded.py
@@ -3,10 +3,10 @@ import os
 
 from catwalk.storage import MettaCSVMatrixStore
 
-from triage.pipelines import PipelineBase
+from triage.experiments import ExperimentBase
 
 
-class SerialPipeline(PipelineBase):
+class SingleThreadedExperiment(ExperimentBase):
     def build_matrices(self):
         logging.info('Creating sparse states')
         self.generate_sparse_states()

--- a/triage/pipelines/__init__.py
+++ b/triage/pipelines/__init__.py
@@ -1,3 +1,0 @@
-from .base import PipelineBase
-from .local_parallel import LocalParallelPipeline
-from .serial import SerialPipeline


### PR DESCRIPTION
Triage's scope has narrowed, in a way, by ceasing to implement core components and only becoming the interface. In another way, it's broadened, to where different interfaces will be implemented here. Because of this, the name 'Pipeline' currently used is far too broad: it refers to an Experiment, which is just one phase of a project.

The subclasses prefixes have also been renamed, partly because of this change but also they just were not as descriptive as they could be.

- Renamings: Pipeline->Experiment, SerialPipeline->SingleThreadedExperiment, LocalParallelPipeline->MultiCoreExperiment
- Rewrite README to reflect Triage's new role