### PR TITLE
Generalize labels interface to query

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -28,26 +28,58 @@ temporal_config:
     training_label_timespans: ['1month'] # time period across which outcomes are labeled in train matrices
     test_label_timespans: ['7day'] # time period across which outcomes are labeled in test matrices
 
+
+# COHORT CONFIG
+# To define what entities make it into different matrices, there are three options (only choose one).
+#
+# 1. Pass an entities table. All distinct entities present in this table (the 'entity_id' column) will be included in all matrices. Other columns will be ignored
+#
+# 2. Pass a query, parameterized with an '{as_of_date}', to select the entity_ids that should be included for a given date. The {as_of_date} will be replaced with each as_of_date that the experiment needs.
+#
+# 3. Pass a dense states table, and information about which state filters to use in this experiment
+#
+#   a. a dense state table that defines when entities were in specific states
+#       should have columns entity_id/state/start time/end time
+#       Note that the time columns are timestamps, not dates. So if you would like
+#       to signify that an entity is in a state for an entire day, make the start
+#       the beginning of the day and the end a day later.
+#   b. a list of state filtering SQL clauses to iterate through. Assuming the
+#       states are boolean columns (the experiment will convert the one you pass in
+#       to this format), write a SQL expression for each state
+#       configuration you want, ie '(permitted OR suspended) AND licensed'
+#
+#
+# Regardless of which method you choose, you may enter a 'name' for your configuration.
+# This will be included in the metadata for each matrix and used to group models
+# If you don't pass one, the string 'default' will be used.
+#
+cohort_config:
+#   entities_table: 'events'
+#   dense_states:
+#        table_name: 'states'
+#        state_filters:
+#        - 'state_one AND state_two'
+#        - '(state_one OR state_two) AND state_three'
+    query: "select entity_id from events where outcome_date < '{as_of_date}'"
+    name: 'past_events'
+
+
 # LABEL GENERATION
-# There are two ways to configure label generation, choose only one:
+# Labels are configured by passing a query with placeholders for the 'as_of_date' and 'label_timespan'.
 #
-# 1. Pass a table of inspection outcomes
-#   An events table is expected, with the columns:
-#       entity_id - an identifier for which the labels are applied to
-#       outcome_date - The date at which some outcome was known
-#       outcome - A boolean outcome
-#   The label for any label timespan will be True if *any* inspection outcomes
-#   for that entity in that timespan are True.
+# The query must return two columns: entity_id and outcome, based on a given as_of_date and label_timespan.
+# The as_of_date and label_timespan must be represented by placeholders marked by curly brackets. The example below
+# reproduces the inspection outcome boolean-or logic:
 #
-# 2. Pass a query that returns two columns: entity_id and outcome, based on a given as_of_date and label_timespan.
-#   The as_of_date and label_timespan must be represented by placeholders marked by curly brackets. The example below
-#   reproduces the inspection outcome boolean-or logic:
+# In addition, you can configure what label is given to entities that are in the matrix
+#   (see 'cohort_config' section) but that do not show up in this label query.
+# By default, these will show up as missing/null.
+# However, passing the key 'include_missing_labels_in_train_as' allows you to pick True or False.
 #
 # In addition to these configuration options, you can pass a name to apply to the label configuration
 # that will be present in matrix metadata for each matrix created by this experiment,
 # under the 'label_name' key. The default label_name is 'outcome'.
 label_config:
-    inspection_outcomes_table: 'events'
     query: |
         select
         events.entity_id,
@@ -56,6 +88,7 @@ label_config:
         where '{as_of_date}' <= outcome_date
             and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
             group by entity_id
+    #include_missing_labels_in_train_as: False
     #name: 'inspections'
 
 
@@ -203,39 +236,6 @@ feature_group_definition:
 # available: all, leave-one-out, leave-one-in
 feature_group_strategies: ['all']
 
