### PR TITLE
Imputation (Closes #196)

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -5,7 +5,7 @@
 # old configuration files are released. Be sure to assign the config version
 # that matches the triage.experiments.CONFIG_VERSION in the triage release 
 # you are developing against!
-config_version: 'v1'
+config_version: 'v2'
 
 # EXPERIMENT METADATA
 # model_comment (optional) will end up in the model_comment column of the
@@ -48,6 +48,27 @@ events_table: 'events'
 # arguments needed to create it. Generally, each of these entries controls
 # the features from one source table, though in the case of multiple groups
 # may result in multiple output tables
+#
+# Rules specifying how to handle imputation of null values must be explicitly
+# defined in your config file. These can be specified in two places: either
+# within each feature or overall for each type of feature (aggregates,
+# categoricals, array_categoricals). In either case, a rule must be given for 
+# each aggregation function (e.g., sum, max, avg, etc) used, or a catch-all
+# can be specified with `all`. Aggregation function-specific rules will take
+# precedence over the `all` rule and feature-specific rules will take 
+# precedence over the higher-level rules. Several examples are provided below.
+#
+# Available Imputation Rules:
+#   * mean: The average value of the feature (for SpacetimeAggregation the 
+#           mean is taken within-date).
+#   * constant: Fill with a constant value from a required `value` parameter.
+#   * zero: Fill with zero.
+#   * null_category: Only available for categorical features. Just flag null 
+#                    values with the null category column. 
+#   * binary_mode: Only available for aggregate column types. Takes the modal 
+#                  value for a binary feature.
+#   * error: Raise an exception if any null values are encountered for this 
+#            feature.
 feature_aggregations:
     -
         # prefix given to the resultant tables
@@ -61,6 +82,24 @@ feature_aggregations:
         # from the date the event happened.
         knowledge_date_column: 'open_date'
 
+        # top-level imputation rules that will apply to all aggregates functions
+        # can also specify categoricals_imputation or array_categoricals_imputation
+        # 
+        # You must specified at least one of the top-level or feature-level imputation
+        # to cover ever feature being defined.
+        aggregates_imputation:
+            # The `all` rule will apply to all aggregation functions, unless over-
+            # ridden by a more specific one
+            all:
+                # every imputation rule must have a `type` parameter, while some
+                # (like 'constant') have other required parameters (`value` here)
+                type: 'constant'
+                value: 0
+            # specifying `max` here will take precedence over the `all` rule for
+            # aggregations using a MAX() function
+            max:
+                type: 'mean'
+
         # aggregates and categoricals define the actual features created. So
         # at least one is required
         #
@@ -69,8 +108,25 @@ feature_aggregations:
         aggregates:
             -
                 quantity: 'homeless::INT'
+                # Imputation rules specified at the level of specific features
+                # will take precedence over the higer-level rules specified
+                # above. Note that the 'count' and 'sum' metrics will be
+                # imputed differently here.
+                imputation:
+                    count:
+                        type: 'mean'
+                    sum:
+                        type: 'constant'
+                        value: 137
                 metrics:
                     - 'count'
+                    - 'sum'
+            - 
+                # since we're specifying `aggregates_imputation` above,
+                # a feature-specific imputation rule can be omitted
+                quantity: 'some_flag'
+                metrics:
+                    - 'max'
                     - 'sum'
         # Categorical features. The column given can be of any type, but the
         # choices must comparable to that type for equality within SQL
@@ -78,6 +134,14 @@ feature_aggregations:
         categoricals:
             -
                 column: 'color'
+                # note that we haven't specified a top level `categoricals_imputation`
+                # set of rules, so we have to include feature-specific imputation
+                # rules for both of our categoricals here.
+                imputation:
+                    sum:
+                        type: 'null_category'
+                    max:
+                        type: 'mean'
                 choices:
                     - 'red'
                     - 'blue'
@@ -86,6 +150,12 @@ feature_aggregations:
                     - 'sum'
             -
                 column: 'shape'
+                # as with the top-level imputation rules, `all` can be used
+                # for the feature-level rules to specify the same type of
+                # imputation for all aggregation functions
+                imputation:
+                    all:
+                        type: 'zero'
                 choice_query: 'select distinct shape from cool_stuff'
                 metrics:
                     - 'sum'

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ sqlalchemy-postgres-copy
 retrying
 results-schema>=1.2
 timechop==0.1.3
-collate==0.2.1
-matrix-architect==0.3
+matrix-architect==0.4
 model-catwalk>=0.3
 metta-data==0.3.0

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -191,6 +191,7 @@ def sample_config():
         'prefix': 'entity_features',
         'from_obj': 'cat_complaints',
         'knowledge_date_column': 'as_of_date',
+        'aggregates_imputation': {'all': {'type': 'constant', 'value': 0}},
         'aggregates': [{
             'quantity': 'cat_sightings',
             'metrics': ['count', 'avg'],
@@ -201,6 +202,7 @@ def sample_config():
         'prefix': 'zip_code_features',
         'from_obj': 'entity_zip_codes join zip_code_events using (zip_code)',
         'knowledge_date_column': 'as_of_date',
+        'aggregates_imputation': {'all': {'type': 'constant', 'value': 0}},
         'aggregates': [{
             'quantity': 'num_events',
             'metrics': ['max', 'min'],
@@ -215,7 +217,7 @@ def sample_config():
     }
 
     return {
-        'config_version': 'v1',
+        'config_version': CONFIG_VERSION,
         'events_table': 'events',
         'entity_column_name': 'entity_id',
         'model_comment': 'test2-final-final',

--- a/triage/experiments/__init__.py
+++ b/triage/experiments/__init__.py
@@ -1,4 +1,4 @@
-CONFIG_VERSION = 'v1'
+CONFIG_VERSION = 'v2'
 
 from .base import ExperimentBase
 from .multicore import MultiCoreExperiment

--- a/triage/experiments/multicore.py
+++ b/triage/experiments/multicore.py
@@ -138,7 +138,7 @@ class MultiCoreExperiment(ExperimentBase):
             'Creating feature tables with %s processes',
             self.n_db_processes
         )
-        for table_name, tasks in self.feature_table_tasks.items():
+        for table_name, tasks in self.feature_aggregation_table_tasks.items():
             logging.info('Processing features for %s', table_name)
             self.feature_generator.run_commands(tasks.get('prepare', []))
             partial_insert = partial(
@@ -154,6 +154,9 @@ class MultiCoreExperiment(ExperimentBase):
             )
             self.feature_generator.run_commands(tasks.get('finalize', []))
             logging.info('%s completed', table_name)
+
+        logging.info('Creating feature imputation tables')
+        self.feature_generator.process_table_tasks(self.feature_imputation_table_tasks)
 
         partial_build_matrix = partial(
             build_matrix,

--- a/triage/experiments/singlethreaded.py
+++ b/triage/experiments/singlethreaded.py
@@ -9,8 +9,10 @@ class SingleThreadedExperiment(ExperimentBase):
         self.generate_sparse_states()
         logging.info('Creating labels')
         self.generate_labels()
-        logging.info('Creating feature tables')
-        self.feature_generator.process_table_tasks(self.feature_table_tasks)
+        logging.info('Creating feature aggregation tables')
+        self.feature_generator.process_table_tasks(self.feature_aggregation_table_tasks)
+        logging.info('Creating feature imputation tables')
+        self.feature_generator.process_table_tasks(self.feature_imputation_table_tasks)
         logging.info('Building all matrices')
         self.planner.build_all_matrices(self.matrix_build_tasks)
 


### PR DESCRIPTION
Support imputation rules in collate/architect to allow users to specify how to handle missing data. See additional details in the related collate and architect PRs.