### PR TITLE
Pass User Metadata to Planner [Resolves #192]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ after_success: codecov
 before_install:
 - sudo apt-get update
 - sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
-before_script:
-- psql -U postgres -c "create extension postgis"
 deploy:
   true:
     repo: dssg/triage

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -126,6 +126,13 @@ state_config:
         - 'state_one AND state_two'
         - '(state_one OR state_two) AND state_three'
 
+# USER METADATA
+# These are arbitrary keys/values that you can have Triage apply to the
+# metadata for each matrix in the experiment. Any keys you include here can
+# be used in the 'model_group_keys' below.
+user_metadata:
+    label_definition: 'severe_violations'
+
 # MODEL GROUPING
 # Model groups are aimed at defining models which are equivalent across time splits.
 # By default, the classifier module name, hyperparameters, and feature names are used.

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -178,12 +178,13 @@ def sample_config():
         'events_table': 'events',
         'entity_column_name': 'entity_id',
         'model_comment': 'test2-final-final',
-        'model_group_keys': ['label_name', 'label_type'],
+        'model_group_keys': ['label_name', 'label_type', 'custom_key'],
         'feature_aggregations': feature_config,
         'state_config': state_config,
         'temporal_config': temporal_config,
         'grid_config': grid_config,
         'scoring': scoring_config,
+        'user_metadata': { 'custom_key': 'custom_value' }
     }
 
 

--- a/triage/experiments/base.py
+++ b/triage/experiments/base.py
@@ -144,7 +144,7 @@ class ExperimentBase(object):
             },
             matrix_directory=self.matrices_directory,
             states=self.config.get('state_config', {}).get('state_filters', []),
-            user_metadata={},
+            user_metadata=self.config.get('user_metadata', {}),
             replace=self.replace
         )
 


### PR DESCRIPTION
- Pass configured user_metadata key to Planner if it exists
- Add user_metadata to example_experiment_config.yaml