-# COHORT CONFIG
-# To define what entities make it into different matrices, there are three options (only choose one).
-#
-# 1. Pass an entities table. All distinct entities present in this table (the 'entity_id' column) will be included in all matrices. Other columns will be ignored
-#
-# 2. Pass a query, parameterized with an '{as_of_date}', to select the entity_ids that should be included for a given date. The {as_of_date} will be replaced with each as_of_date that the experiment needs.
-#
-# 3. Pass a dense states table, and information about which state filters to use in this experiment
-#
-#   a. a dense state table that defines when entities were in specific states
-#       should have columns entity_id/state/start time/end time
-#       Note that the time columns are timestamps, not dates. So if you would like
-#       to signify that an entity is in a state for an entire day, make the start
-#       the beginning of the day and the end a day later.
-#   b. a list of state filtering SQL clauses to iterate through. Assuming the
-#       states are boolean columns (the experiment will convert the one you pass in
-#       to this format), write a SQL expression for each state
-#       configuration you want, ie '(permitted OR suspended) AND licensed'
-#
-#
-# Regardless of which method you choose, you may enter a 'name' for your configuration.
-# This will be included in the metadata for each matrix and used to group models
-# If you don't pass one, the string 'default' will be used.
-l#
-cohort_config:
-#   entities_table: 'events'
-#   dense_states:
-#        table_name: 'states'
-#        state_filters:
-#        - 'state_one AND state_two'
-#        - '(state_one OR state_two) AND state_three'
-    query: "select entity_id from events where outcome_date < '{as_of_date}'"
-    name: 'past_events'
 
 # USER METADATA
 # These are arbitrary keys/values that you can have Triage apply to the

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -15,10 +15,12 @@ from triage.component.architect.features import (
     FeatureGroupCreator,
     FeatureGroupMixer,
 )
-from triage.component.architect.label_generators import InspectionsLabelGenerator
+from triage.component.architect.label_generators import LabelGenerator
 from triage.component.architect.state_table_generators import StateTableGeneratorFromDense
 from triage.component.architect.planner import Planner
 from triage.component.architect.builders import HighMemoryCSVBuilder
+
+from tests.utils import sample_config
 
 
 def populate_source_data(db_engine):
@@ -188,9 +190,9 @@ def basic_integration_test(
                 dense_state_table='states',
             )
 
-            label_generator = InspectionsLabelGenerator(
+            label_generator = LabelGenerator(
                 db_engine=db_engine,
-                events_table='events'
+                query=sample_config()['label_config']['query']
             )
 
             feature_generator = FeatureGenerator(

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -258,33 +258,6 @@ def test_build_error_cleanup_timeout(_clean_up_mock, experiment_class):
 
 
 @parametrize_experiment_classes
-def test_label_generation_query(experiment_class):
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        config = sample_config()
-        query = '''
-        select
-        events.entity_id,
-        bool_or(outcome::bool)::integer as outcome
-        from events
-        where '{as_of_date}' <= outcome_date
-            and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
-            group by entity_id
-        '''
-        config['label_config'] = {'query': query}
-        with TemporaryDirectory() as temp_dir:
-            experiment = experiment_class(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-            )
-            assert experiment.label_generator.__class__.__name__ == 'QueryBinaryLabelGenerator'
-            assert experiment.label_generator.query == query
-
-
-@parametrize_experiment_classes
 def test_custom_label_name(experiment_class):
     with testing.postgresql.Postgresql() as postgresql:
         db_engine = create_engine(postgresql.url())

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -319,9 +319,23 @@ def sample_config():
         }
     }
 
