### PR TITLE
Overhaul model_group_keys

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -3,7 +3,7 @@
 # The experiment configuration changes from time to time, and we upgrade the
 # triage.experiments.CONFIG_VERSION variable whenever drastic changes that break
 # old configuration files are released. Be sure to assign the config version
-# that matches the triage.experiments.CONFIG_VERSION in the triage release 
+# that matches the triage.experiments.CONFIG_VERSION in the triage release
 # you are developing against!
 config_version: 'v3'
 
@@ -47,7 +47,7 @@ temporal_config:
 # that will be present in matrix metadata for each matrix created by this experiment,
 # under the 'label_name' key. The default label_name is 'outcome'.
 label_config:
-    #inspection_outcomes_table: 'events'
+    inspection_outcomes_table: 'events'
     query: |
         select
         events.entity_id,
@@ -73,22 +73,22 @@ label_config:
 # Rules specifying how to handle imputation of null values must be explicitly
 # defined in your config file. These can be specified in two places: either
 # within each feature or overall for each type of feature (aggregates_imputation,
-# categoricals_imputation, array_categoricals_imputation). In either case, a rule must be given for 
+# categoricals_imputation, array_categoricals_imputation). In either case, a rule must be given for
 # each aggregation function (e.g., sum, max, avg, etc) used, or a catch-all
 # can be specified with `all`. Aggregation function-specific rules will take
-# precedence over the `all` rule and feature-specific rules will take 
+# precedence over the `all` rule and feature-specific rules will take
 # precedence over the higher-level rules. Several examples are provided below.
 #
 # Available Imputation Rules:
-#   * mean: The average value of the feature (for SpacetimeAggregation the 
+#   * mean: The average value of the feature (for SpacetimeAggregation the
 #           mean is taken within-date).
 #   * constant: Fill with a constant value from a required `value` parameter.
 #   * zero: Fill with zero.
-#   * null_category: Only available for categorical features. Just flag null 
-#                    values with the null category column. 
-#   * binary_mode: Only available for aggregate column types. Takes the modal 
+#   * null_category: Only available for categorical features. Just flag null
+#                    values with the null category column.
+#   * binary_mode: Only available for aggregate column types. Takes the modal
 #                  value for a binary feature.
-#   * error: Raise an exception if any null values are encountered for this 
+#   * error: Raise an exception if any null values are encountered for this
 #            feature.
 feature_aggregations:
     -
@@ -105,7 +105,7 @@ feature_aggregations:
 
         # top-level imputation rules that will apply to all aggregates functions
         # can also specify categoricals_imputation or array_categoricals_imputation
-        # 
+        #
         # You must specified at least one of the top-level or feature-level imputation
         # to cover ever feature being defined.
         aggregates_imputation:
@@ -142,7 +142,7 @@ feature_aggregations:
                 metrics:
                     - 'count'
                     - 'sum'
-            - 
+            -
                 # since we're specifying `aggregates_imputation` above,
                 # a feature-specific imputation rule can be omitted
                 quantity: 'some_flag'
@@ -226,7 +226,7 @@ feature_group_strategies: ['all']
 # Regardless of which method you choose, you may enter a 'name' for your configuration.
 # This will be included in the metadata for each matrix and used to group models
 # If you don't pass one, the string 'default' will be used.
-#
+l#
 cohort_config:
 #   entities_table: 'events'
 #   dense_states:

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -42,6 +42,10 @@ temporal_config:
 # 2. Pass a query that returns two columns: entity_id and outcome, based on a given as_of_date and label_timespan.
 #   The as_of_date and label_timespan must be represented by placeholders marked by curly brackets. The example below
 #   reproduces the inspection outcome boolean-or logic:
+#
+# In addition to these configuration options, you can pass a name to apply to the label configuration
+# that will be present in matrix metadata for each matrix created by this experiment,
+# under the 'label_name' key. The default label_name is 'outcome'.
 label_config:
     #inspection_outcomes_table: 'events'
     query: |
@@ -52,6 +56,7 @@ label_config:
         where '{as_of_date}' <= outcome_date
             and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
             group by entity_id
+    #name: 'inspections'
 
 
 # FEATURE GENERATION
@@ -216,6 +221,12 @@ feature_group_strategies: ['all']
 #       states are boolean columns (the experiment will convert the one you pass in
 #       to this format), write a SQL expression for each state
 #       configuration you want, ie '(permitted OR suspended) AND licensed'
+#
+#
+# Regardless of which method you choose, you may enter a 'name' for your configuration.
+# This will be included in the metadata for each matrix and used to group models
+# If you don't pass one, the string 'default' will be used.
+#
 cohort_config:
 #   entities_table: 'events'
 #   dense_states:
@@ -224,6 +235,7 @@ cohort_config:
 #        - 'state_one AND state_two'
 #        - '(state_one OR state_two) AND state_three'
     query: "select entity_id from events where outcome_date < '{as_of_date}'"
