### PR TITLE
Use accurate model group keys in example config [Resolves #225]

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -153,13 +153,13 @@ user_metadata:
 # model_group_keys defines a list of *additional* matrix metadata keys that
 # should be considered when creating a model group. For example, if the models are
 # built on matrices with different history lengths (train durations), different
-# in the next month, next year, or next two years), the frequency of rows for each
-# labeling windows (e.g., inspection violations entity (train example frequency), or
+# labeling windows (e.g., inspection violations in the next month, next year, or
+# next two years) the frequency of rows for each entity(train example frequency), or
 # the definition of a positive label.
 model_group_keys:
     - 'train_duration'
-    - 'train_label_window'
-    - 'train_example_frequency'
+    - 'label_window'
+    - 'example_frequency'
     - 'label_definition'
 
 # GRID CONFIGURATION


### PR DESCRIPTION
If merged, this commit will:

- update the key names in model group keys to use the actual names in matrix metadata
- unbutcher the sentence explaining the keys