### PR TITLE
support new timechop names (closes #187)

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -5,7 +5,7 @@
 # old configuration files are released. Be sure to assign the config version
 # that matches the triage.experiments.CONFIG_VERSION in the triage release 
 # you are developing against!
-config_version: 'v2'
+config_version: 'v3'
 
 # EXPERIMENT METADATA
 # model_comment (optional) will end up in the model_comment column of the
@@ -16,16 +16,17 @@ model_comment: 'test'
 # The time window to look at, and how to divide the window into
 # train/test splits
 temporal_config:
-    beginning_of_time: '1995-01-01' # earliest date included in features
-    modeling_start_time: '2012-01-01' # earliest date in any model
-    modeling_end_time: '2015-01-01' # all dates in any model are < this date
-    update_window: '6month' # how frequently to retrain models
-    train_example_frequency: '1day' # time between rows for same entity in train matrix
-    test_example_frequency: '3month' # time between rows for same entity in test matrix
-    train_durations: ['6month', '3month'] # length of time included in a train matrix
-    test_durations: ['1month', '2month'] # length of time included in a test matrix
-    train_label_windows: ['1month'] # time period across which outcomes are labeled in train matrices
-    test_label_windows: ['7day'] # time period across which outcomes are labeled in test matrices
+    feature_start_time: '1995-01-01' # earliest date included in features
+    feature_end_time: '2015-01-01'   # latest date included in features
+    label_start_time: '2012-01-01' # earliest date for which labels are avialable
+    label_end_time: '2015-01-01' # day AFTER last label date (all dates in any model are < this date)
+    model_update_frequency: '6month' # how frequently to retrain models
+    training_as_of_date_frequencies: '1day' # time between as of dates for same entity in train matrix
+    test_as_of_date_frequencies: '3month' # time between as of dates for same entity in test matrix
+    max_training_histories: ['6month', '3month'] # length of time included in a train matrix
+    test_durations: ['0day', '1month', '2month'] # length of time included in a test matrix (0 days will give a single prediction immediately after training end)
+    training_label_timespans: ['1month'] # time period across which outcomes are labeled in train matrices
+    test_label_timespans: ['7day'] # time period across which outcomes are labeled in test matrices
 
 # LABEL GENERATION
 # Information needed to generate labels

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ inflection
 numpy>=1.12
 sqlalchemy-postgres-copy
 retrying
-results-schema>=1.2
-timechop==0.1.5
-matrix-architect==0.4
-model-catwalk>=0.3
-metta-data==0.3.0
+results-schema~=2.0
+timechop~=1.0
+matrix-architect~=1.0
+model-catwalk~=1.0
+metta-data~=1.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -82,11 +82,11 @@ def sample_metta_csv_diff_order(directory):
     ])
     train_matrix = pandas.DataFrame.from_dict(train_dict)
     train_metadata = {
-        'beginning_of_time': datetime.date(2014, 1, 1),
+        'feature_start_time': datetime.date(2014, 1, 1),
         'end_time': datetime.date(2015, 1, 1),
         'matrix_id': 'train_matrix',
         'label_name': 'label',
-        'label_window': '3month',
+        'label_timespan': '3month',
         'indices': ['entity_id'],
     }
 
@@ -99,11 +99,11 @@ def sample_metta_csv_diff_order(directory):
 
     test_matrix = pandas.DataFrame.from_dict(test_dict)
     test_metadata = {
-        'beginning_of_time': datetime.date(2015, 1, 1),
+        'feature_start_time': datetime.date(2015, 1, 1),
         'end_time': datetime.date(2016, 1, 1),
         'matrix_id': 'test_matrix',
         'label_name': 'label',
-        'label_window': '3month',
+        'label_timespan': '3month',
         'indices': ['entity_id'],
     }
 

--- a/triage/experiments/__init__.py
+++ b/triage/experiments/__init__.py
@@ -1,4 +1,4 @@
-CONFIG_VERSION = 'v2'
+CONFIG_VERSION = 'v3'
 
 from .base import ExperimentBase
 from .multicore import MultiCoreExperiment

--- a/triage/experiments/multicore.py
+++ b/triage/experiments/multicore.py
@@ -273,9 +273,10 @@ def test_and_evaluate(
                 predictions_proba=predictions_proba,
                 labels=test_store.labels(),
                 model_id=model_id,
-                evaluation_start_time=split_def['matrix_start_time'],
-                evaluation_end_time=split_def['matrix_end_time'],
-                example_frequency=split_def['example_frequency']
+                # for evaluation range, using first to last as of time:
+                evaluation_start_time=split_def['first_as_of_time'],
+                evaluation_end_time=split_def['last_as_of_time'],
+                as_of_date_frequency=split_def['test_as_of_date_frequency']
             )
         return True
     except Exception:

--- a/triage/experiments/singlethreaded.py
+++ b/triage/experiments/singlethreaded.py
@@ -78,7 +78,8 @@ class SingleThreadedExperiment(ExperimentBase):
                         predictions_proba=predictions_proba,
                         labels=test_store.labels(),
                         model_id=model_id,
-                        evaluation_start_time=split_def['matrix_start_time'],
-                        evaluation_end_time=split_def['matrix_end_time'],
-                        example_frequency=split_def['example_frequency']
+                        # for evaluation range, using first to last as of time:
+                        evaluation_start_time=split_def['first_as_of_time'],
+                        evaluation_end_time=split_def['last_as_of_time'],
+                        as_of_date_frequency=split_def['test_as_of_date_frequency']
                     )


### PR DESCRIPTION
Changes to support the new timechop names in [timechop pr 79](https://github.com/dssg/timechop/pull/79/)

NOTES: 
* several test failures but look like they're coming from `results-schema` not yet being updated
* still need to bump the pegged dependency versions once they're updated.

See also:
* https://github.com/dssg/metta-data/pull/49
* https://github.com/dssg/architect/pull/57
* https://github.com/dssg/catwalk/pull/36
* https://github.com/dssg/results-schema/issues/11