### PR TITLE
Fixing s3 support

### DIFF
--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -17,3 +17,4 @@ retrying
 Dickens==1.0.1
 signalled-timeout==1.0.0
 smart_open==1.5.3
+s3fs

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -4,7 +4,6 @@ import unittest
 import yaml
 from collections import OrderedDict
 
-import boto
 import pandas
 from moto import mock_s3, mock_s3_deprecated
 
@@ -24,11 +23,11 @@ class SomeClass(object):
 
 
 def test_S3Store():
-    import boto3
     with mock_s3():
-        s3_conn = boto3.resource('s3')
-        s3_conn.create_bucket(Bucket='a-bucket')
-        store = S3Store(s3_conn.Object('a-bucket', 'a-path'))
+        import boto3
+        client = boto3.client('s3')
+        client.create_bucket(Bucket='test_bucket', ACL='public-read')
+        store = S3Store(path=f"s3://test_bucket/a_path")
         assert not store.exists()
         store.write(SomeClass('val'))
         assert store.exists()
@@ -198,9 +197,9 @@ class MatrixStoreTest(unittest.TestCase):
 
     def test_s3_save(self):
         with mock_s3_deprecated():
-            s3_conn = boto.connect_s3()
-            bucket_name = 'fake-matrix-bucket'
-            s3_conn.create_bucket(bucket_name)
+            import boto3
+            client = boto3.client('s3')
+            client.create_bucket(Bucket='fake-matrix-bucket', ACL='public-read')
 
             matrix_store_list = self.matrix_store()
 

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -4,7 +4,7 @@ import unittest
 import yaml
 from collections import OrderedDict
 
-import pandas
+import pandas as pd
 from moto import mock_s3, mock_s3_deprecated
 
 from triage.component.catwalk.storage import (
@@ -26,7 +26,7 @@ def test_S3Store():
     with mock_s3():
         import boto3
         client = boto3.client('s3')
-        client.create_bucket(Bucket='test_bucket', ACL='public-read')
+        client.create_bucket(Bucket='test_bucket', ACL='public-read-write')
         store = S3Store(path=f"s3://test_bucket/a_path")
         assert not store.exists()
         store.write(SomeClass('val'))
@@ -70,7 +70,7 @@ class MatrixStoreTest(unittest.TestCase):
             ('m_feature', [0.4, 0.5]),
             ('label', [0, 1])
         ])
-        df = pandas.DataFrame.from_dict(data_dict)
+        df = pd.DataFrame.from_dict(data_dict)
         metadata = {
             'label_name': 'label',
             'indices': ['entity_id'],
@@ -84,7 +84,7 @@ class MatrixStoreTest(unittest.TestCase):
             tmphdf = os.path.join(tmpdir, 'df.h5')
             with open(tmpyaml, 'w') as outfile:
                 yaml.dump(metadata, outfile, default_flow_style=False)
-                df.to_csv(tmpcsv, index=False)
+                df.to_csv(tmpcsv)
                 df.to_hdf(tmphdf, 'matrix')
                 csv = CSVMatrixStore(matrix_path=tmpcsv, metadata_path=tmpyaml)
                 hdf = HDFMatrixStore(matrix_path=tmphdf, metadata_path=tmpyaml)
@@ -104,7 +104,8 @@ class MatrixStoreTest(unittest.TestCase):
                 assert csv.labels().to_dict() == inmemory.labels().to_dict()
                 assert hdf.labels().to_dict() == inmemory.labels().to_dict()
 
-        matrix_store = [inmemory, hdf, csv]
+        matrix_store = [inmemory, csv, hdf]
+
         return matrix_store
 
     def test_MatrixStore_resort_columns(self):
@@ -175,7 +176,7 @@ class MatrixStoreTest(unittest.TestCase):
             'feature_two': [0.5, 0.6],
         }
         matrix = InMemoryMatrixStore(
-            matrix=pandas.DataFrame.from_dict(data),
+            matrix=pd.DataFrame.from_dict(data),
             metadata={'end_time': '2016-01-01', 'indices': ['entity_id']}
         )
 
