### PR TITLE
Enable calling of .run() with only partial binding

### DIFF
--- a/docs/sources/experiments/running.md
+++ b/docs/sources/experiments/running.md
@@ -58,9 +58,46 @@ With that in mind, a more full version of the experiment instantiation might loo
     )
 ```
 
+## Running an Experiment
+
+Once you're at this point, running the experiment is simple:
+
+```
+    experiment.run()
+```
+
+This will run the entire experiment. This could take a while, so we recommend checking logging messages (INFO level will catch a lot of useful information) and keeping an eye on its progress.
+
+## Running parts of an Experiment
+
+If you would like incrementally build, or just incrementally run parts of the Experiment look at their outputs, you can do so. Running a full experiment requires the [experiment config](example_experiment_config.yaml) to be filled out, but when you're getting started using Triage it can be easier to build the experiment piece by piece and see the results as they come in. Make sure logging is set to INFO level before running this to ensure you get all the log messages.
+
+
+1. `experiment.run()` will run until it no longer has enough configuration to proceed. You will see information in the logs telling you about the steps it was able to perform. If you initialize the Experiment with `cleanup=False`, you can view the intermediate tables that are built. They are modified with the experiment hash that the experiment calculates, but this will be printed out in the log messages.
+
+	- `labels_*<experiment_hash>*` for the labels generated per entity and as of date.
+	- `tmp_sparse_states_*<experiment_hash>*` for the membership in each cohort per entity and as_of_date
+
+2. To reproduce the entire Experiment piece by piece, you can run the following. Each one of these methods requires some portion of [experiment config](example_experiment_config.yaml) to be passed:
+
+	- `experiment.split_definitions` will parse temporal config and create time splits. It only requires `temporal_config`.
+
+	- `experiment.generate_cohort()` will use the cohort config and as of dates from the temporal config to generate an internal table keeping track of what entities are in the cohort on different dates. It requires `temporal_config` and `cohort_config`.
+
+	- `experiment.generate_labels()` will use the label config and as of dates from the temporal config to generate an internal labels table. It requires `temporal_config` and `label_config`.
+
+	- `experiment.generate_preimputation_features()` will use the feature aggregation config and as of dates from the temporal config to generate internal features tables. It requires `temporal_config` and `feature_aggregations`.
+
+	- `experiment.generate_imputed_features()` will use the imputation sections of the feature aggregation config and the results from the preimputed features to create internal imputed features tables. It requires `temporal_config` and `feature_aggregations`.
+
+	- `experiment.build_matrices()` will use all of the internal tables generated before this point, along with feature grouping config, to generate all needed matrices.  It requires `temporal_config`, `cohort_config`, `label_config`, and `feature_aggregations`, though it will also use `feature_group_definitions`, `feature_group_strategies`, and `user_metadata` if present.
+
+	- `experiment.train_and_test_models()` will use the generated matrices, grid config and evaluation metric config to train and test all needed models. It requires all configuration keys.
+
+
 ## Validating an Experiment
 
-Configuring an experiment is very complicated, and running an experiment can take a long time as data scales up. If there are any misconfigured values, it's going to help out a lot to figure out what they are before we run the Experiment. So we recommend running the `.validate()` method on the Experiment first. If any problems are detectable in your Experiment, either in configuration or the database tables referenced by it, this method will throw an exception. For instance, if I refer to the 'cat_complaints' table in a feature aggregation but it doesn't exist, I'll see something like this:
+Configuring an experiment is very complicated, and running an experiment can take a long time as data scales up. If there are any misconfigured values, it's going to help out a lot to figure out what they are before we run the Experiment. So when you have completed your experiment config and want to test it out, we recommend running the `.validate()` method on the Experiment first. If any problems are detectable in your Experiment, either in configuration or the database tables referenced by it, this method will throw an exception. For instance, if I refer to the 'cat_complaints' table in a feature aggregation but it doesn't exist, I'll see something like this:
 
 ```
     experiment.validate()
