### PR TITLE
inserting NULLs for individual feature importance - #361

### DIFF
--- a/src/triage/component/catwalk/individual_importance/uniform.py
+++ b/src/triage/component/catwalk/individual_importance/uniform.py
@@ -1,3 +1,5 @@
+from triage.component.catwalk.model_trainers import NO_FEATURE_IMPORTANCE
+
 def _entity_feature_values(matrix, feature_name, as_of_date=None):
     """Finds the value of the given feature for each entity in a matrix
 
@@ -9,11 +11,9 @@ def _entity_feature_values(matrix, feature_name, as_of_date=None):
 
     Returns: (list) of (entity_id, feature_value) tuples
     """
-    feature_wo_importance = 'Algorithm does not support a standard way to calculate feature importance.'
-
     if matrix.index.names == ['entity_id']:
-        if feature_name == feature_wo_importance:
-            #if model does not support feature importance, write 0 as individual importance.
+        if feature_name == NO_FEATURE_IMPORTANCE:
+            # if model does not support feature importance, write 0 as individual importance.
             return list(zip(matrix.index.values, [None] * len(matrix.index.values)))
         else:
             return list(zip(matrix.index.values, matrix[feature_name].tolist()))
@@ -22,7 +22,7 @@ def _entity_feature_values(matrix, feature_name, as_of_date=None):
         index_of_entity = matrix.index.names.index('entity_id')
         index_of_date = matrix.index.names.index('as_of_date')
 
-        if feature_name == feature_wo_importance:
+        if feature_name == NO_FEATURE_IMPORTANCE:
             zipped_iter = zip(matrix.index.values, [None] * len(matrix.index.values))
         else:
             zipped_iter = zip(matrix.index.values, matrix[feature_name].tolist())

--- a/src/triage/component/catwalk/individual_importance/uniform.py
+++ b/src/triage/component/catwalk/individual_importance/uniform.py
@@ -9,13 +9,25 @@ def _entity_feature_values(matrix, feature_name, as_of_date=None):
 
     Returns: (list) of (entity_id, feature_value) tuples
     """
+    feature_wo_importance = 'Algorithm does not support a standard way to calculate feature importance.'
+
     if matrix.index.names == ['entity_id']:
-        return list(zip(matrix.index.values, matrix[feature_name].tolist()))
+        if feature_name == feature_wo_importance:
+            #if model does not support feature importance, write 0 as individual importance.
+            return list(zip(matrix.index.values, [None] * len(matrix.index.values)))
+        else:
+            return list(zip(matrix.index.values, matrix[feature_name].tolist()))
     elif 'entity_id' in matrix.index.names:
         results = []
         index_of_entity = matrix.index.names.index('entity_id')
         index_of_date = matrix.index.names.index('as_of_date')
-        for row in zip(matrix.index.values, matrix[feature_name].tolist()):
+
+        if feature_name == feature_wo_importance:
+            zipped_iter = zip(matrix.index.values, [None] * len(matrix.index.values))
+        else:
+            zipped_iter = zip(matrix.index.values, matrix[feature_name].tolist())
+
+        for row in zipped_iter:
             index_values, feature_value = row
             entity_id = index_values[index_of_entity]
             if index_values[index_of_date] == as_of_date:

--- a/src/triage/component/catwalk/individual_importance/uniform.py
+++ b/src/triage/component/catwalk/individual_importance/uniform.py
@@ -1,5 +1,6 @@
 from triage.component.catwalk.model_trainers import NO_FEATURE_IMPORTANCE
 
+
 def _entity_feature_values(matrix, feature_name, as_of_date=None):
     """Finds the value of the given feature for each entity in a matrix
 

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -154,7 +154,7 @@ class ModelTrainer(object):
                 model_id=model_id,
                 feature_importance=0,
                 feature='Algorithm does not support a standard way' +
-                        'to calculate feature importance.',
+                        ' to calculate feature importance.',
                 rank_abs=0,
                 rank_pct=0,
             ))

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -19,6 +19,9 @@ from .utils import (
     save_db_objects,
 )
 
+NO_FEATURE_IMPORTANCE = 'Algorithm does not support a standard way' +\
+                        ' to calculate feature importance.'
+
 
 class ModelTrainer(object):
     """Trains a series of classifiers using the same training set
@@ -153,8 +156,7 @@ class ModelTrainer(object):
             db_objects.append(FeatureImportance(
                 model_id=model_id,
                 feature_importance=0,
-                feature='Algorithm does not support a standard way' +
-                        ' to calculate feature importance.',
+                feature=NO_FEATURE_IMPORTANCE,
                 rank_abs=0,
                 rank_pct=0,
             ))


### PR DESCRIPTION
Some classifiers do not support feature importance. For them, we write 
`Algorithm does not support a standard way to calculate feature importance.` into results.feature_importance as feature_name. This leads to problems when trying to write individual feature importance because the feature does not exist in the matrix. This PR checks for the fake feature name and sets the individual importances to Nulls. 