### PR TITLE
Update ModelTrainer call for categorical-using classifiers

### DIFF
--- a/triage/experiments/base.py
+++ b/triage/experiments/base.py
@@ -159,6 +159,7 @@ class ExperimentBase(object):
             experiment_hash=self.experiment_hash,
             model_storage_engine=self.model_storage_engine,
             model_group_keys=self.config['model_group_keys'],
+            feature_config=self.config['feature_aggregations'],
             replace=self.replace
         )
 


### PR DESCRIPTION
Simple change to pass feature config to ModelTrainer to conform with new call signature for making use of classifiers that respect categoricals in [this catwalk pr](https://github.com/dssg/catwalk/pull/34).