+    name: 'past_events'
 
 # USER METADATA
 # These are arbitrary keys/values that you can have Triage apply to the
@@ -242,24 +254,31 @@ cohort_config:
 user_metadata:
     label_definition: 'severe_violations'
 
-# MODEL GROUPING
-# Model groups are aimed at defining models which are equivalent across time splits.
-# In other words, you will probably want to define model groups by any  parameters
-# that distinguish models *other than the beginning end dates of their data.*
-# By default, the classifier module name, hyperparameters, and feature names are used.
-# 
+# MODEL GROUPING (optional)
+# Model groups are a way of partitioning trained models in a way that makes for easier analysis.
 #
-# model_group_keys defines a list of *additional* matrix metadata keys that
-# should be considered when creating a model group. For example, if the models are
-# built on matrices with different history lengths (train durations), different
-# labeling windows (e.g., inspection violations in the next month, next year, or
-# next two years) the frequency of rows for each entity(train example frequency), or
-# the definition of a positive label.
-model_group_keys:
-    - 'train_duration'
-    - 'label_window'
-    - 'example_frequency'
-    - 'label_definition'
+# model_group_keys defines a list of training matrix metadata and classifier keys that
+# should be considered when creating a model group.
+#
+# There is an extensive default configuration, which is aimed at producing groups whose
+# constituent models are equivalent to each other in all ways except for when they were trained.
+# This makes the analysis of model stability easier.
+#
+# To accomplish this, the following default keys are used:
+# 'class_path', 'parameters'
+# 'feature_names', 'feature_groups', 'cohort_name', 'state'
+# 'label_name', 'label_timespan', 'as_of_date_frequency', 'max_training_history'
+#
+# If you want to override this list, you can supply a 'model_group_keys' value.
+# All of the defaults are available, along with some other temporal information
+# that could be useful for more specialized analyses:
+#
+# 'first_as_of_time', 'last_as_of_time', 'matrix_info_end_time', 'as_of_times', 'feature_start_time'
+#
+# You can also use any pieces of user_metadata that you included in this experiment definition,
+# as they will be present in the matrix metadata.
+#
+# model_group_keys: ['feature_groups', 'label_definition']
 
 # GRID CONFIGURATION
 # The classifier/hyperparameter combinations that should be trained

--- a/src/tests/architect_tests/test_feature_group_creator.py
+++ b/src/tests/architect_tests/test_feature_group_creator.py
@@ -7,14 +7,17 @@ def test_table_group():
         definition={'tables': ['one', 'three']}
     )
 
-    assert group.subsets({
+    subsets = group.subsets({
         'one': ['col_a', 'col_b', 'col_c'],
         'two': ['col_a', 'col_b', 'col_c'],
         'three': ['col_a', 'col_b', 'col_c'],
-    }) == [
+    })
+    assert subsets == [
         {'one': ['col_a', 'col_b', 'col_c']},
         {'three': ['col_a', 'col_b', 'col_c']},
     ]
+    assert subsets[0].names == ['tables: one']
+    assert subsets[1].names == ['tables: three']
 
 
 def test_prefix_group():
@@ -23,15 +26,18 @@ def test_prefix_group():
         definition={'prefix': ['major_viol', 'severe_viol']}
     )
 
-    assert group.subsets({
+    subsets = group.subsets({
         'one': ['minor_viol_a', 'minor_viol_b', 'minor_viol_c'],
         'two': ['severe_viol_a', 'severe_viol_b', 'severe_viol_c'],
         'three': ['major_viol_a', 'major_viol_b', 'major_viol_c'],
         'four': ['minor_viol_a', 'minor_viol_b', 'minor_viol_c'],
-    }) == [
+    })
+    assert subsets == [
         {'three': ['major_viol_a', 'major_viol_b', 'major_viol_c']},
         {'two': ['severe_viol_a', 'severe_viol_b', 'severe_viol_c']},
     ]
+    assert subsets[0].names == ['prefix: major_viol']
+    assert subsets[1].names == ['prefix: severe_viol']
 
 
 def test_multiple_criteria():
@@ -42,17 +48,23 @@ def test_multiple_criteria():
         }
     )
 
