### PR TITLE
individual feature importances should be optional

### DIFF
--- a/src/triage/component/catwalk/feature_importances.py
+++ b/src/triage/component/catwalk/feature_importances.py
@@ -14,11 +14,13 @@ def _ad_hoc_feature_importances(model):
         model: A trained model that has not a `feature_importances_` attribute
 
     Returns:
-        At this moment, this method only returns the odds ratio of both the
+        At this moment, this method returns
+        (a) the odds ratio of both the
         intercept and the coefficients given by sklearn's implementation of
         the LogisticRegression.
         The order of the odds ratio list is the standard
         of the statistical packages (like R, SAS, etc) i.e. (intercept, coefficients)
+        (b) The coefficients (Weights assigned to the features) of the SVC
     """
     feature_importances = None
 
@@ -29,6 +31,10 @@ def _ad_hoc_feature_importances(model):
 
         # NOTE: We need to squeeze this array so it has the correct dimensions
         feature_importances = coef_odds_ratio.squeeze()
+
+    elif isinstance(model, (SVC)) and (model.get_params()['kernel'] == 'linear'):
+        feature_importances = model.coef_.squeeze()
+
 
     return feature_importances
 
@@ -43,13 +49,10 @@ def get_feature_importances(model):
     Returns:
         Feature importances, or failing that, None
     """
-    feature_importances = None
+
 
     if hasattr(model, 'feature_importances_'):
         feature_importances = model.feature_importances_
-
-    elif isinstance(model, (SVC)) and (model.get_params()['kernel'] == 'linear'):
-        feature_importances = model.coef_.squeeze()
 
     else:
         warnings.warn(

--- a/src/triage/experiments/singlethreaded.py
+++ b/src/triage/experiments/singlethreaded.py
@@ -68,11 +68,14 @@ class SingleThreadedExperiment(ExperimentBase):
                         train_matrix_columns=train_store.columns(),
                     )
 
-                    self.individual_importance_calculator\
-                        .calculate_and_save_all_methods_and_dates(
-                            model_id,
-                            test_store
-                        )
+                    try:
+                        self.individual_importance_calculator\
+                            .calculate_and_save_all_methods_and_dates(
+                                model_id,
+                                test_store
+                            )
+                    except AttributeError:
+                        logging.info("No individual feature importance calculation requested")
 
                     self.evaluator.evaluate(
                         predictions_proba=predictions_proba,


### PR DESCRIPTION
Not in all the experiments we want that, and it has problems with `DummyClassifier` (see #360).

This **PR**:
Individual feature importances is optional for ExperimentBase and for SingleThreadExperiment (Related (Fixes?)to #360). QUESTION: Someone knows how to add this to MultiCore?