+    label_config = {
+        'query': """
+            select
+            events.entity_id,
+            bool_or(outcome::bool)::integer as outcome
+            from events
+            where '{as_of_date}'::date <= outcome_date
+                and outcome_date < '{as_of_date}'::date + interval '{label_timespan}'
+                group by entity_id
+        """,
+        'name': 'custom_label_name',
+        'include_missing_labels_in_train_as': False,
+    }
+
     return {
         'config_version': CONFIG_VERSION,
-        'label_config': {'name': 'custom_label_name', 'inspection_outcomes_table': 'events'},
+        'label_config': label_config,
         'entity_column_name': 'entity_id',
         'model_comment': 'test2-final-final',
         'model_group_keys': ['label_name', 'label_type', 'custom_key'],

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -10,11 +10,19 @@ from triage.component import metta
 
 
 class BuilderBase(object):
-    def __init__(self, db_config, matrix_directory, engine, replace=True):
+    def __init__(
+        self,
+        db_config,
+        matrix_directory,
+        engine,
+        replace=True,
+        include_missing_labels_in_train_as=None,
+    ):
         self.db_config = db_config
         self.matrix_directory = matrix_directory
         self.engine = engine
         self.replace = replace
+        self.include_missing_labels_in_train_as = include_missing_labels_in_train_as
 
     def validate(self):
         for expected_db_config_val in [
@@ -112,18 +120,18 @@ class BuilderBase(object):
         """
 
         as_of_time_strings = [str(as_of_time) for as_of_time in as_of_times]
-        if matrix_type == 'train':
+        if matrix_type == 'test' or self.include_missing_labels_in_train_as is not None:
+            indices_query = self._all_valid_entity_dates_query(
+                as_of_time_strings=as_of_time_strings,
+                state=state
+            )
+        elif matrix_type == 'train':
             indices_query = self._all_labeled_entity_dates_query(
                 as_of_time_strings=as_of_time_strings,
                 state=state,
                 label_name=label_name,
                 label_type=label_type,
                 label_timespan=label_timespan
-            )
-        elif matrix_type == 'test':
-            indices_query = self._all_valid_entity_dates_query(
-                as_of_time_strings=as_of_time_strings,
-                state=state
             )
         else:
             raise ValueError('Unknown matrix type passed: {}'.format(matrix_type))
@@ -338,6 +346,19 @@ class CSVBuilder(BuilderBase):
             self.matrix_directory,
             '{}-{}.csv'.format(matrix_uuid, self.db_config['labels_table_name'])
         )
+        if self.include_missing_labels_in_train_as is None:
+            label_predicate = 'r.label'
+        elif self.include_missing_labels_in_train_as is False:
+            label_predicate = 'coalesce(r.label, 0)'
+        elif self.include_missing_labels_in_train_as is True:
+            label_predicate = 'coalesce(r.label, 1)'
+        else:
+            raise ValueError(
+                'incorrect value "{}" for include_missing_labels_in_train_as'.format(
+                    self.include_missing_labels_in_train_as
+                )
+            )
+
         labels_query = self._outer_join_query(
             right_table_name='{schema}.{table}'.format(
                 schema=self.db_config['labels_schema_name'],
@@ -347,7 +368,7 @@ class CSVBuilder(BuilderBase):
                 schema=self.db_config['features_schema_name'],
                 table=entity_date_table_name
             ),
-            right_column_selections=', r.label as {}'.format(label_name),
+            right_column_selections=', {} as {}'.format(label_predicate, label_name),
             additional_conditions='''AND
                 r.label_name = '{name}' AND
                 r.label_type = '{type}' AND


### PR DESCRIPTION
After internal discussion, it seems that the planned early warning and inspections on-rails label generators are not the direction we want to go. They require too much preprocessing to be used in most cases. The parameterized query is more generally usable, and any transformations needed are transparent in the query. It's easy to implement early warning or inspections on an external layer.

The new label config interface has three keys: a query, a fill-missing behavior (True or False; the absense of the key will leave missing labels as missing), and a name that will go in matrix metadata.

- Replace label generator inheritence with one class that takes a query
- Allow passing of fill-missing behavior for labels in config, to allow early warning style labels [Resolves #281]