-    assert group.subsets({
+    subsets = group.subsets({
         'one': ['minor_a', 'minor_b', 'minor_c'],
         'two': ['severe_a', 'severe_b', 'severe_c'],
         'three': ['major_a', 'major_b', 'major_c'],
         'four': ['minor_a', 'minor_b', 'minor_c'],
-    }) == [
+    })
+    assert subsets == [
         {'three': ['major_a', 'major_b', 'major_c']},
         {'two': ['severe_a', 'severe_b', 'severe_c']},
         {'one': ['minor_a', 'minor_b', 'minor_c']},
         {'two': ['severe_a', 'severe_b', 'severe_c']},
     ]
+
+    assert subsets[0].names == ['prefix: major']
+    assert subsets[1].names == ['prefix: severe']
+    assert subsets[2].names == ['tables: one']
+    assert subsets[3].names == ['tables: two']
 
 
 class TestValidations(TestCase):

--- a/src/tests/architect_tests/test_feature_group_mixer.py
+++ b/src/tests/architect_tests/test_feature_group_mixer.py
@@ -1,12 +1,36 @@
 import itertools
 
 from triage.component.architect.feature_group_mixer import FeatureGroupMixer
+from triage.component.architect.feature_group_creator import FeatureGroup
+
+import pytest
 
 
-def test_feature_group_mixer_leave_one_out():
-    english_numbers = {'one': ['two', 'three'], 'four': ['five', 'six']}
-    letters = {'a': ['b', 'c'], 'd': ['e', 'f']}
-    german_numbers = {'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+@pytest.fixture
+def english_numbers():
+    return FeatureGroup(
+        name='english_numbers',
+        features_by_table={'one': ['two', 'three'], 'four': ['five', 'six']}
+    )
+
+
+@pytest.fixture
+def letters():
+    return FeatureGroup(
+        name='letters',
+        features_by_table={'a': ['b', 'c'], 'd': ['e', 'f']}
+    )
+
+
+@pytest.fixture
+def german_numbers():
+    return FeatureGroup(
+        name='german_numbers',
+        features_by_table={'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+    )
+
+
+def test_feature_group_mixer_leave_one_out(english_numbers, letters, german_numbers):
     feature_groups = [english_numbers, letters, german_numbers]
 
     result = FeatureGroupMixer(['leave-one-out']).generate(feature_groups)
@@ -16,12 +40,14 @@ def test_feature_group_mixer_leave_one_out():
         dict(itertools.chain(english_numbers.items(), letters.items())),
     ]
     assert result == expected
+    assert [g.names for g in result] == [
+        ['letters', 'german_numbers'],
+        ['english_numbers', 'german_numbers'],
+        ['english_numbers', 'letters'],
+    ]
 
 
-def test_feature_group_mixer_leave_one_in():
-    english_numbers = {'one': ['two', 'three'], 'four': ['five', 'six']}
-    letters = {'a': ['b', 'c'], 'd': ['e', 'f']}
-    german_numbers = {'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+def test_feature_group_mixer_leave_one_in(english_numbers, letters, german_numbers):
     feature_groups = [english_numbers, letters, german_numbers]
 
     result = FeatureGroupMixer(['leave-one-in']).generate(feature_groups)
@@ -31,12 +57,14 @@ def test_feature_group_mixer_leave_one_in():
         german_numbers
     ]
     assert result == expected
+    assert [g.names for g in result] == [
+        ['english_numbers'],
+        ['letters'],
+        ['german_numbers'],
+    ]
 
 
-def test_feature_group_mixer_all():
-    english_numbers = {'one': ['two', 'three'], 'four': ['five', 'six']}
-    letters = {'a': ['b', 'c'], 'd': ['e', 'f']}
-    german_numbers = {'eins': ['zwei', 'drei'], 'vier': ['funf', 'sechs']}
+def test_feature_group_mixer_all(english_numbers, letters, german_numbers):
     feature_groups = [english_numbers, letters, german_numbers]
 
     result = FeatureGroupMixer(['all']).generate(feature_groups)
@@ -44,3 +72,4 @@ def test_feature_group_mixer_all():
         dict(itertools.chain(english_numbers.items(), letters.items(), german_numbers.items())),
     ]
     assert result == expected
+    assert result[0].names == ['english_numbers', 'letters', 'german_numbers']

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from tempfile import TemporaryDirectory
 import yaml
-import logging
+
 
 import testing.postgresql
 from sqlalchemy import create_engine
@@ -187,7 +187,6 @@ def basic_integration_test(
                 dense_state_table='states',
             )
 
-
             label_generator = InspectionsLabelGenerator(
                 db_engine=db_engine,
                 events_table='events'
@@ -204,7 +203,8 @@ def basic_integration_test(
                 features_schema_name='features'
             )
 
-            feature_group_creator = FeatureGroupCreator(feature_group_create_rules)
+            feature_group_creator = FeatureGroupCreator(
+                feature_group_create_rules)
 
             feature_group_mixer = FeatureGroupMixer(feature_group_mix_rules)
 
@@ -227,7 +227,8 @@ def basic_integration_test(
 
             # chop time
             split_definitions = chopper.chop_time()
-            num_split_matrices = sum(1 + len(split['test_matrices']) for split in split_definitions)
+            num_split_matrices = sum(
+                1 + len(split['test_matrices']) for split in split_definitions)
 
             # generate as_of_times for feature/label/state generation
             all_as_of_times = []
@@ -315,12 +316,14 @@ def basic_integration_test(
                 feature_dates=all_as_of_times,
                 state_table=state_table_generator.sparse_table_name
             )
-            feature_table_agg_tasks = feature_generator.generate_all_table_tasks(aggregations, task_type='aggregation')
+            feature_table_agg_tasks = feature_generator.generate_all_table_tasks(
+                aggregations, task_type='aggregation')
 
             # create feature aggregation tables
             feature_generator.process_table_tasks(feature_table_agg_tasks)
 
-            feature_table_imp_tasks = feature_generator.generate_all_table_tasks(aggregations, task_type='imputation')
+            feature_table_imp_tasks = feature_generator.generate_all_table_tasks(
+                aggregations, task_type='imputation')
 
             # create feature imputation tables
             feature_generator.process_table_tasks(feature_table_imp_tasks)
@@ -329,7 +332,8 @@ def basic_integration_test(
             # subsetting config
             master_feature_dict = feature_dictionary_creator.feature_dictionary(
                 feature_table_names=feature_table_imp_tasks.keys(),
-                index_column_lookup=feature_generator.index_column_lookup(aggregations)
+                index_column_lookup=feature_generator.index_column_lookup(
+                    aggregations)
             )
 
             feature_dicts = feature_group_mixer.generate(
@@ -348,17 +352,23 @@ def basic_integration_test(
 
             # super basic assertion: did matrices we expect get created?
             matrix_directory = os.path.join(temp_dir, 'matrices')
-            matrices = [path for path in os.listdir(matrix_directory) if '.csv' in path]
-            metadatas = [path for path in os.listdir(matrix_directory) if '.yaml' in path]
-            assert len(matrices) == num_split_matrices * expected_matrix_multiplier
-            assert len(metadatas) == num_split_matrices * expected_matrix_multiplier
+            matrices = [path for path in os.listdir(
+                matrix_directory) if '.csv' in path]
+            metadatas = [path for path in os.listdir(
+                matrix_directory) if '.yaml' in path]
+            assert len(matrices) == num_split_matrices * \
+                expected_matrix_multiplier
+            assert len(metadatas) == num_split_matrices * \
+                expected_matrix_multiplier
             feature_group_name_lists = []
             for metadata_path in metadatas:
                 with open(os.path.join(matrix_directory, metadata_path)) as f:
                     metadata = yaml.load(f)
                     feature_group_name_lists.append(metadata['feature_groups'])
-            deep_unique_tuple = lambda l: set([tuple(i) for i in l])
-            assert deep_unique_tuple(feature_group_name_lists) == deep_unique_tuple(expected_group_lists)
+
+            def deep_unique_tuple(l): return set([tuple(i) for i in l])
+            assert deep_unique_tuple(
+                feature_group_name_lists) == deep_unique_tuple(expected_group_lists)
 
 
 def test_integration_simple():
@@ -391,5 +401,6 @@ def test_integration_feature_grouping():
         feature_group_mix_rules=['leave-one-out', 'all'],
         # 3 feature groups (cat/dog/cat+dog), so the # of matrices should be each train/test split *3
         expected_matrix_multiplier=3,
-        expected_group_lists=[['prefix: cat'], ['prefix: cat', 'prefix: dog'], ['prefix: dog']],
+        expected_group_lists=[['prefix: cat'], [
+            'prefix: cat', 'prefix: dog'], ['prefix: dog']],
     )

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -238,36 +238,6 @@ def basic_integration_test(
                     all_as_of_times.extend(test_matrix['as_of_times'])
             all_as_of_times = list(set(all_as_of_times))
 
-            feature_aggregation_config = [{
-                'prefix': 'cat',
-                'from_obj': 'cat_complaints',
-                'knowledge_date_column': 'as_of_date',
-                'aggregates': [{
-                    'quantity': 'cat_sightings',
-                    'metrics': ['count', 'avg'],
-                    'imputation': {
-                        'all': {'type': 'mean'}
-                    }
-                }],
-                'intervals': ['1y'],
-                'groups': ['entity_id']
-            }, {
-                'prefix': 'dog',
-                'from_obj': 'dog_complaints',
-                'knowledge_date_column': 'as_of_date',
-                'aggregates_imputation': {
-                    'count': {'type': 'constant', 'value': 7},
-                    'sum': {'type': 'mean'},
-                    'avg': {'type': 'zero'}
-                },
-                'aggregates': [{
-                    'quantity': 'dog_sightings',
-                    'metrics': ['count', 'avg'],
-                }],
-                'intervals': ['1y'],
-                'groups': ['entity_id']
-            }]
-
             # generate sparse state table
             state_table_generator.generate_sparse_table(
                 as_of_dates=all_as_of_times

--- a/src/tests/architect_tests/test_label_generators.py
+++ b/src/tests/architect_tests/test_label_generators.py
@@ -27,7 +27,7 @@ events_data = [
 ]
 
 
-def test_training_label_generation():
+def test_inspections_label_generation():
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         create_binary_outcome_events(engine, 'events', events_data)
@@ -36,6 +36,7 @@ def test_training_label_generation():
 
         label_generator = InspectionsLabelGenerator(
             events_table='events',
+            label_name='inspections',
             db_engine=engine
         )
         label_generator._create_labels_table(labels_table_name)
@@ -53,9 +54,9 @@ def test_training_label_generation():
 
         expected = [
             # entity_id, as_of_date, label_timespan, name, type, label
-            (1, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
-            (3, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', True),
-            (4, date(2014, 9, 30), timedelta(180), 'outcome', 'binary', False),
+            (1, date(2014, 9, 30), timedelta(180), 'inspections', 'binary', False),
+            (3, date(2014, 9, 30), timedelta(180), 'inspections', 'binary', True),
+            (4, date(2014, 9, 30), timedelta(180), 'inspections', 'binary', False),
         ]
 
         assert records == expected

--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -13,6 +13,7 @@ from triage.component.catwalk.db import ensure_db
 from triage.component.catwalk.storage import S3ModelStorageEngine, InMemoryMatrixStore
 import datetime
 import pandas
+from .utils import sample_metadata
 
 
 def test_integration():
@@ -32,17 +33,8 @@ def test_integration():
                 'feature_two': [5, 6],
                 'label': [7, 8]
             }).set_index('entity_id')
-            train_metadata = {
-                'feature_start_time': datetime.date(2012, 12, 20),
-                'end_time': datetime.date(2016, 12, 20),
-                'label_name': 'label',
-                'label_timespan': '1y',
-                'feature_names': ['ft1', 'ft2'],
-                'metta-uuid': '1234',
-                'indices': ['entity_id'],
-            }
 
-            train_store = InMemoryMatrixStore(train_matrix, train_metadata)
+            train_store = InMemoryMatrixStore(train_matrix, sample_metadata())
 
             as_of_dates = [
                 datetime.date(2016, 12, 21),
@@ -77,7 +69,6 @@ def test_integration():
                 experiment_hash=experiment_hash,
                 model_storage_engine=model_storage_engine,
                 db_engine=db_engine,
-                model_group_keys=['label_name', 'label_timespan']
             )
             predictor = Predictor(
                 project_path,

--- a/src/tests/catwalk_tests/test_model_grouping.py
+++ b/src/tests/catwalk_tests/test_model_grouping.py
@@ -1,0 +1,98 @@
+import testing.postgresql
+import datetime
+import pytest
+from copy import copy
+
+from sqlalchemy import create_engine
+from triage.component.catwalk.db import ensure_db
+
+from triage.component.catwalk.model_grouping import ModelGrouper
+from .utils import sample_metadata
+
+
+def test_model_grouping_default_config(sample_metadata):
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        ensure_db(engine)
+        model_grouper = ModelGrouper()
+        # get the basic first model group with our default matrix
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            sample_metadata,
+            engine
+        ) == 1
+
+        # the end time is not by default a model group key so changing it
+        # should still get us the same group
+        metadata_new_end_time = copy(sample_metadata)
+        metadata_new_end_time['end_time'] = datetime.date(2017, 3, 20)
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            metadata_new_end_time,
+            engine
+        ) == 1
+
+        # max_training_history is a default key,
+        # so it should trigger a new group
+        metadata_train_history = copy(sample_metadata)
+        metadata_train_history['max_training_history'] = '3y'
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            metadata_train_history,
+            engine
+        ) == 2
+
+        # classifier is of course a default key as well
+        assert model_grouper.get_model_group_id(
+            'module.OtherClassifier',
+            {'param1': 'val1'},
+            sample_metadata,
+            engine
+        ) == 3
+
+
+def test_model_grouping_custom_config(sample_metadata):
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        ensure_db(engine)
+        model_grouper = ModelGrouper(model_group_keys=['feature_names', 'as_of_date_frequency'])
+        # get the basic first model group with our default matrix
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            sample_metadata,
+            engine
+        ) == 1
+
+        # classifier is now not a key, so changing it should not get a new id
+        assert model_grouper.get_model_group_id(
+            'module.OtherClassifier',
+            {'param1': 'val1'},
+            sample_metadata,
+            engine
+        ) == 1
+
+        # as_of_date_frequency is a key,
+        # so it should trigger a new group
+        metadata_frequency = copy(sample_metadata)
+        metadata_frequency['as_of_date_frequency'] = '2w'
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            metadata_frequency,
+            engine
+        ) == 2
+
+        # testing feature names may seem redundant but it is on a separate
+        # code path so make sure its logic works
+        metadata_features = copy(sample_metadata)
+        metadata_features['feature_names'] = ['ft1', 'ft3']
+        assert model_grouper.get_model_group_id(
+            'module.Classifier',
+            {'param1': 'val1'},
+            metadata_features,
+            engine
+        ) == 3

--- a/src/tests/catwalk_tests/utils.py
+++ b/src/tests/catwalk_tests/utils.py
@@ -4,6 +4,7 @@ import random
 import tempfile
 from collections import OrderedDict
 from contextlib import contextmanager
+import pytest
 
 import numpy
 import pandas
@@ -11,7 +12,7 @@ import yaml
 from sqlalchemy.orm import sessionmaker
 
 from triage.component import metta
-from triage.component.catwalk.storage import CSVMatrixStore, HDFMatrixStore
+from triage.component.catwalk.storage import CSVMatrixStore, HDFMatrixStore, InMemoryMatrixStore
 from triage.component.results_schema import Model
 
 
@@ -68,15 +69,35 @@ def fake_trained_model(project_path, model_storage_engine, db_engine, train_matr
     return trained_model, db_model.model_id
 
 
+@pytest.fixture
 def sample_metadata():
     return {
-        'feature_start_time': datetime.date(2015, 1, 1),
-        'end_time': datetime.date(2016, 1, 1),
-        'matrix_id': 'test_matrix',
+        'feature_start_time': datetime.date(2012, 12, 20),
+        'end_time': datetime.date(2016, 12, 20),
         'label_name': 'label',
-        'label_timespan': '3month',
+        'as_of_date_frequency': '1w',
+        'max_training_history': '5y',
+        'state': 'default',
+        'cohort_name': 'default',
+        'label_timespan': '1y',
+        'metta-uuid': '1234',
+        'feature_names': ['ft1', 'ft2'],
+        'feature_groups': ['all: True'],
         'indices': ['entity_id'],
     }
+
+@pytest.fixture
+def sample_df():
+    return pandas.DataFrame.from_dict({
+        'entity_id': [1, 2],
+        'feature_one': [3, 4],
+        'feature_two': [5, 6],
+        'label': ['good', 'bad']
+    })
+
+@pytest.fixture
+def sample_matrix_store():
+   return InMemoryMatrixStore(sample_df(), sample_metadata())
 
 
 def sample_metta_csv_diff_order(directory):

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -282,3 +282,21 @@ def test_label_generation_query(experiment_class):
             )
             assert experiment.label_generator.__class__.__name__ == 'QueryBinaryLabelGenerator'
             assert experiment.label_generator.query == query
+
+
+@parametrize_experiment_classes
+def test_custom_label_name(experiment_class):
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        config = sample_config()
+        config['label_config']['name'] = 'custom_label_name'
+        with TemporaryDirectory() as temp_dir:
+            experiment = experiment_class(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+            )
+            assert experiment.label_generator.label_name == 'custom_label_name'
+            assert experiment.planner.label_names == ['custom_label_name']

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -321,7 +321,7 @@ def sample_config():
 
     return {
         'config_version': CONFIG_VERSION,
-        'label_config': {'inspection_outcomes_table': 'events'},
+        'label_config': {'name': 'custom_label_name', 'inspection_outcomes_table': 'events'},
         'entity_column_name': 'entity_id',
         'model_comment': 'test2-final-final',
         'model_group_keys': ['label_name', 'label_type', 'custom_key'],

--- a/src/triage/component/architect/feature_group_creator.py
+++ b/src/triage/component/architect/feature_group_creator.py
@@ -1,6 +1,27 @@
 import logging
 
 
+class FeatureGroup(dict):
+    def __init__(self, *args, **kwargs):
+        try:
+            self._names = [kwargs.pop('name')]
+        except KeyError:
+            self._names = []
+        try:
+            features = kwargs.pop('features_by_table')
+        except KeyError:
+            features = {}
+        super(FeatureGroup, self).__init__(*args, **features)
+
+    @property
+    def names(self):
+        return self._names
+
+    def update(self, other_group):
+        super(FeatureGroup, self).update(other_group)
+        self._names += other_group.names
+
+
 def table_subsetter(config_item, table, features):
     "Return features matching a given table"
     if table == config_item:
@@ -77,7 +98,7 @@ class FeatureGroupCreator(object):
         subsets = []
         for name, config in sorted(self.definition.items()):
             for config_item in config:
-                subset = {}
+                subset = FeatureGroup(name='{}: {}'.format(name, config_item))
                 for table, features in feature_dictionary.items():
                     matching_features =\
                         self.subsetters[name](config_item, table, features)

--- a/src/triage/component/architect/feature_group_mixer.py
+++ b/src/triage/component/architect/feature_group_mixer.py
@@ -1,4 +1,5 @@
 import logging
+from triage.component.architect.feature_group_creator import FeatureGroup
 
 
 def leave_one_in(feature_groups):
@@ -24,7 +25,7 @@ def leave_one_out(feature_groups):
     for index_to_exclude in range(0, len(feature_groups)):
         group_copy = feature_groups.copy()
         del group_copy[index_to_exclude]
-        feature_dict = {}
+        feature_dict = FeatureGroup()
         for group in group_copy:
             feature_dict.update(group)
         results.append(feature_dict)
@@ -39,7 +40,7 @@ def all_features(feature_groups):
 
     Returns: A list of feature dicts
     """
-    feature_dict = {}
+    feature_dict = FeatureGroup()
     for group in feature_groups:
         feature_dict.update(group)
     return [feature_dict]

--- a/src/triage/component/architect/planner.py
+++ b/src/triage/component/architect/planner.py
@@ -20,11 +20,13 @@ class Planner(object):
         user_metadata,
         engine,
         builder_class=builders.HighMemoryCSVBuilder,
+        cohort_name='default',
         replace=True
     ):
         self.feature_start_time = feature_start_time  # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
+        self.cohort_name = cohort_name
         self.states = states or [state_table_generators.DEFAULT_ACTIVE_STATE]
         self.db_config = db_config
         self.matrix_directory = matrix_directory
@@ -100,6 +102,7 @@ class Planner(object):
             # columns
             'indices': ['entity_id', 'as_of_date'],
             'feature_names': utils.feature_list(feature_dictionary),
+            'feature_groups': feature_dictionary.names,
             'label_name': label_name,
 
             # other information
@@ -108,6 +111,7 @@ class Planner(object):
                 'test_label_timespan',
                 matrix_definition.get('training_label_timespan', '0 days')
             ),
+            'cohort_name': self.cohort_name,
             'state': state,
             'matrix_id': matrix_id,
             'matrix_type': matrix_type

--- a/src/triage/component/catwalk/model_grouping.py
+++ b/src/triage/component/catwalk/model_grouping.py
@@ -1,0 +1,160 @@
+import copy
+import json
+import logging
+
+DEFAULT_KEYS = [
+    'label_timespan',
+    'label_name',
+    'as_of_date_frequency',
+    'max_training_history',
+    'state',
+    'cohort_name',
+    'feature_groups'
+]
+
+
+class ModelGrouper(object):
+    """Assign a model group id to given model input based on default or custom configuration
+
+    This class is a wrapper around the `get_model_group_id` stored procedure,
+    which interfaces with the model_groups table provision a stable model group id .
+    The role of this class is mainly to provide data conversion, sensible defaults, and
+    an abstraction layer over the database.
+
+    Args:
+        model_group_keys (list) A list of matrix metadata keys to uniquely define a model group.'
+            In addition, the non-matrix attributes 'class_path' and 'parameters', referring to
+            classifier training arguments, can be sent.
+    """
+    def __init__(self, model_group_keys=[]):
+        self.model_group_keys = model_group_keys
+
+    def _final_model_group_args(
+        self,
+        class_path,
+        parameters,
+        matrix_metadata,
+    ):
+        """Generates model grouping arguments based on input.
+
+        Applies a set of default or custom grouping keys depending on the object's
+        configuration.
+
+        Formats output in the structure recognized by the get_model_group_id stored procedure:
+        {
+            'class_path: (string)
+            'parameters': (dict)
+            'feature_names': (list)
+            'model_config': (dict)
+        }
+
+        Args:
+        class_path (string): a full class path for the classifier
+        parameters (dict): all hyperparameters to be passed to the classifier
+        matrix_metadata(dict): key-value pairs describing the configuration that produced
+            a matrix used for training
+
+        Returns: (dict) a dictionary of arguments suitable for the 'get_model_group_id'
+            stored procedure
+        """
+        # step 1: is there an override?
+        if len(self.model_group_keys) > 0:
+            final = {}
+            keys = copy.copy(self.model_group_keys)
+            if 'class_path' in keys:
+                final['class_path'] = class_path
+                keys.remove('class_path')
+            else:
+                final['class_path'] = ''
+
+            if 'parameters' in keys:
+                final['parameters'] = parameters
+                keys.remove('parameters')
+            else:
+                final['parameters'] = {}
+
+            if 'feature_names' in keys:
+                final['feature_names'] = matrix_metadata['feature_names']
+                keys.remove('feature_names')
+            else:
+                final['feature_names'] = []
+
+            final['model_config'] = {}
+
+            for model_group_key in keys:
+                final['model_config'][model_group_key] = matrix_metadata[model_group_key]
+
+            return final
+
+        # step 2: if no override, apply defaults
+        else:
+            model_config = {}
+            for model_group_key in DEFAULT_KEYS:
+                model_config[model_group_key] = matrix_metadata[model_group_key]
+
+            return dict(
+                class_path=class_path,
+                parameters=parameters,
+                feature_names=matrix_metadata['feature_names'],
+                model_config=model_config
+            )
+
+    def get_model_group_id(
+        self,
+        class_path,
+        parameters,
+        matrix_metadata,
+        db_engine
+    ):
+        """
+        Returns model group id using store procedure 'get_model_group_id' which will
+        return the same value for models with the same class_path, parameters,
+        features, and model_config
+
+        Args:
+            class_path (string) A full classpath to the model class
+            parameters (dict) hyperparameters to give to the model constructor
+            matrix_metadata (dict) stored metadata about the train matrix
+            db_engine (sqlalchemy.engine) A database engine pointing to a database with
+             a results.model_groups table and get_model_group_id stored procedure
+
+        Returns: (int) a database id for the model group id
+        """
+        model_group_args = self._final_model_group_args(
+            class_path,
+            parameters,
+            matrix_metadata,
+        )
+        db_conn = db_engine.raw_connection()
+        cur = db_conn.cursor()
+        cur.execute("SELECT EXISTS ( "
+                    "       SELECT * "
+                    "       FROM pg_catalog.pg_proc "
+                    "       WHERE proname = 'get_model_group_id' ) ")
+        condition = cur.fetchone()
+
+        if condition:
+            query = (
+                "SELECT get_model_group_id( "
+                "            '{class_path}'::TEXT, "
+                "            '{parameters}'::JSONB, "
+                "             ARRAY{feature_names}::TEXT [] , "
+                "            '{model_config}'::JSONB )".format(
+                    class_path=model_group_args['class_path'],
+                    parameters=json.dumps(model_group_args['parameters']),
+                    feature_names=model_group_args['feature_names'],
+                    model_config=json.dumps(model_group_args['model_config'], sort_keys=True))
+            )
+            logging.info('Getting model group from query %s', query)
+            cur.execute(query)
+            db_conn.commit()
+            model_group_id = cur.fetchone()
+            model_group_id = model_group_id[0]
+
+        else:
+            logging.info("Could not found stored procedure public.model_group_id")
+            model_group_id = None
+        db_conn.close()
+
+        logging.debug('Model_group_id = {}'.format(model_group_id))
+        return model_group_id

--- a/src/triage/component/catwalk/model_grouping.py
+++ b/src/triage/component/catwalk/model_grouping.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import logging
 
@@ -26,8 +25,8 @@ class ModelGrouper(object):
             In addition, the non-matrix attributes 'class_path' and 'parameters', referring to
             classifier training arguments, can be sent.
     """
-    def __init__(self, model_group_keys=[]):
-        self.model_group_keys = model_group_keys
+    def __init__(self, model_group_keys=()):
+        self.model_group_keys = frozenset(model_group_keys)
 
     def _final_model_group_args(
         self,
@@ -60,7 +59,7 @@ class ModelGrouper(object):
         # step 1: is there an override?
         if len(self.model_group_keys) > 0:
             final = {}
-            keys = copy.copy(self.model_group_keys)
+            keys = set(self.model_group_keys)
             if 'class_path' in keys:
                 final['class_path'] = class_path
                 keys.remove('class_path')


### PR DESCRIPTION
There are a few related changes here, with the goal of making model grouping work more effectively, with a better set of default parameters, more customization, some additional types of information available to model grouping to make them more useful, and better documentation for how it works.

1. Cohort information:
It is useful to have the definition of the experiment's cohort present in the matrix metadata, both for manual inspection purposes but also model grouping. To do this, we add a 'name' attribute to the cohort_config section of the experiment definition.

- Update ExperimentBase to send cohort_config name to Planner
- Update example_experiment_config with cohort name
- Update experiment validation to receive a new 'name

2. Label information:
It's also useful to have label definition information in the matrix metadata. There is already a place for this in the matrix metadata: the 'label_name'. However, in this past this has been hardcoded to be 'outcome'. Now, similar to cohort_config, the label_config section of the experiment definition now has a 'name' attribute that is passed through to Experiment components and ultimately stored as matrix metadata, where it is now useful for model_group_keys

- Update ExperimentBase to look for label_config->name and send the data to both Planner and LabelGenerator.
- Update BinaryLabelGenerators to receive a label_name and include it in its rows

3. Feature group information:
Although the list of feature names is already present in matrix metadata and used in model groups, these lists are often very large and it is often hard to parse more high-level information about the features from this flat list of feature names. To accomplish this, the feature grouping code had to switch from a dict-based grouping and mixing system to use a new class, the FeatureGroup, that does this but also keeps track of short names for the fgroups.

- Add FeatureGroup class that acts as a dictionary with a list of names of other FeatureGroups that it was built from, use in both FeatureGroupCreator and FeatureGroupMixer
- Update feature grouping tests to check names (plus convert common data to fixtures)

4. Getting this new information into matrices:
All routes to getting new pieces of information into matrix_metadata goes through the Planner class, so it has an updated interface and behavior to include these new keys.

- Update Planner to include cohort_name and feature_groups in matrix metadata
- Update architect integration test to verify that correct feature group names are applied to matrices
- Update planner/builder tests to verify cohort name
- Update planner/builder tests to verify feature group names

5. Update model group logic:
We want a more extensive list of default model grouping keys, one that works for most experiments without customization. So in addition to the classifier/hyperparameters/feature list, this now includes training matrix temporal information, as well as the new information behind cohorts/feature groups/etc. In addition, we want this to be more customizable, so if the user specifies a `model_group_keys` value in the experiment definition, it will replace rather than add.
This involved breaking out the model grouping functionality from the ModelTrainer class. ModelTrainer had gotten quite big, and model grouping is not necessarily coupled to training (and indeed may not be in the future). So now there is a ModelGrouper class that is passed into the ModelTrainer object as an argument.

- Add ModelGrouper class to handle model grouping logic and database access, with test
- Update example_experiment_config and algorithm doc with new behavior
- Add custom model group test case to ModelTrainer test, refactor to use fixtures to make new tests easier to build
- Update validator to contain the correct model group keys, both from this change and the recent timechop interface update