@@ -79,33 +116,6 @@ If the validation runs without any errors, you should see a success message (eit
 We'd like to add more validations for common misconfiguration problems over time. If you got an unexpected error that turned out to be related to a confusing configuration value, help us out by adding to the [validation module](triage/experiments/validate.py) and submitting a pull request!
 
 
-## Running an Experiment
-
-Once you're at this point, running the experiment is simple:
-
-```
-    experiment.run()
-```
-
-This will run the entire experiment. This could take a while, so we recommend checking logging messages (INFO level will catch a lot of useful information) and keeping an eye on its progress.
-
-## Running parts of an Experiment
-
-If you would like to run parts of the Experiment one by one and look at their outputs, you can do so. To reproduce the entire Experiment piece by piece, you can run the following:
-
-- `experiment.split_definitions` will parse temporal config and create time splits.
-
-- `experiment.generate_sparse_states()` will use the cohort config and as of dates from the temporal config to generate an internal table keeping track of what entities are in the cohort on different dates.
-
-- `experiment.generate_labels()` will use the label config and as of dates from the temporal config to generate an internal labels table.
-
-- `experiment.generate_preimputation_features()` will use the feature aggregation config and as of dates from the temporal config to generate internal features tables.
-
-- `experiment.generate_imputed_features()` will use the imputation sections of the feature aggregation config and the results from the preimputed features to create internal imputed features tables
-
-- `experiment.build_matrices()` will use all of the internal tables generated before this point, along with feature grouping config, to generate all needed matrices.
-
-- `experiment.train_and_test_models()` will use the generated matrices, grid config and evaluation metric config to train and test all needed models.
 
 
 ## Evaluating results of an Experiment

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -53,7 +53,8 @@ def test_simple_experiment(experiment_class):
                 config=sample_config(),
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections')
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True,
             ).run()
 
         # assert
@@ -152,6 +153,7 @@ def test_restart_experiment(experiment_class):
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
                 project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True
             )
             experiment.run()
 
@@ -163,6 +165,7 @@ def test_restart_experiment(experiment_class):
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
                 project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True,
                 replace=False
             )
             experiment.make_entity_date_table = mock.Mock()

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -216,6 +216,7 @@ def test_cleanup_timeout(_clean_up_mock, experiment_class):
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
                 project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True,
                 cleanup_timeout=0.02,  # Set short timeout
             )
             with pytest.raises(TimeoutError):
@@ -234,6 +235,7 @@ def test_build_error(experiment_class):
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
                 project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True,
             )
 
             with mock.patch.object(experiment, 'generate_matrices') as build_mock:
@@ -258,6 +260,7 @@ def test_build_error_cleanup_timeout(_clean_up_mock, experiment_class):
                 db_engine=db_engine,
                 model_storage_class=FSModelStorageEngine,
                 project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=True,
                 cleanup_timeout=0.02,  # Set short timeout
             )
 

--- a/src/tests/test_partial_experiments.py
+++ b/src/tests/test_partial_experiments.py
@@ -13,17 +13,17 @@ from tests.utils import sample_config, populate_source_data
 from triage.experiments import SingleThreadedExperiment
 from triage.database_reflection import schema_tables
 from triage.validation_primitives import table_should_have_data
+from unittest import TestCase
+from contextlib import contextmanager
 
 
 import logging
 logging.basicConfig(level=logging.INFO)
 
-def test_get_splits():
+
+@contextmanager
+def prepare_experiment(config):
     with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'config_version': sample_config()['config_version']
-        }
         db_engine = create_engine(postgresql.url())
         ensure_db(db_engine)
         populate_source_data(db_engine)
@@ -35,140 +35,163 @@ def test_get_splits():
                 project_path=os.path.join(temp_dir, 'inspections'),
                 cleanup=False
             )
