### PR TITLE
Update license

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Risk modeling and prediction
 [![Build Status](https://travis-ci.org/dssg/triage.svg?branch=master)](https://travis-ci.org/dssg/triage)
 [![codecov](https://codecov.io/gh/dssg/triage/branch/master/graph/badge.svg)](https://codecov.io/gh/dssg/triage)
 [![codeclimate](https://codeclimate.com/github/dssg/triage.png)](https://codeclimate.com/github/dssg/triage)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 
 ## Basic Usage

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ from setuptools import setup
 with open('README.md') as readme_file:
     readme = readme_file.read()
 
+with open('LICENSE') as license_file:
+    license = license_file.read()
+
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
@@ -32,7 +35,7 @@ setup(
                  'triage'},
     include_package_data=True,
     install_requires=requirements,
-    license="MIT license",
+    license=license,
     zip_safe=False,
     keywords='triage',
     classifiers=[


### PR DESCRIPTION
The license was messed up: in the actual license file we were using the correct UChicago license, but the README had a MIT badge and setup.py referred to MIT.

- Remove MIT license badge
- Remove MIT license from setup.py