### PR TITLE
Version triage config files [Resolves #191]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -1,4 +1,12 @@
 ---
+# CONFIG_VERSION
+# The experiment configuration changes from time to time, and we upgrade the
+# triage.experiments.CONFIG_VERSION variable whenever drastic changes that break
+# old configuration files are released. Be sure to assign the config version
+# that matches the triage.experiments.CONFIG_VERSION in the triage release 
+# you are developing against!
+config_version: 'v1'
+
 # EXPERIMENT METADATA
 # model_comment (optional) will end up in the model_comment column of the
 # models table for each model created in this experiment

--- a/triage/experiments/__init__.py
+++ b/triage/experiments/__init__.py
@@ -1,3 +1,5 @@
+CONFIG_VERSION = 'v1'
+
 from .base import ExperimentBase
 from .multicore import MultiCoreExperiment
 from .singlethreaded import SingleThreadedExperiment


### PR DESCRIPTION
- Add experiments.CONFIG_VERSION to track the config version in the current code
- Add check at ExperimentBase construction time that ensures the config version matches the current one.
- Add config_version section to example_experiment_config.yaml
- Refactor experiment tests to share basic sample config