+            yield experiment
+
+
+class GetSplits(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
             assert experiment.split_definitions
 
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
 
-def test_cohort():
-    with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'cohort_config': sample_config()['cohort_config'],
-            'config_version': sample_config()['config_version']
-        }
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        populate_source_data(db_engine)
-        with TemporaryDirectory() as temp_dir:
-            experiment = SingleThreadedExperiment(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-                cleanup=False
-            )
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()
+
+
+class Cohort(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'cohort_config': sample_config()['cohort_config'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
-            table_should_have_data(experiment.sparse_states_table_name, db_engine)
+            table_should_have_data(experiment.sparse_states_table_name, experiment.db_engine)
+
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
+
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()
 
 
-def test_labels():
-    with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'label_config': sample_config()['label_config'],
-            'config_version': sample_config()['config_version']
-        }
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        populate_source_data(db_engine)
-        with TemporaryDirectory() as temp_dir:
-            experiment = SingleThreadedExperiment(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-                cleanup=False
-            )
+class Labels(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'label_config': sample_config()['label_config'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
-            table_should_have_data(experiment.labels_table_name, db_engine)
+            table_should_have_data(experiment.labels_table_name, experiment.db_engine)
+
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
+
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()
 
 
-def test_preimputation_features():
-    with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'feature_aggregations': sample_config()['feature_aggregations'],
-            'config_version': sample_config()['config_version']
-        }
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        populate_source_data(db_engine)
-        with TemporaryDirectory() as temp_dir:
-            experiment = SingleThreadedExperiment(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-                cleanup=False
-            )
+class PreimputationFeatures(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'feature_aggregations': sample_config()['feature_aggregations'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
             generated_tables = [
                 table
-                for table in schema_tables(experiment.features_schema_name, db_engine).keys()
+                for table in schema_tables(
+                    experiment.features_schema_name,
+                    experiment.db_engine
+                ).keys()
                 if '_aggregation' in table
             ]
 
             assert len(generated_tables) == len(sample_config()['feature_aggregations'])
             for table in generated_tables:
-                table_should_have_data(table, db_engine)
+                table_should_have_data(table, experiment.db_engine)
+
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
+
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()
 
 
-def test_postimputation_features():
-    with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'feature_aggregations': sample_config()['feature_aggregations'],
-            'cohort_config': sample_config()['cohort_config'],
-            'config_version': sample_config()['config_version']
-        }
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        populate_source_data(db_engine)
-        with TemporaryDirectory() as temp_dir:
-            experiment = SingleThreadedExperiment(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-                cleanup=False
-            )
+class PostimputationFeatures(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'feature_aggregations': sample_config()['feature_aggregations'],
+        'cohort_config': sample_config()['cohort_config'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
             generated_tables = [
                 table
-                for table in schema_tables(experiment.features_schema_name, db_engine).keys()
+                for table in schema_tables(experiment.features_schema_name, experiment.db_engine).keys()
                 if '_aggregation_imputed' in table
             ]
 
             assert len(generated_tables) == len(sample_config()['feature_aggregations'])
             for table in generated_tables:
-                table_should_have_data(table, db_engine)
+                table_should_have_data(table, experiment.db_engine)
+
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
+
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()
 
 
-def test_generate_matrices():
-    with testing.postgresql.Postgresql() as postgresql:
-        config = {
-            'temporal_config': sample_config()['temporal_config'],
-            'feature_aggregations': sample_config()['feature_aggregations'],
-            'cohort_config': sample_config()['cohort_config'],
-            'label_config': sample_config()['label_config'],
-            'config_version': sample_config()['config_version']
-        }
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        populate_source_data(db_engine)
-        with TemporaryDirectory() as temp_dir:
-            experiment = SingleThreadedExperiment(
-                config=config,
-                db_engine=db_engine,
-                model_storage_class=FSModelStorageEngine,
-                project_path=os.path.join(temp_dir, 'inspections'),
-                cleanup=False
-            )
+class Matrices(TestCase):
+    config = {
+        'temporal_config': sample_config()['temporal_config'],
+        'feature_aggregations': sample_config()['feature_aggregations'],
+        'cohort_config': sample_config()['cohort_config'],
+        'label_config': sample_config()['label_config'],
+        'config_version': sample_config()['config_version']
+    }
+
+    def test_run(self):
+        with prepare_experiment(self.config) as experiment:
             experiment.run()
-            matrices_path = os.path.join(temp_dir, 'inspections', 'matrices')
+            matrices_path = experiment.matrices_directory
             matrices_and_metadata = [f for f in os.listdir(matrices_path) if isfile(join(matrices_path, f))]
             matrices = experiment.matrix_build_tasks
             assert len(matrices) > 0
             for matrix in matrices:
                 assert '{}.csv'.format(matrix) in matrices_and_metadata
                 assert '{}.yaml'.format(matrix) in matrices_and_metadata
+
+    def test_validate_nonstrict(self):
+        with prepare_experiment(self.config) as experiment:
+            experiment.validate(strict=False)
+
+    def test_validate_strict(self):
+        with prepare_experiment(self.config) as experiment:
+            with self.assertRaises(ValueError):
+                experiment.validate()

--- a/src/tests/test_partial_experiments.py
+++ b/src/tests/test_partial_experiments.py
@@ -1,0 +1,174 @@
+import os
+from os.path import isfile, join
+from tempfile import TemporaryDirectory
+
+import testing.postgresql
+from triage import create_engine
+
+from triage.component.catwalk.db import ensure_db
+from triage.component.catwalk.storage import FSModelStorageEngine
+
+from tests.utils import sample_config, populate_source_data
+
+from triage.experiments import SingleThreadedExperiment
+from triage.database_reflection import schema_tables
+from triage.validation_primitives import table_should_have_data
+
+
+import logging
+logging.basicConfig(level=logging.INFO)
+
+def test_get_splits():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            assert experiment.split_definitions
+
+
+def test_cohort():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'cohort_config': sample_config()['cohort_config'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            table_should_have_data(experiment.sparse_states_table_name, db_engine)
+
+
+def test_labels():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'label_config': sample_config()['label_config'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            table_should_have_data(experiment.labels_table_name, db_engine)
+
+
+def test_preimputation_features():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'feature_aggregations': sample_config()['feature_aggregations'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            generated_tables = [
+                table
+                for table in schema_tables(experiment.features_schema_name, db_engine).keys()
+                if '_aggregation' in table
+            ]
+
+            assert len(generated_tables) == len(sample_config()['feature_aggregations'])
+            for table in generated_tables:
+                table_should_have_data(table, db_engine)
+
+
+def test_postimputation_features():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'feature_aggregations': sample_config()['feature_aggregations'],
+            'cohort_config': sample_config()['cohort_config'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            generated_tables = [
+                table
+                for table in schema_tables(experiment.features_schema_name, db_engine).keys()
+                if '_aggregation_imputed' in table
+            ]
+
+            assert len(generated_tables) == len(sample_config()['feature_aggregations'])
+            for table in generated_tables:
+                table_should_have_data(table, db_engine)
+
+
+def test_generate_matrices():
+    with testing.postgresql.Postgresql() as postgresql:
+        config = {
+            'temporal_config': sample_config()['temporal_config'],
+            'feature_aggregations': sample_config()['feature_aggregations'],
+            'cohort_config': sample_config()['cohort_config'],
+            'label_config': sample_config()['label_config'],
+            'config_version': sample_config()['config_version']
+        }
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        populate_source_data(db_engine)
+        with TemporaryDirectory() as temp_dir:
+            experiment = SingleThreadedExperiment(
+                config=config,
+                db_engine=db_engine,
+                model_storage_class=FSModelStorageEngine,
+                project_path=os.path.join(temp_dir, 'inspections'),
+                cleanup=False
+            )
+            experiment.run()
+            matrices_path = os.path.join(temp_dir, 'inspections', 'matrices')
+            matrices_and_metadata = [f for f in os.listdir(matrices_path) if isfile(join(matrices_path, f))]
+            matrices = experiment.matrix_build_tasks
+            assert len(matrices) > 0
+            for matrix in matrices:
+                assert '{}.csv'.format(matrix) in matrices_and_metadata
+                assert '{}.yaml'.format(matrix) in matrices_and_metadata

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -294,7 +294,7 @@ class CSVBuilder(BuilderBase):
         except ValueError as e:
             logging.warning(
                 'Not able to build entity-date table due to: %s - will not build matrix',
-                str(e)
+                exc_info=True
             )
             return
         logging.info('Extracting feature group data from database into file '

--- a/src/triage/component/architect/database_reflection.py
+++ b/src/triage/component/architect/database_reflection.py
@@ -68,14 +68,14 @@ def table_exists(table_name, db_engine):
 def table_has_data(table_name, db_engine):
     """Check whether the table contains any data
 
-    The table is expected to exist.
-
     Args:
         table_name (string) A table name (with schema)
         db_engine (sqlalchemy.engine)
 
     Returns: (boolean) Whether or not the table has any data
     """
+    if not table_exists(table_name, db_engine):
+        return False
     results = [
         row for row in
         db_engine.execute('select * from {} limit 1'.format(table_name))

--- a/src/triage/component/architect/feature_generators.py
+++ b/src/triage/component/architect/feature_generators.py
@@ -564,6 +564,15 @@ class FeatureGenerator(object):
             table_tasks[imp_tbl_name] = {}
             return table_tasks
 
+        if not aggregation.state_table:
+            logging.warning(
+                'No state table available to aggregation, cannot create imputation table for %s',
+                imp_tbl_name
+            )
+            table_tasks[imp_tbl_name] = {}
+            return table_tasks
+
+
         # excute query to find columns with null values and create lists of columns
         # that do and do not need imputation when creating the imputation table
         with self.db_engine.begin() as conn:

--- a/src/triage/component/architect/feature_group_creator.py
+++ b/src/triage/component/architect/feature_group_creator.py
@@ -121,6 +121,6 @@ class FeatureGroupCreator(object):
 
                 subsets.append(subset)
         if not any(subset for subset in subsets if any(subset)):
-            raise Exception('No matching feature groups found!')
+            logging.warning('No matching feature groups available.')
         logging.info('Found %s total feature subsets', len(subsets))
         return subsets

--- a/src/triage/component/architect/label_generators.py
+++ b/src/triage/component/architect/label_generators.py
@@ -5,6 +5,17 @@ import textwrap
 DEFAULT_LABEL_NAME = 'outcome'
 
 
+class LabelGeneratorNoOp(object):
+    def generate_all_labels(self, labels_table, as_of_dates, label_timespans):
+        logging.warning('No label configuration is available, so no labels will be created')
+
+    def generate(self, start_date, label_timespan, labels_table):
+        logging.warning('No label configuration is available, so no labels will be created')
+
+    def clean_up(self, labels_table_name):
+        pass
+
+
 class LabelGenerator(object):
     def __init__(self, db_engine, query, label_name=None):
         self.db_engine = db_engine
@@ -101,3 +112,6 @@ class LabelGenerator(object):
         self.db_engine.execute(
             full_insert_query,
         )
+
+    def clean_up(self, labels_table_name):
+        self.db_engine.execute('drop table if exists {}'.format(labels_table_name))

--- a/src/triage/component/architect/state_table_generators.py
+++ b/src/triage/component/architect/state_table_generators.py
@@ -2,6 +2,7 @@ import logging
 from abc import ABC, abstractmethod
 
 from triage.component.architect.database_reflection import table_has_data
+from triage.database_reflection import table_row_count
 
 
 DEFAULT_ACTIVE_STATE = 'active'
@@ -70,6 +71,10 @@ class StateTableGeneratorBase(ABC):
             raise ValueError(self._empty_table_message(as_of_dates))
 
         logging.info('Sparse states table generated at %s', self.sparse_table_name)
+        logging.info('Generating stats on %s', self.sparse_table_name)
+        logging.info('Row count of %s: %s',
+                     self.sparse_table_name,
+                     table_row_count(self.sparse_table_name, self.db_engine))
 
     def clean_up(self):
         self.db_engine.execute(

--- a/src/triage/component/architect/state_table_generators.py
+++ b/src/triage/component/architect/state_table_generators.py
@@ -270,3 +270,17 @@ class StateTableGeneratorFromDense(StateTableGeneratorBase):
                     as_of_dates if len(as_of_dates) <= 5 else as_of_dates[:5] + ['…']
                 )),
             )
+
+
+class StateTableGeneratorNoOp(object):
+    def generate_sparse_table(self, as_of_dates):
+        logging.warning('No cohort configuration is available, so no cohort will be created')
+        return
+
+    def clean_up(self):
+        logging.warning('No cohort table exists, so nothing to tear down')
+        return
+
+    @property
+    def sparse_table_name(self):
+        return None

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -28,6 +28,8 @@ def feature_list(feature_dictionary):
 
     Returns: sorted list of feature names
     """
+    if not feature_dictionary:
+        return []
     return sorted(
         functools.reduce(
             operator.concat,

--- a/src/triage/component/catwalk/model_testers.py
+++ b/src/triage/component/catwalk/model_testers.py
@@ -25,8 +25,8 @@ class ModelTester(object):
         self.evaluator = ModelEvaluator(
             db_engine=db_engine,
             sort_seed=evaluator_config.get('sort_seed', None),
-            testing_metric_groups=evaluator_config['testing_metric_groups'],
-            training_metric_groups=evaluator_config['training_metric_groups']
+            testing_metric_groups=evaluator_config.get('testing_metric_groups', []),
+            training_metric_groups=evaluator_config.get('training_metric_groups', [])
         )
 
     def generate_model_test_tasks(self, split, train_store, model_ids, matrix_store_creator):

--- a/src/triage/database_reflection.py
+++ b/src/triage/database_reflection.py
@@ -95,12 +95,10 @@ def table_row_count(table_name, db_engine):
 
     Returns: (int) The number of rows in the table
     """
-    result = [
+    return next(
         row for row in
         db_engine.execute('select count(*) from {}'.format(table_name))
-    ]
-
-    return result[0]
+    )
 
 
 def table_has_column(table_name, column, db_engine):

--- a/src/triage/database_reflection.py
+++ b/src/triage/database_reflection.py
@@ -68,20 +68,39 @@ def table_exists(table_name, db_engine):
 def table_has_data(table_name, db_engine):
     """Check whether the table contains any data
 
-    The table is expected to exist.
-
     Args:
         table_name (string) A table name (with schema)
         db_engine (sqlalchemy.engine)
 
     Returns: (boolean) Whether or not the table has any data
     """
+    if not table_exists(table_name, db_engine):
+        return False
     result = [
         row for row in
         db_engine.execute('select 1 from {} limit 1'.format(table_name))
     ]
 
     return any(result)
+
+
+def table_row_count(table_name, db_engine):
+    """Return the length of the table.
+
+    The table is expected to exist.
+
+    Args:
+        table_name (string) A table name (with schema)
+        db_engine (sqlalchemy.engine)
+
+    Returns: (int) The number of rows in the table
+    """
+    result = [
+        row for row in
+        db_engine.execute('select count(*) from {}'.format(table_name))
+    ]
+
+    return result[0]
 
 
 def table_has_column(table_name, column, db_engine):
@@ -114,3 +133,9 @@ def column_type(table_name, column, db_engine):
         sqlalchemy.types.Boolean
     """
     return type(reflected_table(table_name, db_engine).columns[column].type)
+
+
+def schema_tables(schema_name, db_engine):
+    meta = MetaData(schema=schema_name, bind=db_engine)
+    meta.reflect()
+    return meta.tables

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -28,11 +28,12 @@ from triage.component.catwalk.model_grouping import ModelGrouper
 from triage.component.catwalk.model_trainers import ModelTrainer
 from triage.component.catwalk.model_testers import ModelTester
 from triage.component.catwalk.utils import save_experiment_and_get_hash
-from triage.component.catwalk.storage import CSVMatrixStore
+from triage.component.catwalk.storage import CSVMatrixStore, FSModelStorageEngine
 
 from triage.experiments import CONFIG_VERSION
 from triage.experiments.validate import ExperimentValidator
 
+from triage.database_reflection import table_has_data
 from triage.util.db import create_engine
 
 
@@ -65,9 +66,10 @@ class ExperimentBase(ABC):
         self,
         config,
         db_engine,
-        model_storage_class=None,
+        model_storage_class=FSModelStorageEngine,
         project_path=None,
         replace=True,
+        cleanup=True,
         cleanup_timeout=None,
     ):
         self._check_config_version(config)
@@ -98,6 +100,11 @@ class ExperimentBase(ABC):
         self.labels_table_name = 'labels_{}'.format(self.experiment_hash)
         self.initialize_components()
 
+        self.cleanup = cleanup
+        if self.cleanup:
+            logging.info('cleanup is set to True, so intermediate tables (labels and states) will be removed after matrix creation')
+        else:
+            logging.info('cleanup is set to False, so intermediate tables (labels and states) will not be removed after matrix creation')
         self.cleanup_timeout = (self.cleanup_timeout if cleanup_timeout is None
                                 else cleanup_timeout)
 
@@ -153,13 +160,16 @@ class ExperimentBase(ABC):
                 dense_state_table=cohort_config['dense_states']['table_name']
             )
         else:
-            raise ValueError('Cohort config missing or unrecognized')
+            logging.warning('cohort_config missing or unrecognized. Without a cohort, you will not be able to make matrices or perform feature imputation.')
 
-        self.label_generator = LabelGenerator(
-            label_name=self.config['label_config'].get('name', None),
-            query=self.config['label_config']['query'],
-            db_engine=self.db_engine,
-        )
+        if 'label_config' in self.config:
+            self.label_generator = LabelGenerator(
+                label_name=self.config['label_config'].get('name', None),
+                query=self.config['label_config']['query'],
+                db_engine=self.db_engine,
+            )
+        else:
+            logging.warning('label_config missing or unrecognized. Without labels, you will not be able to make matrices.')
 
         self.feature_dictionary_creator = FeatureDictionaryCreator(
             features_schema_name=self.features_schema_name,
@@ -200,11 +210,10 @@ class ExperimentBase(ABC):
                 # TODO: have planner/builder take state table later on, so we
                 # can grab it from the StateTableGenerator instead of
                 # duplicating it here
-                'sparse_state_table_name': 'tmp_sparse_states_{}'
-                                           .format(self.experiment_hash),
+                'sparse_state_table_name': self.sparse_states_table_name,
             },
             matrix_directory=self.matrices_directory,
-            include_missing_labels_in_train_as=self.config['label_config']
+            include_missing_labels_in_train_as=self.config.get('label_config', {})
             .get('include_missing_labels_in_train_as', None),
             engine=self.db_engine,
             replace=self.replace
@@ -227,6 +236,10 @@ class ExperimentBase(ABC):
             individual_importance_config=self.config.get('individual_importance', {}),
             evaluator_config=self.config.get('scoring', {})
         )
+
+    @property
+    def sparse_states_table_name(self):
+        return 'tmp_sparse_states_{}'.format(self.experiment_hash)
 
     @cachedproperty
     def split_definitions(self):
@@ -261,16 +274,13 @@ class ExperimentBase(ABC):
         split_definitions = self.chopper.chop_time()
         logging.info('Computed and stored split definitions: %s',
                      split_definitions)
-        return split_definitions
-
-    def print_time_split_summary(self):
-        print('\n----TIME SPLIT SUMMARY----\n')
-        print('Number of time splits: {}'.format(len(self.split_definitions)))
-        for split_index, split in enumerate(self.split_definitions):
+        logging.info('\n----TIME SPLIT SUMMARY----\n')
+        logging.info('Number of time splits: {}'.format(len(split_definitions)))
+        for split_index, split in enumerate(split_definitions):
             train_times = split['train_matrix']['as_of_times']
             test_times = [as_of_time for test_matrix in split['test_matrices']
                           for as_of_time in test_matrix['as_of_times']]
-            print('''Split index {}:
+            logging.info('''Split index {}:
             Training as_of_time_range: {} to {} ({} total)
             Testing as_of_time range: {} to {} ({} total)\n\n'''.format(
                 split_index,
@@ -281,8 +291,8 @@ class ExperimentBase(ABC):
                 max(test_times),
                 len(test_times)
             ))
-        print('For more detailed information on your time splits, '
-              'inspect the experiment `split_definitions` property')
+
+        return split_definitions
 
     @cachedproperty
     def all_as_of_times(self):
@@ -296,10 +306,10 @@ class ExperimentBase(ABC):
         all_as_of_times = []
         for split in self.split_definitions:
             all_as_of_times.extend(split['train_matrix']['as_of_times'])
-            logging.info('Adding as_of_times from train matrix: %s',
+            logging.debug('Adding as_of_times from train matrix: %s',
                          split['train_matrix']['as_of_times'])
             for test_matrix in split['test_matrices']:
-                logging.info('Adding as_of_times from test matrix: %s',
+                logging.debug('Adding as_of_times from test matrix: %s',
                              test_matrix['as_of_times'])
                 all_as_of_times.extend(test_matrix['as_of_times'])
 
@@ -312,6 +322,7 @@ class ExperimentBase(ABC):
             'Computed %s distinct as_of_times for label and feature generation',
             len(distinct_as_of_times)
         )
+        logging.info('You can view all as_of_times by inspecting `.all_as_of_times` on this Experiment')
         return distinct_as_of_times
 
     @cachedproperty
@@ -322,10 +333,17 @@ class ExperimentBase(ABC):
 
         """
         logging.info('Creating collate aggregations')
+        if hasattr(self, 'state_table_generator'):
+            cohort_table = self.state_table_generator.sparse_table_name
+        else:
+            cohort_table = None
+        if 'feature_aggregations' not in self.config:
+            logging.warning('No feature_aggregation config is available')
+            return []
         return self.feature_generator.aggregations(
             feature_aggregation_config=self.config['feature_aggregations'],
             feature_dates=self.all_as_of_times,
-            state_table=self.state_table_generator.sparse_table_name,
+            state_table=cohort_table
         )
 
     @cachedproperty
@@ -407,6 +425,12 @@ class ExperimentBase(ABC):
         Returns: (list) of dicts
 
         """
+        if not table_has_data(self.sparse_states_table_name, self.db_engine):
+            logging.warning('cohort table is not populated, cannot build any matrices')
+            return {}
+        if not table_has_data(self.labels_table_name, self.db_engine):
+            logging.warning('labels table is not populated, cannot build any matrices')
+            return {}
         (
             updated_split_definitions,
             matrix_build_tasks
@@ -451,13 +475,19 @@ class ExperimentBase(ABC):
 
         Results are stored in the database, not returned
         """
+        if not hasattr(self, 'label_generator'):
+            logging.warning('No label configuration is available, so no labels will be created')
+            return
         self.label_generator.generate_all_labels(
             self.labels_table_name,
             self.all_as_of_times,
             self.all_label_timespans
         )
 
-    def generate_sparse_states(self):
+    def generate_cohort(self):
+        if not hasattr(self, 'state_table_generator'):
+            logging.warning('No cohort configuration is available, so no cohort will be created')
+            return
         self.state_table_generator.generate_sparse_table(
             as_of_dates=self.all_as_of_times
         )
@@ -503,26 +533,36 @@ class ExperimentBase(ABC):
 
     def generate_preimputation_features(self):
         self.process_query_tasks(self.feature_aggregation_table_tasks)
+        logging.info('Finished running preimputation feature queries. The final results are in tables: %s',
+                     ','.join(agg.get_table_name() for agg in self.collate_aggregations)
+                     )
 
-    def generate_imputed_features(self):
+    def impute_missing_features(self):
         self.process_query_tasks(self.feature_imputation_table_tasks)
+        logging.info('Finished running postimputation feature queries. The final results are in tables: %s',
+                     ','.join(agg.get_table_name(imputed=True) for agg in self.collate_aggregations)
+                     )
 
     def build_matrices(self):
         self.process_matrix_build_tasks(self.matrix_build_tasks)
 
     def generate_matrices(self):
-        logging.info('Creating sparse states')
-        self.generate_sparse_states()
+        logging.info('Creating cohort')
+        self.generate_cohort()
         logging.info('Creating labels')
         self.generate_labels()
         logging.info('Creating feature aggregation tables')
         self.generate_preimputation_features()
         logging.info('Creating feature imputation tables')
-        self.generate_imputed_features()
+        self.impute_missing_features()
         logging.info('Building all matrices')
         self.build_matrices()
 
     def train_and_test_models(self):
+        if 'grid_config' not in self.config:
+            logging.warning('No grid_config was passed in the experiment config. No models will be trained')
+            return
+
         for split_num, split in enumerate(self.full_matrix_definitions):
             self.log_split(split_num, split)
             train_store = self.matrix_store(split['train_uuid'])
@@ -563,17 +603,18 @@ class ExperimentBase(ABC):
 
     def validate(self):
         ExperimentValidator(self.db_engine).run(self.config)
-        self.print_time_split_summary()
 
     def _run(self):
         try:
             logging.info('Generating matrices')
             self.generate_matrices()
         finally:
-            logging.info('Cleaning up state table')
-            with timeout(self.cleanup_timeout):
-                self.state_table_generator.clean_up()
-                self.db_engine.execute('drop table if exists {}'.format(self.labels_table_name))
+            if self.cleanup:
+                logging.info('Cleaning up state table')
+                with timeout(self.cleanup_timeout):
+                    if hasattr(self, 'state_table_generator'):
+                        self.state_table_generator.clean_up()
+                    self.db_engine.execute('drop table if exists {}'.format(self.labels_table_name))
 
         self.train_and_test_models()
 

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -599,8 +599,8 @@ class ExperimentBase(ABC):
 
             self.process_model_test_tasks(test_tasks)
 
-    def validate(self):
-        ExperimentValidator(self.db_engine).run(self.config)
+    def validate(self, strict=True):
+        ExperimentValidator(self.db_engine, strict=strict).run(self.config)
 
     def _run(self):
         try:


### PR DESCRIPTION
- Modify various components and experiment itself to more gracefully handle missing configuration, sometimes adding checks where there are not but in some cases changing exception raising to warning
- Add cleanup boolean flag to experiment to control whether or not the temporary tables are cleaned up
- Tweak logging to make incremental output more clear
- Add partial_experiments test to ensure that incremental outputs will be available if only some configuration is sent
- Modify 'running parts of an experiment' section of experiment run doc with information about .run() and cleanup=False