### PR TITLE
Cohort definition

### DIFF
--- a/docs/sources/experiments/algorithm.md
+++ b/docs/sources/experiments/algorithm.md
@@ -32,11 +32,13 @@ The Experiment keeps track of what states any given entities are in to, based on
 
 In code, it does this by computing what it calls the 'sparse' state table for an experiment. This is a table with a boolean flag entry for every entity, as_of_time, and state. The structure of this table allows for state filtering based on SQL conditions given by the user.
 
-Based on configuration, it can get created through one of two code paths:
+Based on configuration, it can get created through one of three code paths:
 
 1. If the user passes what we call a 'dense states' table, with the following structure: entity id/state/start/end, and a list of state filters. This 'dense states' table basically holds time ranges that entities were in specific states. When converting this to a sparse table, we take each as_of_time present in the Experiment, and for each known state (that is, the distinct values found in the 'dense states' table), see if there is any entry in the dense states table with this state whose range overlaps this as_of_time. If so, the entity is considered to be in that state as of that date.
 
-2. If the user doesn't pass a dense states table, we use the events table to create a default one. It will simply use all entities present in the events table, and mark them as 'active' for every as_of_time in the experiment.
+2. If the user passes what we call an 'entities' table, containing an entity_id, it will simply use all distinct entities present in said table, and mark them as 'active' for every as_of_time in the experiment. Any other columns are ignored.
+
+3. If the user passes a query, parameterized with an as of date, we will populate the table by running it for each as_of_date.
 
 This table is created and exists until matrices are built, at which point it is considered unnecessary and then dropped.
 

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -183,18 +183,23 @@ feature_group_definition:
 # available: all, leave-one-out, leave-one-in
 feature_group_strategies: ['all']
 
-# STATE MANAGEMENT (optional)
-# If you want to only include rows in your matrices in a specific state,
-# provide:
-# 1. a dense state table that defines when entities were in specific states
-#   should have columns entity_id/state/start/end
-# 2. a list of state filtering SQL clauses to iterate through. Assuming the
-#   states are boolean columns (the experiment will convert the one you pass in
-#   to this format), write a SQL expression for each state
-#   configuration you want, ie '(permitted OR suspended) AND licensed'
-state_config:
-    table_name: 'states'
-    state_filters:
+# COHORT CONFIG
+# To define what entities make it into different matrices, there are two options.
+#
+# 1. Pass an entities table. All distinct entities present in this table (the 'entity_id' column) will be included in all matrices. Other columns will be ignored
+#
+# 2. Pass a dense states table, and information about which state filters to use in this experiment
+#
+#   a. a dense state table that defines when entities were in specific states
+#       should have columns entity_id/state/start/end
+#   b. a list of state filtering SQL clauses to iterate through. Assuming the
+#       states are boolean columns (the experiment will convert the one you pass in
+#       to this format), write a SQL expression for each state
+#       configuration you want, ie '(permitted OR suspended) AND licensed'
+cohort_config:
+    dense_states:
+        table_name: 'states'
+        state_filters:
         - 'state_one AND state_two'
         - '(state_one OR state_two) AND state_three'
 

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -184,11 +184,13 @@ feature_group_definition:
 feature_group_strategies: ['all']
 
 # COHORT CONFIG
-# To define what entities make it into different matrices, there are two options.
+# To define what entities make it into different matrices, there are three options (only choose one).
 #
 # 1. Pass an entities table. All distinct entities present in this table (the 'entity_id' column) will be included in all matrices. Other columns will be ignored
 #
-# 2. Pass a dense states table, and information about which state filters to use in this experiment
+# 2. Pass a query, parameterized with an '{as_of_date}', to select the entity_ids that should be included for a given date. The {as_of_date} will be replaced with each as_of_date that the experiment needs.
+#
+# 3. Pass a dense states table, and information about which state filters to use in this experiment
 #
 #   a. a dense state table that defines when entities were in specific states
 #       should have columns entity_id/state/start/end
@@ -197,11 +199,13 @@ feature_group_strategies: ['all']
 #       to this format), write a SQL expression for each state
 #       configuration you want, ie '(permitted OR suspended) AND licensed'
 cohort_config:
-    dense_states:
-        table_name: 'states'
-        state_filters:
-        - 'state_one AND state_two'
-        - '(state_one OR state_two) AND state_three'
+#   entities_table: 'events'
+#   dense_states:
+#        table_name: 'states'
+#        state_filters:
+#        - 'state_one AND state_two'
+#        - '(state_one OR state_two) AND state_three'
+    query: "select entity_id from events where outcome_date < '{as_of_date}'"
 
 # USER METADATA
 # These are arbitrary keys/values that you can have Triage apply to the

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -13,7 +13,7 @@ from triage.component.architect.features import (
     FeatureGroupCreator,
     FeatureGroupMixer,
 )
-from triage.component.architect.state_table_generators import StateTableGenerator
+from triage.component.architect.state_table_generators import StateTableGeneratorFromDense
 from triage.component.architect.label_generators import BinaryLabelGenerator
 from triage.component.architect.planner import Planner
 
@@ -178,7 +178,7 @@ def basic_integration_test(
                 test_durations=['1months'],
             )
 
-            state_table_generator = StateTableGenerator(
+            state_table_generator = StateTableGeneratorFromDense(
                 db_engine=db_engine,
                 experiment_hash='abcd',
                 dense_state_table='states',
@@ -263,12 +263,6 @@ def basic_integration_test(
                 'intervals': ['1y'],
                 'groups': ['entity_id']
             }]
-
-            state_table_generator.validate()
-            label_generator.validate()
-            feature_generator.validate(feature_aggregation_config)
-            feature_group_creator.validate()
-            planner.validate()
 
             # generate sparse state table
             state_table_generator.generate_sparse_table(

--- a/src/tests/architect_tests/test_state_table_generators.py
+++ b/src/tests/architect_tests/test_state_table_generators.py
@@ -4,7 +4,7 @@ import pytest
 import testing.postgresql
 from sqlalchemy.engine import create_engine
 
-from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities
+from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities, StateTableGeneratorFromQuery
 
 from . import utils
 
@@ -173,3 +173,65 @@ def test_sparse_table_generator_from_entities():
         assert results == expected_output
         utils.assert_index(engine, table_generator.sparse_table_name, 'entity_id')
         utils.assert_index(engine, table_generator.sparse_table_name, 'as_of_date')
+
+
+def test_sparse_states_from_query():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 1, 1), True),
+        (3, datetime(2016, 1, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, 'events', input_data)
+        table_generator = StateTableGeneratorFromQuery(
+            query='select entity_id from events where outcome_date < {as_of_date}',
+            db_engine=engine,
+            experiment_hash='exp_hash',
+        )
+        as_of_dates = [
+            datetime(2016, 1, 1),
+            datetime(2016, 2, 1),
+            datetime(2016, 3, 1),
+            datetime(2016, 4, 1),
+            datetime(2016, 5, 1),
+            datetime(2016, 6, 1),
+        ]
+        table_generator.generate_sparse_table(as_of_dates)
+        expected_output = [
+            (1, datetime(2016, 2, 1), True),
+            (1, datetime(2016, 3, 1), True),
+            (1, datetime(2016, 4, 1), True),
+            (1, datetime(2016, 5, 1), True),
+            (1, datetime(2016, 6, 1), True),
+            (2, datetime(2016, 2, 1), True),
+            (2, datetime(2016, 3, 1), True),
+            (2, datetime(2016, 4, 1), True),
+            (2, datetime(2016, 5, 1), True),
+            (2, datetime(2016, 6, 1), True),
+            (3, datetime(2016, 2, 1), True),
+            (3, datetime(2016, 3, 1), True),
+            (3, datetime(2016, 4, 1), True),
+            (3, datetime(2016, 5, 1), True),
+            (3, datetime(2016, 6, 1), True),
+            (5, datetime(2016, 4, 1), True),
+            (5, datetime(2016, 5, 1), True),
+            (5, datetime(2016, 6, 1), True),
+        ]
+        results = [row for row in engine.execute(
+            '''
+                select entity_id, as_of_date, active from {}
+                order by entity_id, as_of_date
+            '''.format(
+                table_generator.sparse_table_name
+            )
+        )]
+        assert results == expected_output
+        utils.assert_index(engine, table_generator.sparse_table_name, 'entity_id')
+        utils.assert_index(engine, table_generator.sparse_table_name, 'as_of_date')
+

--- a/src/tests/architect_tests/test_state_table_generators.py
+++ b/src/tests/architect_tests/test_state_table_generators.py
@@ -4,7 +4,7 @@ import pytest
 import testing.postgresql
 from sqlalchemy.engine import create_engine
 
-from triage.component.architect.state_table_generators import StateTableGenerator
+from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities
 
 from . import utils
 
@@ -21,9 +21,9 @@ def test_sparse_state_table_generator():
         engine = create_engine(postgresql.url())
         utils.create_dense_state_table(engine, 'states', input_data)
 
-        table_generator = StateTableGenerator(
-            engine,
-            'exp_hash',
+        table_generator = StateTableGeneratorFromDense(
+            db_engine=engine,
+            experiment_hash='exp_hash',
             dense_state_table='states'
         )
         as_of_dates = [
@@ -61,9 +61,9 @@ def test_empty_dense_state_table():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         utils.create_dense_state_table(engine, 'states', ())  # no data
-        table_generator = StateTableGenerator(
-            engine,
-            'exp_hash',
+        table_generator = StateTableGeneratorFromDense(
+            db_engine=engine,
+            experiment_hash='exp_hash',
             dense_state_table='states'
         )
 
@@ -88,9 +88,9 @@ def test_empty_sparse_state_table():
             (1, 'injail', datetime(2014, 7, 7), datetime(2014, 7, 15)),
             (1, 'injail', datetime(2016, 3, 7), datetime(2016, 4, 2)),
         ))
-        table_generator = StateTableGenerator(
-            engine,
-            'exp_hash',
+        table_generator = StateTableGeneratorFromDense(
+            db_engine=engine,
+            experiment_hash='exp_hash',
             dense_state_table='states'
         )
 
@@ -108,7 +108,7 @@ def test_empty_sparse_state_table():
         engine.dispose()
 
 
-def test_sparse_table_generator_from_events():
+def test_sparse_table_generator_from_entities():
     input_data = [
         (1, datetime(2016, 1, 1), True),
         (1, datetime(2016, 4, 1), False),
@@ -122,10 +122,10 @@ def test_sparse_table_generator_from_events():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         utils.create_binary_outcome_events(engine, 'events', input_data)
-        table_generator = StateTableGenerator(
-            engine,
-            'exp_hash',
-            events_table='events'
+        table_generator = StateTableGeneratorFromEntities(
+            entities_table='events',
+            db_engine=engine,
+            experiment_hash='exp_hash',
         )
         as_of_dates = [
             datetime(2016, 1, 1),

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -312,9 +312,11 @@ def sample_config():
         'groups': ['entity_id', 'zip_code']
     }]
 
-    state_config = {
-        'table_name': 'states',
-        'state_filters': ['state_one or state_two'],
+    cohort_config = {
+        'dense_states': {
+            'table_name': 'states',
+            'state_filters': ['state_one or state_two'],
+        }
     }
 
     return {
@@ -324,7 +326,7 @@ def sample_config():
         'model_comment': 'test2-final-final',
         'model_group_keys': ['label_name', 'label_type', 'custom_key'],
         'feature_aggregations': feature_config,
-        'state_config': state_config,
+        'cohort_config': cohort_config,
         'temporal_config': temporal_config,
         'grid_config': grid_config,
         'scoring': scoring_config,

--- a/src/triage/component/architect/state_table_generators.py
+++ b/src/triage/component/architect/state_table_generators.py
@@ -21,8 +21,10 @@ class StateTableGeneratorBase(ABC):
         The output format is entity id/date/state1/state3/state3...
 
     Subclasses must implement the following methods:
-        '_create_and_populate_sparse_table' to take dates and return a query to create the states table for those dates.
-        '_empty_table_message' to provide a helpful message to the user if no rows are found in the resultant table
+        '_create_and_populate_sparse_table' to take dates
+            and return a query to create the states table for those dates
+        '_empty_table_message' to provide a helpful message to the user
+            if no rows are found in the resultant table
 
     The main interface of StateTableGenerator objects is the
     `generate_sparse_table` method, which produces the latter
@@ -49,9 +51,8 @@ class StateTableGeneratorBase(ABC):
     def sparse_table_name(self):
         return 'tmp_sparse_states_{}'.format(self.experiment_hash)
 
-
     def generate_sparse_table(self, as_of_dates):
-        """Convert the object's input table 
+        """Convert the object's input table
         into a sparse states table for the given as_of_dates
 
         Args:
@@ -67,7 +68,6 @@ class StateTableGeneratorBase(ABC):
         logging.info('Indices created on entity_id and as_of_date for sparse state table')
         if not table_has_data(self.sparse_table_name, self.db_engine):
             raise ValueError(self._empty_table_message(as_of_dates))
-
 
     def clean_up(self):
         self.db_engine.execute(
@@ -91,7 +91,8 @@ class StateTableGeneratorFromEntities(StateTableGeneratorBase):
         self.entities_table = entities_table
 
     def _create_and_populate_sparse_table(self, as_of_dates):
-        """Create a 'sparse'-style table from an convert an entities table and addressing a specific set of dates
+        """Create a 'sparse'-style table from an entities table
+            for a specific set of dates
 
         This will include all entities for all given dates
 
@@ -125,7 +126,8 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
     """Generates a 'sparse'-style states table from a given query
 
     Args:
-    query (string) SQL query string to select entities for a given as_of_date (parameterized with brackets: {as_of_date})
+    query (string) SQL query string to select entities for a given as_of_date
+        The as_of_date should be parameterized with brackets: {as_of_date}
     """
 
     def __init__(self, query, *args, **kwargs):
@@ -134,7 +136,8 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
         self.query = query
 
     def _create_and_populate_sparse_table(self, as_of_dates):
-        """Create a 'sparse'-style states table by sequentially running a given date-parameterized query for all known dates.
+        """Create a 'sparse'-style states table by sequentially running a
+            given date-parameterized query for all known dates.
 
         Args:
         as_of_dates (list of datetime.date): Dates to calculate entity states as of
@@ -146,18 +149,18 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
                 as_of_date timestamp,
                 {active_state} boolean
             )
-        '''.format(
-            sparse_state_table=self.sparse_table_name,
-            active_state=DEFAULT_ACTIVE_STATE
-        ))
+            '''.format(
+                sparse_state_table=self.sparse_table_name,
+                active_state=DEFAULT_ACTIVE_STATE
+            )
+        )
         logging.info('Created sparse state table, now inserting rows')
         for as_of_date in as_of_dates:
             formatted_date = "'{}'::timestamp".format(as_of_date.isoformat())
             dated_query = self.query.replace('{as_of_date}', formatted_date)
             full_query = '''insert into {sparse_state_table}
                 select q.entity_id, {as_of_date}, true
-                from 
-                ({query}) q
+                from ({query}) q
                 group by 1, 2, 3
             '''.format(
                 sparse_state_table=self.sparse_table_name,
@@ -172,7 +175,9 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
             self.db_engine.execute(full_query)
 
     def _empty_table_message(self, as_of_dates):
-        return "Query does not return any rows for the given as_of_dates: {as_of_dates} '{query}'".format(
+        return """Query does not return any rows for the given as_of_dates:
+            {as_of_dates}
+            '{query}'""".format(
             query=self.query,
             as_of_dates=', '.join(str(as_of_date) for as_of_date in (
                 as_of_dates if len(as_of_dates) <= 5 else as_of_dates[:5] + ['…']

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -15,7 +15,7 @@ from triage.component.architect.features import (
     FeatureGroupMixer,
 )
 from triage.component.architect.planner import Planner
-from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities
+from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities, StateTableGeneratorFromQuery
 from triage.component.timechop import Timechop
 from triage.component.catwalk.db import ensure_db
 from triage.component.catwalk.model_trainers import ModelTrainer
@@ -108,7 +108,13 @@ class ExperimentBase(ABC):
         )
 
         cohort_config = self.config.get('cohort_config', {})
-        if 'entities_table' in cohort_config:
+        if 'query' in cohort_config:
+            self.state_table_generator_factory = partial(
+                StateTableGeneratorFromQuery,
+                experiment_hash=self.experiment_hash,
+                query=cohort_config['query']
+            )
+        elif 'entities_table' in cohort_config:
             self.state_table_generator_factory = partial(
                 StateTableGeneratorFromEntities,
                 experiment_hash=self.experiment_hash,

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -15,7 +15,11 @@ from triage.component.architect.features import (
     FeatureGroupMixer,
 )
 from triage.component.architect.planner import Planner
-from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities, StateTableGeneratorFromQuery
+from triage.component.architect.state_table_generators import (
+    StateTableGeneratorFromDense,
+    StateTableGeneratorFromEntities,
+    StateTableGeneratorFromQuery
+)
 from triage.component.timechop import Timechop
 from triage.component.catwalk.db import ensure_db
 from triage.component.catwalk.model_trainers import ModelTrainer
@@ -172,7 +176,9 @@ class ExperimentBase(ABC):
                                            .format(self.experiment_hash),
             },
             matrix_directory=self.matrices_directory,
-            states=self.config.get('cohort_config', {}).get('dense_states', {}).get('state_filters', []),
+            states=self.config.get('cohort_config', {})\
+            .get('dense_states', {})\
+            .get('state_filters', []),
             user_metadata=self.config.get('user_metadata', {}),
             replace=self.replace
         )

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from abc import ABCMeta, abstractmethod
+from abc import ABC, abstractmethod
 from datetime import datetime
 from functools import partial
 
@@ -15,7 +15,7 @@ from triage.component.architect.features import (
     FeatureGroupMixer,
 )
 from triage.component.architect.planner import Planner
-from triage.component.architect.state_table_generators import StateTableGenerator
+from triage.component.architect.state_table_generators import StateTableGeneratorFromDense, StateTableGeneratorFromEntities
 from triage.component.timechop import Timechop
 from triage.component.catwalk.db import ensure_db
 from triage.component.catwalk.model_trainers import ModelTrainer
@@ -33,7 +33,7 @@ def dt_from_str(dt_str):
     return datetime.strptime(dt_str, '%Y-%m-%d')
 
 
-class ExperimentBase(object, metaclass=ABCMeta):
+class ExperimentBase(ABC):
     """The base class for all Experiments."""
 
     cleanup_timeout = 60  # seconds
@@ -107,13 +107,21 @@ class ExperimentBase(object, metaclass=ABCMeta):
             test_durations=split_config['test_durations'],
         )
 
-        self.state_table_generator_factory = partial(
-            StateTableGenerator,
-            experiment_hash=self.experiment_hash,
-            dense_state_table=self.config.get('state_config', {})
-            .get('table_name', None),
-            events_table=self.config['events_table']
-        )
+        cohort_config = self.config.get('cohort_config', {})
+        if 'entities_table' in cohort_config:
+            self.state_table_generator_factory = partial(
+                StateTableGeneratorFromEntities,
+                experiment_hash=self.experiment_hash,
+                entities_table=cohort_config['entities_table']
+            )
+        elif 'dense_states' in cohort_config:
+            self.state_table_generator_factory = partial(
+                StateTableGeneratorFromDense,
+                experiment_hash=self.experiment_hash,
+                dense_state_table=cohort_config['dense_states']['table_name']
+            )
+        else:
+            raise ValueError('Cohort config missing or unrecognized')
 
         self.label_generator_factory = partial(
             BinaryLabelGenerator,
@@ -158,7 +166,7 @@ class ExperimentBase(object, metaclass=ABCMeta):
                                            .format(self.experiment_hash),
             },
             matrix_directory=self.matrices_directory,
-            states=self.config.get('state_config', {}).get('state_filters', []),
+            states=self.config.get('cohort_config', {}).get('dense_states', {}).get('state_filters', []),
             user_metadata=self.config.get('user_metadata', {}),
             replace=self.replace
         )


### PR DESCRIPTION
The main goal of this PR is to allow the definition of cohorts with a query. It also includes a refactoring commit, to clean up and prepare the StateTableGenerator for the cohort changes. I'd probably recommend viewing each of these commits separately for clarity, or at least look at the new feature commit in isolation (it is much shorter than the refactoring).  I pasted both commit messages below for the details.

    Allow defining cohort with a query [Resolves #333]
    
    - Add StateTableGeneratorFromQuery class to generate a state table from a query, parameterized with a date, to return some set of entities that should be included for that date.
    - Expose the new fubctionality at the 'query' key in cohort_config
    - Update example experiment config, validator, and algorithm doc with new functionality

    Refactor States config into Cohort config, and split into inherited classes
    
    - Make StateTableGenerator into StateTableGeneratorBase and inherited classes for different approaches to populating it, including making the child responsible for creating the table, giving them more flexibility
    - Rename events table option for cohort config into entities table to more correctly message that no other column but entity id is used
    - Convert states_config to cohort_config to more explicitly choose between the options (no more fallback). Update validations and example experiment config with these changes
    - Now that there is no fallback state config, remove the nostate test from experiment tests
    - Remove vestigial StateFilter class
    - Remove validation from StateTableGeneratorBase because this is handled at the Experiment level now
