### PR TITLE
Decouple Planner from Builder [Resolves #269]

### DIFF
--- a/src/tests/architect_tests/test_builders.py
+++ b/src/tests/architect_tests/test_builders.py
@@ -10,14 +10,13 @@ from mock import Mock
 from sqlalchemy import create_engine
 
 from triage.component import metta
-from triage.component.architect import Planner, builders
+from triage.component.architect import builders
 from triage.component.architect.feature_group_creator import FeatureGroup
 
 from .utils import (
     create_schemas,
     create_entity_date_df,
     convert_string_column_to_date,
-    NamedTempFile,
     TemporaryDirectory,
 )
 
@@ -85,8 +84,8 @@ features1_pre = [
 # collate will ensure every entity/date combination in the state
 # table have an imputed value in the features table, so ensure
 # this is true for our test (filling with 9's):
-f0_dict = {(r[0], r[1]) : r for r in features0_pre}
-f1_dict = {(r[0], r[1]) : r for r in features1_pre}
+f0_dict = {(r[0], r[1]): r for r in features0_pre}
+f1_dict = {(r[0], r[1]): r for r in features1_pre}
 
 for rec in states:
     ent_dt = (rec[0], rec[1])
@@ -248,28 +247,22 @@ def test_write_to_csv():
         )
 
         with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                states = ['state_one AND state_two'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine,
-                builder_class = builders.HighMemoryCSVBuilder
+            builder = builders.HighMemoryCSVBuilder(
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                engine=engine,
             )
 
             # for each table, check that corresponding csv has the correct # of rows
             for table in features_tables:
-                planner.builder.write_to_csv(
+                builder.write_to_csv(
                     '''
                         select *
                         from features.features{}
                     '''.format(features_tables.index(table)),
                     'test_csv.csv'
                 )
-                reader = csv.reader(planner.builder.open_fh_for_reading('test_csv.csv'))
+                reader = csv.reader(builder.open_fh_for_reading('test_csv.csv'))
                 assert(len([row for row in reader]) == len(table) + 1)
 
 
@@ -304,21 +297,16 @@ def test_make_entity_date_table():
         )
 
         with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                states = ['state_one AND state_two'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine
+            builder = builders.HighMemoryCSVBuilder(
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                engine=engine
             )
             engine.execute(
                 'CREATE TABLE features.tmp_entity_date (a int, b date);'
             )
             # call the function to test the creation of the table
-            entity_date_table_name = planner.builder.make_entity_date_table(
+            entity_date_table_name = builder.make_entity_date_table(
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
@@ -330,14 +318,14 @@ def test_make_entity_date_table():
 
             # read in the table
             result = pd.read_sql(
-                "select * from features.{} order by entity_id, as_of_date".format(entity_date_table_name),
+                "select * from features.{} order by entity_id, as_of_date"
+                .format(entity_date_table_name),
                 engine
             )
-            labels_df = pd.read_sql('select * from labels.labels', engine)
-
             # compare the table to the test dataframe
             test = (result == ids_dates)
             assert(test.all().all())
+
 
 def test_write_features_data():
     dates = [datetime.datetime(2016, 1, 1, 0, 0),
@@ -360,16 +348,13 @@ def test_write_features_data():
     features_dfs = []
     for i, table in enumerate(features_tables):
         cols = ['entity_id', 'as_of_date'] + features[i]
-        temp_df = pd.DataFrame(
-            table,
-            columns = cols
-        )
+        temp_df = pd.DataFrame(table, columns=cols)
         temp_df['as_of_date'] = convert_string_column_to_date(temp_df['as_of_date'])
         features_dfs.append(
             ids_dates.merge(
-                right = temp_df,
-                how = 'left',
-                on = ['entity_id', 'as_of_date']
+                right=temp_df,
+                how='left',
+                on=['entity_id', 'as_of_date']
             )
         )
 
@@ -384,23 +369,18 @@ def test_write_features_data():
         )
 
         with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                states = ['state_one AND state_two'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine,
+            builder = builders.HighMemoryCSVBuilder(
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                engine=engine,
             )
 
             # make the entity-date table
-            entity_date_table_name = planner.builder.make_entity_date_table(
+            entity_date_table_name = builder.make_entity_date_table(
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
-                state = 'state_one AND state_two',
+                state='state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
                 label_timespan='1 month'
@@ -410,7 +390,7 @@ def test_write_features_data():
                 ('features{}'.format(i), feature_list) for i, feature_list in enumerate(features)
             )
 
-            features_csv_names = planner.builder.write_features_data(
+            features_csv_names = builder.write_features_data(
                 as_of_times=dates,
                 feature_dictionary=feature_dictionary,
                 entity_date_table_name=entity_date_table_name,
@@ -421,7 +401,7 @@ def test_write_features_data():
             for feature_csv_name, df in zip(sorted(features_csv_names), features_dfs):
                 df = df.reset_index()
 
-                result = pd.read_csv(planner.builder.open_fh_for_reading(feature_csv_name))\
+                result = pd.read_csv(builder.open_fh_for_reading(feature_csv_name))\
                     .reset_index()
                 result['as_of_date'] = convert_string_column_to_date(result['as_of_date'])
                 test = (result == df)
@@ -436,11 +416,10 @@ def test_write_labels_data():
     dates = [datetime.datetime(2016, 1, 1, 0, 0),
              datetime.datetime(2016, 2, 1, 0, 0)]
 
-
     # make a dataframe of labels to test against
     labels_df = pd.DataFrame(
         labels,
-        columns = [
+        columns=[
             'entity_id',
             'as_of_date',
             'label_timespan',
@@ -463,29 +442,24 @@ def test_write_labels_data():
             states
         )
         with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                states = ['state_one AND state_two'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = engine,
+            builder = builders.HighMemoryCSVBuilder(
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                engine=engine,
             )
 
             # make the entity-date table
-            entity_date_table_name = planner.builder.make_entity_date_table(
+            entity_date_table_name = builder.make_entity_date_table(
                 as_of_times=dates,
                 label_type='binary',
                 label_name='booking',
-                state = 'state_one AND state_two',
+                state='state_one AND state_two',
                 matrix_type='train',
                 matrix_uuid='my_uuid',
                 label_timespan='1 month'
             )
 
-            csv_filename = planner.builder.write_labels_data(
+            csv_filename = builder.write_labels_data(
                 label_name=label_name,
                 label_type=label_type,
                 label_timespan='1 month',
@@ -498,7 +472,7 @@ def test_write_labels_data():
                 'booking': [0, 0, 1, 0],
             }).set_index(['entity_id', 'as_of_date'])
 
-            result = pd.read_csv(planner.builder.open_fh_for_reading(csv_filename))\
+            result = pd.read_csv(builder.open_fh_for_reading(csv_filename))\
                 .set_index(['entity_id', 'as_of_date'])
             test = (result == df)
             assert(test.all().all())
@@ -509,15 +483,10 @@ class TestMergeFeatureCSVs(TestCase):
         """We assert column names, so replacing 'date' with 'as_of_date'
         should result in an error"""
         with TemporaryDirectory() as temp_dir:
-            planner = Planner(
-                feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                label_names = ['booking'],
-                label_types = ['binary'],
-                states = ['state_one AND state_two'],
-                db_config = db_config,
-                matrix_directory = temp_dir,
-                user_metadata = {},
-                engine = None,
+            builder = builders.HighMemoryCSVBuilder(
+                db_config=db_config,
+                matrix_directory=temp_dir,
+                engine=None,
             )
             rowlists = [
                 [
@@ -543,128 +512,17 @@ class TestMergeFeatureCSVs(TestCase):
             filekeys = []
             for rows in rowlists:
                 filekey = uuid.uuid4()
-                planner.builder.open_fh_for_writing(filekey)
+                builder.open_fh_for_writing(filekey)
                 filekeys.append(filekey)
-                writer = csv.writer(planner.builder.filehandles[filekey])
+                writer = csv.writer(builder.filehandles[filekey])
                 for row in rows:
                     writer.writerow(row)
             with self.assertRaises(KeyError):
-                planner.builder.merge_feature_csvs(
+                builder.merge_feature_csvs(
                     filekeys,
                     matrix_directory=temp_dir,
                     matrix_uuid='1234'
                 )
-
-def test_generate_plans():
-    matrix_set_definitions = [
-        {
-            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
-            'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
-            'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
-            'train_matrix': {
-                'first_as_of_time': datetime.datetime(2010, 1, 1, 0, 0),
-                'matrix_info_end_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'as_of_times': [
-                    datetime.datetime(2010, 1, 1, 0, 0),
-                    datetime.datetime(2010, 1, 2, 0, 0),
-                    datetime.datetime(2010, 1, 3, 0, 0),
-                    datetime.datetime(2010, 1, 4, 0, 0),
-                    datetime.datetime(2010, 1, 5, 0, 0)
-                ]
-            },
-            'test_matrices': [{
-                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
-                'as_of_times': [
-                    datetime.datetime(2010, 1, 6, 0, 0),
-                    datetime.datetime(2010, 1, 7, 0, 0),
-                    datetime.datetime(2010, 1, 8, 0, 0),
-                    datetime.datetime(2010, 1, 9, 0, 0),
-                    datetime.datetime(2010, 1, 10, 0, 0)
-                ]
-            }]
-        },
-        {
-            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
-            'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
-            'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
-            'train_matrix': {
-                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
-                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
-                'as_of_times': [
-                    datetime.datetime(2010, 1, 6, 0, 0),
-                    datetime.datetime(2010, 1, 7, 0, 0),
-                    datetime.datetime(2010, 1, 8, 0, 0),
-                    datetime.datetime(2010, 1, 9, 0, 0),
-                    datetime.datetime(2010, 1, 10, 0, 0)
-                ]
-            },
-            'test_matrices': [{
-                'first_as_of_time': datetime.datetime(2010, 1, 11, 0, 0),
-                'matrix_info_end_time': datetime.datetime(2010, 1, 16, 0, 0),
-                'as_of_times': [
-                    datetime.datetime(2010, 1, 11, 0, 0),
-                    datetime.datetime(2010, 1, 12, 0, 0),
-                    datetime.datetime(2010, 1, 13, 0, 0),
-                    datetime.datetime(2010, 1, 14, 0, 0),
-                    datetime.datetime(2010, 1, 15, 0, 0)
-                ]
-            }]
-        }
-    ]
-    feature_dict_one = FeatureGroup(
-        name='first_features',
-        features_by_table={'features0': ['f1', 'f2'], 'features1': ['f1', 'f2']}
-    )
-    feature_dict_two = FeatureGroup(
-        name='second_features',
-        features_by_table={'features2': ['f3', 'f4'], 'features3': ['f5', 'f6']}
-    )
-    feature_dicts = [feature_dict_one, feature_dict_two]
-    planner = Planner(
-        feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-        label_names = ['booking'],
-        label_types = ['binary'],
-        cohort_name = 'prior_bookings',
-        states = ['state_one AND state_two'],
-        db_config = db_config,
-        user_metadata = {},
-        matrix_directory = '', # this test won't write anything
-        engine = None # or look at the db!
-    )
-
-    updated_matrix_definitions, build_tasks = planner.generate_plans(matrix_set_definitions, feature_dicts)
-    # test that it added uuids: we don't much care what they are
-    matrix_uuids = []
-    for matrix_def in updated_matrix_definitions:
-        assert isinstance(matrix_def['train_uuid'], str)
-        matrix_uuids.append(matrix_def['train_uuid'])
-        for test_uuid in matrix_def['test_uuids']:
-            assert isinstance(test_uuid, str)
-    assert len(set(matrix_uuids)) == 4
-
-    # not going to assert anything on the keys (uuids), just get out the values
-    build_tasks = build_tasks.values()
-    assert len(build_tasks) == 8 # 2 splits * 2 matrices per split * 2 feature dicts
-
-    assert sum(1 for task in build_tasks if task['matrix_type'] == 'train') == 4
-    assert sum(1 for task in build_tasks if task['matrix_type'] == 'test') == 4
-    assert all(task for task in build_tasks if task['matrix_directory'] == '')
-    assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_one) == 4
-    assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_two) == 4
-    assert sum(
-        1 for task in build_tasks
-        if task['matrix_metadata']['feature_groups'] == ['first_features']
-    ) == 4
-    assert sum(
-        1 for task in build_tasks
-        if task['matrix_metadata']['feature_groups'] == ['second_features']
-    ) == 4
-    assert sum(
-        1 for task in build_tasks
-        if task['matrix_metadata']['cohort_name'] == 'prior_bookings'
-    ) == 8
-
 
 
 class TestBuildMatrix(TestCase):
@@ -684,21 +542,16 @@ class TestBuildMatrix(TestCase):
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
             with TemporaryDirectory() as temp_dir:
-                planner = Planner(
-                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                    label_names = ['booking'],
-                    label_types = ['binary'],
-                    states = ['state_one AND state_two'],
-                    db_config = db_config,
-                    matrix_directory = temp_dir,
-                    user_metadata = {},
-                    engine = engine
+                builder = builders.HighMemoryCSVBuilder(
+                    db_config=db_config,
+                    matrix_directory=temp_dir,
+                    engine=engine
                 )
                 feature_dictionary = FeatureGroup(
                     name='mygroup',
                     features_by_table={
-                    'features0': ['f1', 'f2'],
-                    'features1': ['f3', 'f4'],
+                        'features0': ['f1', 'f2'],
+                        'features1': ['f3', 'f4'],
                     }
                 )
                 matrix_metadata = {
@@ -710,15 +563,15 @@ class TestBuildMatrix(TestCase):
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
-                planner.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'train'
+                builder.build_matrix(
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='train'
                 )
 
                 matrix_filename = os.path.join(
@@ -745,22 +598,12 @@ class TestBuildMatrix(TestCase):
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
             with TemporaryDirectory() as temp_dir:
-                planner = Planner(
-                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                    label_names = ['booking'],
-                    label_types = ['binary'],
-                    states = ['state_one AND state_two'],
-                    db_config = db_config,
-                    matrix_directory = temp_dir,
-                    user_metadata = {},
-                    engine = engine
+                builder = builders.HighMemoryCSVBuilder(
+                    db_config=db_config,
+                    matrix_directory=temp_dir,
+                    engine=engine
                 )
 
-                matrix_dates = {
-                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'as_of_times': dates
-                }
                 feature_dictionary = {
                     'features0': ['f1', 'f2'],
                     'features1': ['f3', 'f4'],
@@ -774,15 +617,15 @@ class TestBuildMatrix(TestCase):
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
-                planner.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                builder.build_matrix(
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
                 matrix_filename = os.path.join(
                     temp_dir,
@@ -794,9 +637,8 @@ class TestBuildMatrix(TestCase):
                     assert(len([row for row in reader]) == 6)
 
     def test_nullcheck(self):
-        f0_dict = {(r[0], r[1]) : r for r in features0_pre}
-        f1_dict = {(r[0], r[1]) : r for r in features1_pre}
-
+        f0_dict = {(r[0], r[1]): r for r in features0_pre}
+        f1_dict = {(r[0], r[1]): r for r in features1_pre}
 
         features0 = sorted(f0_dict.values(), key=lambda x: (x[1], x[0]))
         features1 = sorted(f1_dict.values(), key=lambda x: (x[1], x[0]))
@@ -818,22 +660,12 @@ class TestBuildMatrix(TestCase):
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
             with TemporaryDirectory() as temp_dir:
-                planner = Planner(
-                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                    label_names = ['booking'],
-                    label_types = ['binary'],
-                    states = ['state_one AND state_two'],
-                    db_config = db_config,
-                    matrix_directory = temp_dir,
-                    user_metadata = {},
-                    engine = engine
+                builder = builders.HighMemoryCSVBuilder(
+                    db_config=db_config,
+                    matrix_directory=temp_dir,
+                    engine=engine
                 )
 
-                matrix_dates = {
-                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'as_of_times': dates
-                }
                 feature_dictionary = {
                     'features0': ['f1', 'f2'],
                     'features1': ['f3', 'f4'],
@@ -848,15 +680,15 @@ class TestBuildMatrix(TestCase):
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
                 with self.assertRaises(ValueError):
-                    planner.build_matrix(
-                        as_of_times = dates,
-                        label_name = 'booking',
-                        label_type = 'binary',
-                        feature_dictionary = feature_dictionary,
-                        matrix_directory = temp_dir,
-                        matrix_metadata = matrix_metadata,
-                        matrix_uuid = uuid,
-                        matrix_type = 'test'
+                    builder.build_matrix(
+                        as_of_times=dates,
+                        label_name='booking',
+                        label_type='binary',
+                        feature_dictionary=feature_dictionary,
+                        matrix_directory=temp_dir,
+                        matrix_metadata=matrix_metadata,
+                        matrix_uuid=uuid,
+                        matrix_type='test'
                     )
 
     def test_replace(self):
@@ -875,23 +707,13 @@ class TestBuildMatrix(TestCase):
                      datetime.datetime(2016, 3, 1, 0, 0)]
 
             with TemporaryDirectory() as temp_dir:
-                planner = Planner(
-                    feature_start_time = datetime.datetime(2010, 1, 1, 0, 0),
-                    label_names = ['booking'],
-                    label_types = ['binary'],
-                    states = ['state_one AND state_two'],
-                    db_config = db_config,
-                    matrix_directory = temp_dir,
-                    user_metadata = {},
-                    engine = engine,
+                builder = builders.HighMemoryCSVBuilder(
+                    db_config=db_config,
+                    matrix_directory=temp_dir,
+                    engine=engine,
                     replace=False
                 )
 
-                matrix_dates = {
-                    'first_as_of_time': datetime.datetime(2016, 1, 1, 0, 0),
-                    'matrix_info_end_time': datetime.datetime(2016, 3, 1, 0, 0),
-                    'as_of_times': dates
-                }
                 feature_dictionary = {
                     'features0': ['f1', 'f2'],
                     'features1': ['f3', 'f4'],
@@ -905,15 +727,15 @@ class TestBuildMatrix(TestCase):
                     'label_timespan': '1 month'
                 }
                 uuid = metta.generate_uuid(matrix_metadata)
-                planner.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                builder.build_matrix(
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
 
                 matrix_filename = os.path.join(
@@ -926,15 +748,15 @@ class TestBuildMatrix(TestCase):
                     assert(len([row for row in reader]) == 6)
 
                 # rerun
-                planner.builder.make_entity_date_table = Mock()
-                planner.builder.build_matrix(
-                    as_of_times = dates,
-                    label_name = 'booking',
-                    label_type = 'binary',
-                    feature_dictionary = feature_dictionary,
-                    matrix_directory = temp_dir,
-                    matrix_metadata = matrix_metadata,
-                    matrix_uuid = uuid,
-                    matrix_type = 'test'
+                builder.make_entity_date_table = Mock()
+                builder.build_matrix(
+                    as_of_times=dates,
+                    label_name='booking',
+                    label_type='binary',
+                    feature_dictionary=feature_dictionary,
+                    matrix_directory=temp_dir,
+                    matrix_metadata=matrix_metadata,
+                    matrix_uuid=uuid,
+                    matrix_type='test'
                 )
-                assert not planner.builder.make_entity_date_table.called
+                assert not builder.make_entity_date_table.called

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -18,6 +18,7 @@ from triage.component.architect.features import (
 from triage.component.architect.label_generators import InspectionsLabelGenerator
 from triage.component.architect.state_table_generators import StateTableGeneratorFromDense
 from triage.component.architect.planner import Planner
+from triage.component.architect.builders import HighMemoryCSVBuilder
 
 
 def populate_source_data(db_engine):
@@ -209,10 +210,16 @@ def basic_integration_test(
             feature_group_mixer = FeatureGroupMixer(feature_group_mix_rules)
 
             planner = Planner(
-                engine=db_engine,
                 feature_start_time=datetime(2010, 1, 1),
                 label_names=['outcome'],
                 label_types=['binary'],
+                matrix_directory=os.path.join(temp_dir, 'matrices'),
+                states=state_filters,
+                user_metadata={},
+            )
+
+            builder = HighMemoryCSVBuilder(
+                engine=db_engine,
                 db_config={
                     'features_schema_name': 'features',
                     'labels_schema_name': 'public',
@@ -220,8 +227,6 @@ def basic_integration_test(
                     'sparse_state_table_name': 'tmp_sparse_states_abcd',
                 },
                 matrix_directory=os.path.join(temp_dir, 'matrices'),
-                states=state_filters,
-                user_metadata={},
                 replace=True
             )
 
@@ -318,7 +323,7 @@ def basic_integration_test(
                 )
 
             # go and build the matrices
-            planner.build_all_matrices(matrix_build_tasks)
+            builder.build_all_matrices(matrix_build_tasks)
 
             # super basic assertion: did matrices we expect get created?
             matrix_directory = os.path.join(temp_dir, 'matrices')

--- a/src/tests/architect_tests/test_planner.py
+++ b/src/tests/architect_tests/test_planner.py
@@ -1,0 +1,114 @@
+import datetime
+
+from triage.component.architect import Planner
+from triage.component.architect.feature_group_creator import FeatureGroup
+
+
+def test_Planner():
+    matrix_set_definitions = [
+        {
+            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
+            'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
+            'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+            'train_matrix': {
+                'first_as_of_time': datetime.datetime(2010, 1, 1, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'as_of_times': [
+                    datetime.datetime(2010, 1, 1, 0, 0),
+                    datetime.datetime(2010, 1, 2, 0, 0),
+                    datetime.datetime(2010, 1, 3, 0, 0),
+                    datetime.datetime(2010, 1, 4, 0, 0),
+                    datetime.datetime(2010, 1, 5, 0, 0)
+                ]
+            },
+            'test_matrices': [{
+                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'as_of_times': [
+                    datetime.datetime(2010, 1, 6, 0, 0),
+                    datetime.datetime(2010, 1, 7, 0, 0),
+                    datetime.datetime(2010, 1, 8, 0, 0),
+                    datetime.datetime(2010, 1, 9, 0, 0),
+                    datetime.datetime(2010, 1, 10, 0, 0)
+                ]
+            }]
+        },
+        {
+            'feature_start_time': datetime.datetime(1990, 1, 1, 0, 0),
+            'modeling_start_time': datetime.datetime(2010, 1, 1, 0, 0),
+            'modeling_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+            'train_matrix': {
+                'first_as_of_time': datetime.datetime(2010, 1, 6, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'as_of_times': [
+                    datetime.datetime(2010, 1, 6, 0, 0),
+                    datetime.datetime(2010, 1, 7, 0, 0),
+                    datetime.datetime(2010, 1, 8, 0, 0),
+                    datetime.datetime(2010, 1, 9, 0, 0),
+                    datetime.datetime(2010, 1, 10, 0, 0)
+                ]
+            },
+            'test_matrices': [{
+                'first_as_of_time': datetime.datetime(2010, 1, 11, 0, 0),
+                'matrix_info_end_time': datetime.datetime(2010, 1, 16, 0, 0),
+                'as_of_times': [
+                    datetime.datetime(2010, 1, 11, 0, 0),
+                    datetime.datetime(2010, 1, 12, 0, 0),
+                    datetime.datetime(2010, 1, 13, 0, 0),
+                    datetime.datetime(2010, 1, 14, 0, 0),
+                    datetime.datetime(2010, 1, 15, 0, 0)
+                ]
+            }]
+        }
+    ]
+    feature_dict_one = FeatureGroup(
+        name='first_features',
+        features_by_table={'features0': ['f1', 'f2'], 'features1': ['f1', 'f2']}
+    )
+    feature_dict_two = FeatureGroup(
+        name='second_features',
+        features_by_table={'features2': ['f3', 'f4'], 'features3': ['f5', 'f6']}
+    )
+    feature_dicts = [feature_dict_one, feature_dict_two]
+    planner = Planner(
+        feature_start_time=datetime.datetime(2010, 1, 1, 0, 0),
+        label_names=['booking'],
+        label_types=['binary'],
+        cohort_name='prior_bookings',
+        states=['state_one AND state_two'],
+        user_metadata={},
+        matrix_directory='',  # this test won't write anything
+    )
+
+    updated_matrix_definitions, build_tasks = \
+        planner.generate_plans(matrix_set_definitions, feature_dicts)
+    # test that it added uuids: we don't much care what they are
+    matrix_uuids = []
+    for matrix_def in updated_matrix_definitions:
+        assert isinstance(matrix_def['train_uuid'], str)
+        matrix_uuids.append(matrix_def['train_uuid'])
+        for test_uuid in matrix_def['test_uuids']:
+            assert isinstance(test_uuid, str)
+    assert len(set(matrix_uuids)) == 4
+
+    # not going to assert anything on the keys (uuids), just get out the values
+    build_tasks = build_tasks.values()
+    assert len(build_tasks) == 8  # 2 splits * 2 matrices per split * 2 feature dicts
+
+    assert sum(1 for task in build_tasks if task['matrix_type'] == 'train') == 4
+    assert sum(1 for task in build_tasks if task['matrix_type'] == 'test') == 4
+    assert all(task for task in build_tasks if task['matrix_directory'] == '')
+    assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_one) == 4
+    assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_two) == 4
+    assert sum(
+        1 for task in build_tasks
+        if task['matrix_metadata']['feature_groups'] == ['first_features']
+    ) == 4
+    assert sum(
+        1 for task in build_tasks
+        if task['matrix_metadata']['feature_groups'] == ['second_features']
+    ) == 4
+    assert sum(
+        1 for task in build_tasks
+        if task['matrix_metadata']['cohort_name'] == 'prior_bookings'
+    ) == 8

--- a/src/triage/component/architect/planner.py
+++ b/src/triage/component/architect/planner.py
@@ -4,7 +4,7 @@ import logging
 
 from triage.component import metta
 
-from . import builders, utils, state_table_generators
+from . import utils, state_table_generators
 
 
 class Planner(object):
@@ -15,33 +15,17 @@ class Planner(object):
         label_names,
         label_types,
         states,
-        db_config,
         matrix_directory,
         user_metadata,
-        engine,
-        builder_class=builders.HighMemoryCSVBuilder,
         cohort_name='default',
-        replace=True
     ):
         self.feature_start_time = feature_start_time  # earliest time included in features
         self.label_names = label_names
         self.label_types = label_types
         self.cohort_name = cohort_name
         self.states = states or [state_table_generators.DEFAULT_ACTIVE_STATE]
-        self.db_config = db_config
         self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata
-        self.engine = engine
-        self.replace = replace
-        self.builder = builder_class(
-            db_config,
-            matrix_directory,
-            engine,
-            replace
-        )
-
-    def validate(self):
-        self.builder.validate()
 
     def _generate_build_task(
         self,
@@ -220,10 +204,3 @@ class Planner(object):
             len(build_tasks.keys())
         )
         return updated_definitions, build_tasks
-
-    def build_all_matrices(self, *args, **kwargs):
-        self.builder.build_all_matrices(*args, **kwargs)
-
-    def build_matrix(self, *args, **kwargs):
-        logging.info(f"Building matrix with {args}, {kwargs}")
-        self.builder.build_matrix(*args, **kwargs)

--- a/src/triage/experiments/multicore.py
+++ b/src/triage/experiments/multicore.py
@@ -164,7 +164,7 @@ class MultiCoreExperiment(ExperimentBase):
 
         partial_build_matrix = partial(
             build_matrix,
-            planner_factory=self.planner_factory,
+            matrix_builder_factory=self.matrix_builder_factory,
             db_connection_string=self.db_engine.url
         )
         logging.info(
@@ -211,15 +211,15 @@ def insert_into_table(
 
 def build_matrix(
     build_tasks,
-    planner_factory,
+    matrix_builder_factory,
     db_connection_string,
 ):
     try:
         db_engine = create_engine(db_connection_string)
-        planner = planner_factory(engine=db_engine)
+        builder = matrix_builder_factory(engine=db_engine)
 
         for i, build_task in enumerate(build_tasks):
-            planner.build_matrix(**build_task)
+            builder.build_matrix(**build_task)
 
         return True
     except Exception:

--- a/src/triage/experiments/singlethreaded.py
+++ b/src/triage/experiments/singlethreaded.py
@@ -14,7 +14,7 @@ class SingleThreadedExperiment(ExperimentBase):
         logging.info('Creating feature imputation tables')
         self.feature_generator.process_table_tasks(self.feature_imputation_table_tasks)
         logging.info('Building all matrices')
-        self.planner.build_all_matrices(self.matrix_build_tasks)
+        self.matrix_builder.build_all_matrices(self.matrix_build_tasks)
 
     def catwalk(self):
         for split_num, split in enumerate(self.full_matrix_definitions):


### PR DESCRIPTION
Once upon a time, the Planner and Builder classes lived in one Timechop class called 'The Architect'. Eventually, the different functionalities (figuring out and deduping what matrices needed to be built, and then building matrices one-by-one) diverged into the two classes you see today, but to support backwards compatibility Planner delegated the building itself to Builder, as opposed to letting the Experiment have its own reference to a builder. This half-solution has lived on for far too long. We will be making much more changes in the builder soon, and it'll be easier to work on in its proper place.

- Remove builder delegation methods from Planner
- Create matrix builder in Experiment, and call build_matrix/build_all_matrices directly from experiments
- Split test_planner_builders into test_planner and test_builders