### PR TITLE
Always insert ranks for predictions [Resolves #357]

### DIFF
--- a/docs/sources/experiments/algorithm.md
+++ b/docs/sources/experiments/algorithm.md
@@ -166,6 +166,8 @@ For each test matrix, predictions, individual importances, and evaluation metric
 #### Predictions
 The trained model's prediction probabilities (`predict_proba()`) are computed and saved for the test matrix. More specifically, `predict_proba` returns the probabilities for each label (false and true), but in this case only the probabilities for the true label are saved in the `results.predictions` table. The `entity_id` and `as_of_date` are retrieved from the matrix's index, and stored in the database table along with the probability score, label value (if it has one), as well as other metadata.
 
+The predictions table also contains entity rankings, both absolute and percentile, scoped by `as_of_date`. Ties in both cases are broken by the database ordering, so no two entities will have the same rank or percentile, nor will there be gaps.
+
 ### Individual Feature Importance
 Feature importances (of a configurable number of top features, defaulting to 5) for each prediction are computed and written to the `results.individual_importances` table. Right now, there are no sophisticated calculation methods integrated into the experiment; simply the top 5 global feature importances for the model are copied to the `individual_importances` table.
 

--- a/src/tests/catwalk_tests/test_predictors.py
+++ b/src/tests/catwalk_tests/test_predictors.py
@@ -82,7 +82,21 @@ def test_predictor():
             # 4. that the entity ids match the given dataset
             assert sorted([record[0] for record in records]) == [1, 2]
 
-            # 5. running with same model_id, different as of date
+            # 5. that absolute ranks are computed
+            ranks = [
+                row[0] for row in
+                db_engine.execute('select distinct(rank_abs) from results.predictions order by 1')
+            ]
+            assert ranks == [1, 2]
+
+            # 6. that percentile ranks are computed
+            ranks = [
+                row[0] for row in
+                db_engine.execute('select distinct(rank_pct) from results.predictions order by 1')
+            ]
+            assert ranks == [0, 1]
+
+            # 7. running with same model_id, different as of date
             # then with same as of date only replaces the records
             # with the same date
             new_matrix = pandas.DataFrame.from_dict({
@@ -119,7 +133,7 @@ def test_predictor():
             ]
             assert len(records) == 4
 
-            # 6. That we can delete the model when done prediction on it
+            # 8. That we can delete the model when done prediction on it
             predictor.delete_model(model_id)
             assert predictor.load_model(model_id) == None
 
@@ -171,6 +185,20 @@ def test_predictor_composite_index():
             join results.models using (model_id)''')
         ]
         assert len(records) == 4
+
+        # 3. that absolute ranks are computed
+        ranks = [
+            row[0] for row in
+            db_engine.execute('select distinct(rank_abs) from results.predictions order by 1')
+        ]
+        assert ranks == [1, 2]
+
+        # 4. that percentile ranks are computed
+        ranks = [
+            row[0] for row in
+            db_engine.execute('select distinct(rank_pct) from results.predictions order by 1')
+        ]
+        assert ranks == [0, 1]
 
 
 def test_predictor_get_train_columns():

--- a/src/triage/component/catwalk/predictors.py
+++ b/src/triage/component/catwalk/predictors.py
@@ -40,11 +40,9 @@ class Predictor(object):
             self.sessionmaker = sessionmaker(bind=self.db_engine)
         self.replace = replace
 
-
     @property
     def session(self):
         return session_manager(self.sessionmaker)
-
 
     @db_retry
     def _retrieve_model_hash(self, model_id):
@@ -208,11 +206,12 @@ class Predictor(object):
         self._generate_ranks(model_id, matrix_store.uuid)
 
     def _generate_ranks(self, model_id, matrix_uuid):
-        """Update predictions table with rankings.
+        """Update predictions table with rankings, both absolute and percentile.
 
         All entities should have different ranks, so to break ties:
         - abs_rank uses the 'row_number' function, so ties are broken by the database ordering
-        - pct_rank uses the output of the abs_rank to compute percentiles (as opposed to raw scores), so it inherits the tie-breaking from abs_rank
+        - pct_rank uses the output of the abs_rank to compute percentiles
+          (as opposed to raw scores), so it inherits the tie-breaking from abs_rank
 
         Args:
             model_id (int) the id of the model associated with the given predictions

--- a/src/triage/component/catwalk/utils.py
+++ b/src/triage/component/catwalk/utils.py
@@ -145,7 +145,7 @@ def session_manager(constructor):
     try:
         yield session
         session.commit()
-    except:
+    except Exception:
         session.rollback()
         raise
     finally:

--- a/src/triage/component/catwalk/utils.py
+++ b/src/triage/component/catwalk/utils.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import random
 import tempfile
+from contextlib import contextmanager
 
 import postgres_copy
 import sqlalchemy
@@ -135,3 +136,17 @@ def save_db_objects(db_engine, db_objects):
             ])
         f.seek(0)
         postgres_copy.copy_from(f, first_object_type, db_engine, format='csv')
+
+
+@contextmanager
+def session_manager(constructor):
+    """Provide a transactional scope around a series of operations."""
+    session = constructor()
+    try:
+        yield session
+        session.commit()
+    except:
+        session.rollback()
+        raise
+    finally:
+        session.close()


### PR DESCRIPTION
- Refactor predictions db insert to use save_db_objects utility (a more generic way of implementing the same COPY procedure), and to have both matrix index code paths use the same logic
- Add query after predictions copying to update table with ranks
- Refactor save_db_objects to take an iterable instead of needing a list, to help support big collections of objects (like Predictions!)