### PR TITLE
Support zero filling with no imputation flag

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -63,6 +63,11 @@ events_table: 'events'
 #           mean is taken within-date).
 #   * constant: Fill with a constant value from a required `value` parameter.
 #   * zero: Fill with zero.
+#   * zero_noflag: Fill with zero without generating an "imputed" flag. This 
+#                  option should be used only for cases where null values are 
+#                  explicitly known to be zero such as absence of an entity 
+#                  from an events table indicating that no such event has 
+#                  occurred.
 #   * null_category: Only available for categorical features. Just flag null 
 #                    values with the null category column. 
 #   * binary_mode: Only available for aggregate column types. Takes the modal 

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -177,10 +177,10 @@ feature_aggregations:
 # define how to group features and generate combinations
 # feature_group_definition allows you to create groups/subset of your features
 # by different criteria.
-# for instance, 'tables' allows you to send a list of collate feature tables (collate builds these by appending 'aggregation' to the prefix)
+# for instance, 'tables' allows you to send a list of collate feature tables (collate builds these by appending 'aggregation_imputed' to the prefix)
 # 'prefix' allows you to specify a list of feature name prefixes
 feature_group_definition:
-    tables: ['prefix_aggregation']
+    tables: ['prefix_aggregation_imputed']
 
 # strategies for generating combinations of groups
 # available: all, leave-one-out, leave-one-in


### PR DESCRIPTION
Minor documentation updates for the additional rule to allow zero filling with no imputation flag in cases (such as event counts) where NULLs are known to be 0 exactly.