### PR TITLE
Clean up States Table in finally block [Resolves #197]

### DIFF
--- a/triage/experiments/base.py
+++ b/triage/experiments/base.py
@@ -392,5 +392,9 @@ class ExperimentBase(object):
         pass
 
     def run(self):
-        self.build_matrices()
+        try:
+            self.build_matrices()
+        finally:
+            logging.info('Matrix build done or errored, cleaning up state table')
+            self.state_table_generator.clean_up()
         self.catwalk()

--- a/triage/experiments/multicore.py
+++ b/triage/experiments/multicore.py
@@ -188,7 +188,6 @@ class MultiCoreExperiment(ExperimentBase):
             self.matrix_build_tasks.values(),
             self.n_processes
         )
-        self.state_table_generator.clean_up()
 
     def parallelize(
         self,

--- a/triage/experiments/singlethreaded.py
+++ b/triage/experiments/singlethreaded.py
@@ -16,7 +16,6 @@ class SingleThreadedExperiment(ExperimentBase):
         self.feature_generator.process_table_tasks(self.feature_table_tasks)
         logging.info('Building all matrices')
         self.planner.build_all_matrices(self.matrix_build_tasks)
-        self.state_table_generator.clean_up()
 
     def catwalk(self):
         for split_num, split in enumerate(self.full_matrix_definitions):


### PR DESCRIPTION
- Move state_table_generator.clean_up calls to finally block in base class

Note: We can't accomplish this using a temporary table because the states table has to live far longer than one database session.