### PR TITLE
Support collate groups [Resolves #188]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -102,10 +102,10 @@ feature_aggregations:
 # define how to group features and generate combinations
 # feature_group_definition allows you to create groups/subset of your features
 # by different criteria.
-# for instance, 'tables' allows you to send a list of collate feature tables
+# for instance, 'tables' allows you to send a list of collate feature tables (collate builds these by appending 'aggregation' to the prefix)
 # 'prefix' allows you to specify a list of feature name prefixes
 feature_group_definition:
-    tables: ['prefix_entity_id']
+    tables: ['prefix_aggregation']
 
 # strategies for generating combinations of groups
 # available: all, leave-one-out, leave-one-in

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ retrying
 results-schema==1.1.0
 timechop==0.1.3
 collate==0.2.1
-matrix-architect==0.2.1
+matrix-architect==0.3
 model-catwalk==0.2.1
 metta-data==0.3.0


### PR DESCRIPTION
Here, support for collate's multiple-groups functionality is added by using the updated interface of architect.FeatureGenerator. It requires a list of collate aggregations. So here we add that list to the necessary calls and expose the collate_aggregations list as a property of the Experiment.

- Add Experiment#collate_aggregations
- Modify Experiment#feature_table_tasks and #feature_dicts to pass the collate aggregations
- Add multiple-groups example to example config and tests