@@ -189,29 +190,25 @@ class MatrixStoreTest(unittest.TestCase):
             'as_of_date': ['2016-01-01', '2016-01-01', '2017-01-01', '2017-01-01']
         }
         matrix = InMemoryMatrixStore(
-            matrix=pandas.DataFrame.from_dict(data),
+            matrix=pd.DataFrame.from_dict(data),
             metadata={'indices': ['entity_id', 'as_of_date']}
         )
 
         self.assertEqual(matrix.as_of_dates, ['2016-01-01', '2017-01-01'])
 
     def test_s3_save(self):
-        with mock_s3_deprecated():
+        with mock_s3():
             import boto3
             client = boto3.client('s3')
-            client.create_bucket(Bucket='fake-matrix-bucket', ACL='public-read')
+            client.create_bucket(Bucket='fake-matrix-bucket', ACL='public-read-write')
 
             matrix_store_list = self.matrix_store()
 
             for matrix_store in matrix_store_list:
-                matrix_store.save(project_path='s3://fake-matrix-bucket', name='test')
+                if isinstance(matrix_store, CSVMatrixStore):
+                    matrix_store.save(project_path='s3://fake-matrix-bucket', name='test')
+                    # CSV
+                    csv = CSVMatrixStore(matrix_path='s3://fake-matrix-bucket/test.csv', metadata_path='s3://fake-matrix-bucket/test.yaml')
 
-            # HDF
-            hdf = HDFMatrixStore(matrix_path='s3://fake-matrix-bucket/test.h5', metadata_path='s3://fake-matrix-bucket/test.yaml')
-            # CSV
-            csv = CSVMatrixStore(matrix_path='s3://fake-matrix-bucket/test.csv', metadata_path='s3://fake-matrix-bucket/test.yaml')
-
-            assert csv.metadata == matrix_store_list[0].metadata
-            assert csv.matrix.to_dict() == matrix_store_list[0].matrix.to_dict()
-            assert hdf.metadata == matrix_store_list[0].metadata
-            assert hdf.matrix.to_dict() == matrix_store_list[0].matrix.to_dict()
+                    assert csv.metadata == matrix_store_list[0].metadata
+                    assert csv.matrix.to_dict() == matrix_store_list[0].matrix.to_dict()

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -249,7 +249,7 @@ class CSVBuilder(BuilderBase):
             matrix_uuid
         )
         try:
-            logging.info('Extracting label data frmo database into file for '
+            logging.info('Extracting label data from database into file for '
                          'matrix %s', matrix_uuid)
             labels_csv_name = self.write_labels_data(
                 label_name,

--- a/src/triage/component/catwalk/README.rst
+++ b/src/triage/component/catwalk/README.rst
@@ -35,7 +35,7 @@ Below is a complete sample usage of the three Catwalk components::
     from sqlalchemy import create_engine
 
     from triage.component import metta
-    from triage.component.catwalk.storage import FSModelStorageEngine, MettaCSVMatrixStore
+    from triage.component.catwalk.storage import FSModelStorageEngine, CSVMatrixStore
     from triage.component.catwalk.model_trainers import ModelTrainer
     from triage.component.catwalk.predictors import Predictor
     from triage.component.catwalk.evaluation import ModelEvaluator
@@ -66,9 +66,9 @@ Below is a complete sample usage of the three Catwalk components::
     }
     train_matrix_uuid = metta.archive_matrix(train_metadata, train_matrix, format='csv')
 
-    # The MettaCSVMatrixStore bundles the matrix and metadata together
+    # The CSVMatrixStore bundles the matrix and metadata together
     # for catwalk to use
-    train_matrix_store = MettaCSVMatrixStore(
+    train_matrix_store = CSVMatrixStore(
         matrix_path='{}.csv'.format(train_matrix_uuid),
         metadata_path='{}.yaml'.format(train_matrix_uuid)
     )
@@ -91,9 +91,9 @@ Below is a complete sample usage of the three Catwalk components::
     }
     test_matrix_uuid = metta.archive_matrix(test_metadata, test_matrix, format='csv')
 
-    # The MettaCSVMatrixStore bundles the matrix and metadata together
+    # The CSVMatrixStore bundles the matrix and metadata together
     # for catwalk to use
-    test_matrix_store = MettaCSVMatrixStore(
+    test_matrix_store = CSVMatrixStore(
         matrix_path='{}.csv'.format(test_matrix_uuid),
         metadata_path='{}.yaml'.format(test_matrix_uuid)
     )

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -105,7 +105,6 @@ class ModelStorageEngine(object):
 class S3ModelStorageEngine(ModelStorageEngine):
     def __init__(self, *args, **kwargs):
         super(S3ModelStorageEngine, self).__init__(*args, **kwargs)
-        self.s3_conn = s3_conn
 
     def get_store(self, model_hash):
         full_path=os.path.join(self.project_path, 'trained_models', model_hash)

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -337,7 +337,6 @@ class CSVMatrixStore(MatrixStore):
 
     def __init__(self, matrix_path=None, metadata_path=None):
         super().__init__(matrix_path, metadata_path)
-        self.metadata = self.load_metadata()
 
     def _get_head_of_matrix(self):
         try:

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -180,7 +180,7 @@ class MatrixStore(object):
 
         if scheme in ('','file') and (not os.path.exists(self.matrix_path)):
             return True
-        elif scheme == 's3' and (not s3fs.S3FileSystem().existx(self.matrix_path)):
+        elif scheme == 's3' and (not s3fs.S3FileSystem().exists(self.matrix_path)):
             return True
         else:
             head_of_matrix = self.head_of_matrix

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -3,7 +3,7 @@ import os
 import pickle
 
 import pandas as pd
-import smart_open
+import logging
 import yaml
 
 from .utils import (
@@ -353,6 +353,10 @@ class CSVMatrixStore(MatrixStore):
                 raise ValueError(f"URL scheme not supported: {scheme} (from {self.matrix_path})")
 
             head_of_matrix.set_index(self.metadata['indices'], inplace=True)
+        except FileNotFoundError as fnfe:
+            logging.error(f"Matrix isn't there: {fnfe}")
+            logging.error("Returning None")
+            head_of_matrix = None
         except pd.errors.EmptyDataError:
             head_of_matrix = None
 

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -140,27 +140,39 @@ class MatrixStore(object):
     def __init__(self, matrix_path=None, metadata_path=None):
         self.matrix_path = matrix_path
         self.metadata_path = metadata_path
-        self._matrix = None
-        self._metadata = None
-        self._head_of_matrix = None
+        self.matrix = None
+        self.metadata = None
+        self.head_of_matrix = None
 
     @property
     def matrix(self):
-        if self._matrix is None:
-            self._load()
-        return self._matrix
+        if self.__matrix is None:
+            self.__matrix = self._load()
+        return self.__matrix
+
+    @matrix.setter
+    def matrix(self, matrix):
+        self.__matrix = matrix
 
     @property
     def metadata(self):
-        if self._metadata is None:
-            self._load()
-        return self._metadata
+        if self.__metadata is None:
+            self.__metadata = self.load_metadata()
+        return self.__metadata
+
+    @metadata.setter
+    def metadata(self, metadata):
+        self.__metadata = metadata
 
     @property
     def head_of_matrix(self):
-        if self._head_of_matrix is None:
-            self._get_head_of_matrix()
-        return self._head_of_matrix
+        if self.__head_of_matrix is None:
+            self.__head_of_matrix = self._get_head_of_matrix()
+        return self.__head_of_matrix
+
+    @head_of_matrix.setter
+    def head_of_matrix(self, head_of_matrix):
+        self.__head_of_matrix = head_of_matrix
 
     @property
     def empty(self):
@@ -229,10 +241,10 @@ class MatrixStore(object):
                     Columnset and desired columnset mismatch. Unique items: %s
                 ''', columnset ^ desired_columnset)
 
-    def save_yaml(self, df, project_path, name):
+    def save_metadata(self, df, project_path, name):
         path_parsed = urlparse(project_path)
-        scheme = path_parsed.scheme # If '' of 'file' is a regular file or 's3'
-        if not scheme or scheme == 'file': # Local file
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
             with open(os.path.join(project_path, name + ".yaml"), "wb") as f:
                 yaml.dump(df, f, encoding='utf-8')
         elif scheme == 's3':
@@ -240,148 +252,152 @@ class MatrixStore(object):
             with s3.open(os.path.join(project_path, name + ".yaml"), "wb") as f:
                 yaml.dump(df, f, encoding='utf-8')
         else:
-            raise ValueError(f"URL scheme not supported: {scheme} (from {os.path.join(project_path, name + '.yaml')})")
+            raise ValueError(f"""
+                  URL scheme not supported:
+                  {scheme} (from {os.path.join(project_path, name + '.yaml')})
+            """)
 
-    def load_yaml(self, metadata_path):
-        path_parsed = urlparse(metadata_path)
-        scheme = path_parsed.scheme # If '' of 'file' is a regular file or 's3'
-        if not scheme or scheme == 'file': # Local file
-            with open(metadata_path, "r", encoding='utf-8') as f:
+    def load_metadata(self):
+        path_parsed = urlparse(self.metadata_path)
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
+            with open(self.metadata_path, "r", encoding='utf-8') as f:
                 metadata = yaml.load(f.read())
         elif scheme == 's3':
             s3 = s3fs.S3FileSystem()
-            with s3.open(metadata_path, 'rb', encoding='utf-8') as f:
+            with s3.open(self.metadata_path, 'rb', encoding='utf-8') as f:
                 metadata = yaml.load(f.read())
         else:
-            raise ValueError(f"URL scheme not supported: {scheme} (from {metadata_path})")
+            raise ValueError(f"""
+                  URL scheme not supported:
+                  {scheme} (from {self.metadata_path})"
+            """)
+
+        return metadata
 
     def __getstate__(self):
         # when we serialize (say, for multiprocessing),
         # we don't want the cached members to show up
         # as they can be enormous
-        self._matrix = None
+        self.matrix = None
         self._labels = None
-        self._metadata = None
-        self._head_of_matrix = None
+        self.metadata = None
+        self.head_of_matrix = None
         return self.__dict__.copy()
 
 
 class HDFMatrixStore(MatrixStore):
 
+    def __init__(self, matrix_path=None, metadata_path=None):
+        super().__init__(matrix_path, metadata_path)
+        self.metadata = self.load_metadata()
+
     def _get_head_of_matrix(self):
         try:
-            hdf = pd.HDFStore(self.matrix_path)
-            key = hdf.keys()[0]
-            head_of_matrix = hdf.select(key, start=0, stop=1)
-            head_of_matrix.set_index(self.metadata['indices'], inplace=True)
-            self._head_of_matrix = head_of_matrix
+            head_of_matrix = pd.read_hdf(self.matrix_path, start=0, stop=1)
+            # Is the index already in place?
+            if head_of_matrix.index.name not in self.metadata['indices']:
+                head_of_matrix.set_index(self.metadata['indices'], inplace=True)
         except pd.errors.EmptyDataError:
-            self._head_of_matrix = None
+            head_of_matrix = None
+
+        return head_of_matrix
 
     def _load(self):
-        with smart_open.smart_open(self.matrix_path, "rb") as f:
-            self._matrix = self._read_hdf_from_buffer(f)
-        self._metadata = self.load_yaml(self.metadata_path)
-        try:
-            self._matrix.set_index(self._metadata['indices'], inplace=True)
-        except Exception:
-            pass
+        path_parsed = urlparse(self.matrix_path)
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
+            matrix = pd.read_hdf(self.matrix_path)
+        else:
+            raise ValueError(f"""
+                  URL scheme not supported:
+                  {scheme} (from {self.matrix_path})
+            """)
+        # Is the index already in place?
+        if matrix.index.name not in self.metadata['indices']:
+            matrix.set_index(self.metadata['indices'], inplace=True)
 
-    def _read_hdf_from_buffer(self, buffer):
-        with pd.HDFStore(
-                "data.h5",
-                mode="r",
-                driver="H5FD_CORE",
-                driver_core_backing_store=0,
-                driver_core_image=buffer.read()) as store:
-
-            if len(store.keys()) > 1:
-                raise Exception('Ambiguous matrix store. More than one dataframe in the hdf file.')
-
-            try:
-                return store["matrix"]
-
-            except KeyError:
-                print("The hdf file should contain one and only key, matrix.")
-                return store[store.keys()[0]]
-
-    def _write_hdf_to_buffer(self, df):
-        with pd.HDFStore(
-                "data.h5",
-                mode="w",
-                driver="H5FD_CORE",
-                driver_core_backing_store=0) as out:
-            out["matrix"] = df
-            return out._handle.get_file_image()
+        return matrix
 
     def save(self, project_path, name):
-        with smart_open.smart_open(os.path.join(project_path, name + ".h5"), "wb") as f:
-            f.write(self._write_hdf_to_buffer(self.matrix))
-        self.save_yaml(self.metadata, project_path, name)
+        path_parsed = urlparse(self.project_path)
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
+            with open(os.path.join(project_path, name + ".h5"), "w") as f:
+                self.matrix.to_hdf(f, format='table', mode='w')
+        else:
+            raise ValueError(f"""
+                  URL scheme not supported:
+                  {scheme} (from {os.path.join(project_path, name + '.h5')})
+            """)
+
+        self.save_metadata(self.metadata, project_path, name)
 
 
 class CSVMatrixStore(MatrixStore):
+
+    def __init__(self, matrix_path=None, metadata_path=None):
+        super().__init__(matrix_path, metadata_path)
+        self.metadata = self.load_metadata()
+
     def _get_head_of_matrix(self):
         try:
             head_of_matrix = pd.read_csv(self.matrix_path, nrows=1)
             head_of_matrix.set_index(self.metadata['indices'], inplace=True)
-            self._head_of_matrix = head_of_matrix
         except pd.errors.EmptyDataError:
-            self._head_of_matrix = None
+            head_of_matrix = None
+        return head_of_matrix
 
     def _load(self):
         path_parsed = urlparse(self.matrix_path)
-        scheme = path_parsed.scheme # If '' of 'file' is a regular file or 's3'
-        if not scheme or scheme == 'file': # Local file
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
             with open(self.matrix_path, "r") as f:
-                self._matrix = pd.read_csv(f)
+                matrix = pd.read_csv(f)
         elif scheme == 's3':
             s3 = s3fs.S3FileSystem()
             with s3.open(self.matrix_path, 'rb') as f:
-                self_matrix = pd.read_csv(f)
+                matrix = pd.read_csv(f)
         else:
             raise ValueError(f"URL scheme not supported: {scheme} (from {self.matrix_path})")
 
-        self._metadata = self.load_yaml(self.metadata_path)
-        self._matrix.set_index(self.metadata['indices'], inplace=True)
+        matrix.set_index(self.metadata['indices'], inplace=True)
+
+        return matrix
 
     def save(self, project_path, name):
-        path_parsed = urlparse(self.matrix_path)
-        scheme = path_parsed.scheme # If '' of 'file' is a regular file or 's3'
-        if not scheme or scheme == 'file': # Local file
+        path_parsed = urlparse(project_path)
+        scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+        if not scheme or scheme == 'file':  # Local file
             with open(os.path.join(project_path, name + ".csv"), "w") as f:
                 self.matrix.to_csv(f)
         elif scheme == 's3':
+            bytes_to_write = self.matrix.to_csv(None).encode()
             s3 = s3fs.S3FileSystem()
             with s3.open(os.path.join(project_path, name + ".csv"), "wb") as f:
-                self.matrix.to_csv(f)
+                f.write(bytes_to_write)
         else:
             raise ValueError(f"URL scheme not supported: {scheme} (from {os.path.join(project_path, name + '.csv')})")
 
-
-        self.save_yaml(self.metadata, project_path, name)
+        self.save_metadata(self.metadata, project_path, name)
 
 
 class InMemoryMatrixStore(MatrixStore):
     def __init__(self, matrix, metadata, labels=None):
-        self._matrix = matrix
-        self._metadata = metadata
+        super().__init__()
+        self.matrix = matrix
+        self.metadata = metadata
+        self.matrix.set_index(self.metadata['indices'], inplace=True)
         self._labels = labels
-        self._head_of_matrix = None
+        self.head_of_matrix = None
 
     def _get_head_of_matrix(self):
-        self._head_of_matrix = self.matrix.head(n=1)
+        return self.matrix.head(n=1)
 
     @property
     def empty(self):
         head_of_matrix = self.head_of_matrix
         return head_of_matrix.empty
-
-    @property
-    def matrix(self):
-        if self._metadata['indices'][0] in self._matrix.columns:
-            self._matrix.set_index(self._metadata['indices'], inplace=True)
-        return self._matrix
 
     def save(self, project_path, name):
         return None

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -386,6 +386,7 @@ class CSVMatrixStore(MatrixStore):
     def save(self, project_path, name):
         path_parsed = urlparse(project_path)
         scheme = path_parsed.scheme  # If '' of 'file' is a regular file or 's3'
+
         if not scheme or scheme == 'file':  # Local file
             with open(os.path.join(project_path, name + ".csv"), "w") as f:
                 self.matrix.to_csv(f)

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -15,10 +15,8 @@ from .utils import (
 
 import s3fs
 
-try:
-    from urllib.parse import urlparse
-except:
-    from urlparse import urlparse
+from urllib.parse import urlparse # Python3
+
 
 class Store(object):
     def __init__(self, path):

--- a/src/triage/component/metta/README.md
+++ b/src/triage/component/metta/README.md
@@ -65,6 +65,8 @@ metta.archive_train_test(train_config,
                          overwrite=False)
 ```
 
+The argument `directory` could be a path to the local file system or `s3` path (only supported for `csv` format due to limitations of `pytables`)
+
 ### Storing a train and multiple test sets
 ```
 from triage.component import metta

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py35, flake8
+envlist = py36, flake8
 
 [testenv:flake8]
 deps = -r{toxinidir}/requirement/include/lint.txt
 commands = flake8 src/triage
 
-[testenv:py35]
+[testenv:py36]
 setenv = BOTO_CONFIG=/tmp/nowhere
 deps = -r{toxinidir}/requirement/test.txt
 commands = py.test --basetemp={envtmpdir} {posargs:-vvv --cov=triage}


### PR DESCRIPTION
Catwalk
-----------------------
Removed `smart_open`, now using `s3fs`
 **Reason**: `smart_open` uses `boto` instead of `boto3`. `boto` lacks of several features (like using aws `sts`)

- `S3Store` is working, and also `S3ModelStoreEngine`
- `CSVMatrixStore` supports storing to s3 using `s3fs`
- HDFMatrixStore now doesn' t support storing to s3 (not that impotant since triage only supports CSVMatrixStore)

Metta
--------------------

Added support to store matrices in `s3` (only for `csv`)

**NOTES**:
- This code uses `python 3.6`
- Tests passes (but a lot of testing was missing)
- Tested in a readl project (`sfpd_eis`)
- We need to unify how we handle the storage, now is distributed in `architect`, `metta` and `catlwalk`
