### PR TITLE
Audition basic cli and files store

### DIFF
--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -8,7 +8,7 @@ import factory
 import testing.postgresql
 from sqlalchemy import create_engine
 
-from triage.component.audition import Auditioner, Audition
+from triage.component.audition import Auditioner, AuditionRunner
 from triage.component.catwalk.db import ensure_db
 
 from tests.results_tests.factories import (
@@ -100,10 +100,9 @@ def test_Audition(mock_getcwd):
 
         session.commit()
 
-
         with tempfile.TemporaryDirectory() as td:
             mock_getcwd.return_value = td
-            Audition(config_dict=config, db_engine=db_engine, directory=td).run()
+            AuditionRunner(config_dict=config, db_engine=db_engine, directory=td).run()
             assert len(os.listdir(os.getcwd())) == 6
 
 

--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -100,10 +100,10 @@ def test_Audition(mock_getcwd):
 
         session.commit()
 
+
         with tempfile.TemporaryDirectory() as td:
             mock_getcwd.return_value = td
             Audition(config_dict=config, db_engine=db_engine, directory=td).run()
-
             assert len(os.listdir(os.getcwd())) == 6
 
 

--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -1,12 +1,14 @@
 from datetime import datetime
 import tempfile
+import yaml
+import os
+import mock
 
 import factory
 import testing.postgresql
-import yaml
 from sqlalchemy import create_engine
 
-from triage.component.audition import Auditioner
+from triage.component.audition import Auditioner, Audition
 from triage.component.catwalk.db import ensure_db
 
 from tests.results_tests.factories import (
@@ -17,6 +19,94 @@ from tests.results_tests.factories import (
     session,
     MatrixFactory
 )
+
+config = {
+    'filter': {'distance_table': 'distance_table',
+    'max_from_best': 1.0,
+    'metric': 'precision@',
+    'models_table': 'models',
+    'parameter': '50_abs',
+    'threshold_value': 0.0},
+    'model_groups': {'query': 'SELECT DISTINCT(model_group_id) FROM model_metadata.model_groups'},
+    'rules':
+        [
+            {
+                'selection_rules': [
+                    {'name': 'best_current_value', 'n': 3},
+                    {'name': 'best_average_value', 'n': 3},
+                    {'name': 'lowest_metric_variance', 'n': 3},
+                    {'dist_from_best_case': [0.05], 'name': 'most_frequent_best_dist', 'n': 3}
+                    ],
+                'shared_parameters': [
+                    {'metric': 'precision@', 'parameter': '50_abs'},
+                    ]
+            },
+            {
+                'selection_rules': [
+                    {'metric1_weight': 0.5, 'metric2': 'recall@','name': 'best_average_two_metrics', 'n': 3, 'parameter2': '50_abs'}
+                    ],
+                'shared_parameters': [
+                    {'metric1': 'precision@', 'parameter1': '50_abs'}
+                    ]
+            }
+        ],
+    'time_stamps': {'query': "SELECT DISTINCT train_end_time FROM model_metadata.models WHERE model_group_id IN ({}) AND EXTRACT(DAY FROM train_end_time) IN (1) AND train_end_time >= '2012-01-01'"}
+}
+
+@mock.patch('os.getcwd')
+def test_Audition(mock_getcwd):
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        init_engine(db_engine)
+
+        num_model_groups = 10
+        model_types = [
+            'classifier type {}'.format(i)
+            for i in range(0, num_model_groups)
+        ]
+        model_groups = [
+            ModelGroupFactory(model_type=model_type)
+            for model_type in model_types
+        ]
+        train_end_times = [
+            datetime(2013, 1, 1),
+            datetime(2014, 1, 1),
+            datetime(2015, 1, 1),
+            datetime(2016, 1, 1),
+        ]
+
+        models = [
+            ModelFactory(model_group_rel=model_group, train_end_time=train_end_time)
+            for model_group in model_groups
+            for train_end_time in train_end_times
+        ]
+        metrics = [
+            ('precision@', '100_abs'),
+            ('recall@', '100_abs'),
+            ('precision@', '50_abs'),
+            ('recall@', '50_abs'),
+            ('fpr@', '10_pct'),
+        ]
+
+        class ImmediateEvalFactory(EvaluationFactory):
+            evaluation_start_time = factory.LazyAttribute(lambda o: o.model_rel.train_end_time)
+
+        for model in models:
+            for (metric, parameter) in metrics:
+                ImmediateEvalFactory(model_rel=model,
+                                     metric=metric,
+                                     parameter=parameter)
+
+        session.commit()
+
+        # Audition(config_dict=config, db_engine=db_engine, directory='tmp/').run()
+
+        with tempfile.TemporaryDirectory() as td:
+            mock_getcwd.return_value = td
+            Audition(config_dict=config, db_engine=db_engine, directory=td).run()
+
+            assert len(os.listdir(os.getcwd())) == 6
 
 
 def test_Auditioner():

--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -100,8 +100,6 @@ def test_Audition(mock_getcwd):
 
         session.commit()
 
-        # Audition(config_dict=config, db_engine=db_engine, directory='tmp/').run()
-
         with tempfile.TemporaryDirectory() as td:
             mock_getcwd.return_value = td
             Audition(config_dict=config, db_engine=db_engine, directory=td).run()

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -6,7 +6,7 @@ from descriptors import cachedproperty
 from argcmdr import RootCommand, Command, main, cmdmethod
 from sqlalchemy.engine.url import URL
 from triage.experiments import CONFIG_VERSION
-from triage.component.audition import Audition as AuditionRunner
+from triage.component.audition import AuditionRunner
 from triage.util.db import create_engine
 
 

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
-
+import yaml
 from argcmdr import RootCommand, Command, main
 from triage.experiments import CONFIG_VERSION
-
+from triage.component.audition import Audition as AuditionRunner
+from triage import create_engine
 
 class Triage(RootCommand):
     """manage Triage database and experiments"""
@@ -20,6 +21,65 @@ class ConfigVersion(Command):
     """Return the experiment config version compatible with this installation of Triage"""
     def __call__(self, args):
         print(CONFIG_VERSION)
+
+
+@Triage.register
+class Audition(Command):
+    """ Audition command to run or validate the config file
+    """
+    class Run(Command):
+        """Run Audition
+        """
+        def __init__(self, parser):
+            parser.add_argument(
+                '-c', '--config',
+                default='audition_config.yaml',
+                help="config file for audition",
+            )
+
+            parser.add_argument(
+                '-d', '--directory',
+                default='some path',
+                help="directory to store the result plots from audition",
+            )
+
+            self.db_engine = create_engine()
+
+        def __call__(self, args):
+            """A function/script to run the whole thing in Audition
+            """
+            dir_plot = args.directory
+            config_fname = args.config
+            try:
+                with open(config_fname) as fd:
+                    config = yaml.load(fd)
+            except Exception as err:
+                raise err
+
+            AuditionRunner(config, dir_plot).run()
+
+    class Validate(Command):
+        """Validate the config file for audition
+        """
+        def __init__(self, parser):
+            parser.add_argument(
+                '-c', '--config',
+                default='audition_config.yaml',
+                help="config file for audition",
+            )
+
+        def __call__(self, args):
+            """A function/script to run the validate the config file
+            """
+            config_fname = args.config
+            try:
+                with open(config_fname) as fd:
+                    config = yaml.load(fd)
+                    self.config = config
+            except Exception as err:
+                raise err
+
+            AuditionRunner(config_fname).validate()
 
 
 def execute():

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -64,23 +64,29 @@ class Audition(Command):
         dir_plot = self.args.directory
         config = yaml.load(self.args.config)
         db_engine = create_engine(db_url)
-        print(db_engine)
         return AuditionRunner(config, db_engine, dir_plot)
 
     def __call__(self, args):
         self['run'](args)
 
-    @cmdmethod('-d', '--directory', default=os.getcwd(), help="directory to store the result plots from audition")
-    @cmdmethod('-v', '--validate', action='store_true', help="validate first")
+    @cmdmethod('-d', '--directory', default=None, help="directory to store the result plots from audition")
+    @cmdmethod('-v', '--validate', action='store_true', help="validate before running audition")
+    @cmdmethod('--no-validate', action='store_false', dest='validate', help="run audtion without validation")
+    @cmdmethod('--validate-only', action='store_true', help="only validate the config file not running audition")
     def run(self, args):
-        if args.validate:
-            self['validate']()
-        self.runner.run()
-
-    @cmdmethod('-v', '--validate', action='store_true')
-    def validate(self, args):
-        self.runner.validate()
-
+        if args.validate_only:
+            try:
+                self.runner.validate()
+            except Exception as err:
+                raise(err)
+        elif args.validate:
+            try:
+                self.runner.validate()
+                self.runner.run()
+            except Exception as err:
+                raise(err)
+        else:
+            self.runner.run()
 
 def execute():
     main(Triage)

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -1,6 +1,8 @@
 import logging
 
 import yaml
+import json
+import os
 from smart_open import smart_open
 
 from .distance_from_best import DistanceFromBestTable, BestDistancePlotter
@@ -9,10 +11,9 @@ from .regrets import SelectionRulePicker, SelectionRulePlotter
 from .selection_rule_performance import SelectionRulePerformancePlotter
 from .model_group_performance import ModelGroupPerformancePlotter
 from .selection_rule_grid import make_selection_rule_grid
-
+from .pre_audition import PreAudition
 
 class Auditioner(object):
-
     def __init__(
         self,
         db_engine,
@@ -21,6 +22,7 @@ class Auditioner(object):
         initial_metric_filters,
         models_table=None,
         distance_table=None,
+        directory=None,
     ):
         """Filter model groups using a two-step process:
 
@@ -74,7 +76,7 @@ class Auditioner(object):
         self.metric_filters = initial_metric_filters
         # sort the train end times so we can reliably pick off the last time later
         self.train_end_times = sorted(train_end_times)
-
+        self.directory = directory
         models_table = models_table or 'models'
         distance_table = distance_table or 'best_distance'
         self.distance_from_best_table = DistanceFromBestTable(
@@ -82,7 +84,7 @@ class Auditioner(object):
             models_table=models_table,
             distance_table=distance_table
         )
-        self.best_distance_plotter = BestDistancePlotter(self.distance_from_best_table)
+        self.best_distance_plotter = BestDistancePlotter(self.distance_from_best_table, self.directory)
         self.model_group_thresholder = ModelGroupThresholder(
             distance_from_best_table=self.distance_from_best_table,
             train_end_times=train_end_times,
@@ -90,12 +92,12 @@ class Auditioner(object):
             initial_metric_filters=initial_metric_filters
         )
         self.model_group_performance_plotter = \
-            ModelGroupPerformancePlotter(self.distance_from_best_table)
+            ModelGroupPerformancePlotter(self.distance_from_best_table, self.directory)
 
         self.selection_rule_picker = SelectionRulePicker(self.distance_from_best_table)
-        self.selection_rule_plotter = SelectionRulePlotter(self.selection_rule_picker)
+        self.selection_rule_plotter = SelectionRulePlotter(self.selection_rule_picker, self.directory)
         self.selection_rule_performance_plotter = \
-            SelectionRulePerformancePlotter(self.selection_rule_picker)
+            SelectionRulePerformancePlotter(self.selection_rule_picker, directory)
 
         self.distance_from_best_table.create_and_populate(
             model_group_ids,
@@ -157,6 +159,10 @@ class Auditioner(object):
                 model_group_ids[selection_rule.descriptive_name]
             )
         return model_group_ids
+
+    def save_result_model_group_ids(self, fname='results_model_group_ids.json'):
+        with open(os.path.join(self.directory, fname), 'w') as f:
+            f.write(json.dumps(self.selection_rule_model_group_ids))
 
     def plot_model_groups(self):
         """Display model group plots, one of the below for each configured metric.
@@ -341,3 +347,41 @@ class Auditioner(object):
         logging.info('Writing final model group ids to export to Tyra')
         with smart_open(write_path, 'w') as f:
             yaml.dump({'selection_rule_model_groups': self.selection_rule_model_group_ids}, f)
+
+
+class Audition(object):
+    def __init__(self, config_dict, db_engine, directory=None):
+        self.dir = directory
+        self.config = config_dict
+        self.db_engine = db_engine
+
+    def run(self):
+        pre_aud = PreAudition(self.db_engine)
+        model_group_ids = pre_aud.get_model_groups(self.config['model_groups']['query'])
+        query_end_times = self.config['time_stamps']['query'].format(', '.join(map(str, model_group_ids)))
+        end_times = pre_aud.get_train_end_times(query=query_end_times)
+
+        aud = Auditioner(
+            db_engine=self.db_engine,
+            model_group_ids=model_group_ids,
+            train_end_times=end_times,
+            initial_metric_filters=[
+                {'metric': self.config['filter']['metric'],
+                 'parameter': self.config['filter']['parameter'],
+                 'max_from_best': self.config['filter']['max_from_best'],
+                 'threshold_value': self.config['filter']['threshold_value']
+                }
+            ],
+            models_table=self.config['filter']['models_table'],
+            distance_table=self.config['filter']['distance_table'],
+            directory=self.dir
+        )
+
+        aud.plot_model_groups()
+        aud.register_selection_rule_grid(rule_grid=self.config['rules'], plot=True)
+        aud.save_result_model_group_ids()
+
+        logging.info(f"Audition ran! Results are stored in {self.dir}.")
+
+    def validate(self):
+        raise NotImplementedError("To be implemented")

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -352,6 +352,7 @@ class Auditioner(object):
 class Audition(object):
     def __init__(self, config_dict, db_engine, directory=None):
         self.dir = directory
+        print(self.dir)
         self.config = config_dict
         self.db_engine = db_engine
 

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -349,10 +349,9 @@ class Auditioner(object):
             yaml.dump({'selection_rule_model_groups': self.selection_rule_model_group_ids}, f)
 
 
-class Audition(object):
+class AuditionRunner(object):
     def __init__(self, config_dict, db_engine, directory=None):
         self.dir = directory
-        print(self.dir)
         self.config = config_dict
         self.db_engine = db_engine
 
@@ -386,6 +385,6 @@ class Audition(object):
 
     def validate(self):
         try:
-            print("Validate")
+            logging.info("Validate!")
         except Exception as err:
             raise err

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -384,4 +384,7 @@ class Audition(object):
         logging.info(f"Audition ran! Results are stored in {self.dir}.")
 
     def validate(self):
-        raise NotImplementedError("To be implemented")
+        try:
+            print("Validate")
+        except Exception as err:
+            raise err

--- a/src/triage/component/audition/distance_from_best.py
+++ b/src/triage/component/audition/distance_from_best.py
@@ -358,7 +358,7 @@ def plot_best_dist(metric, parameter, df_best_dist, directory=None, **plt_format
     plt_title = 'Fraction of models X pp worse than best {} {}'.format(metric, parameter)
 
     if directory:
-        path_to_save = os.path.join(directory, f'/distance_from_best_{metric}{parameter}.png')
+        path_to_save = os.path.join(directory, f'distance_from_best_{metric}{parameter}.png')
     else:
         path_to_save = None
 

--- a/src/triage/component/audition/distance_from_best.py
+++ b/src/triage/component/audition/distance_from_best.py
@@ -1,5 +1,5 @@
 import logging
-
+import os
 import numpy as np
 import pandas as pd
 
@@ -358,9 +358,9 @@ def plot_best_dist(metric, parameter, df_best_dist, directory=None, **plt_format
     plt_title = 'Fraction of models X pp worse than best {} {}'.format(metric, parameter)
 
     if directory:
-        path_to_save = directory + f'/distance_from_best_{metric}{parameter}.png'
+        path_to_save = os.path.join(directory + f'/distance_from_best_{metric}{parameter}.png')
     else:
-        path_to_save = directory
+        path_to_save = None
 
     plot_cats(
         frame=df_best_dist,

--- a/src/triage/component/audition/distance_from_best.py
+++ b/src/triage/component/audition/distance_from_best.py
@@ -358,7 +358,7 @@ def plot_best_dist(metric, parameter, df_best_dist, directory=None, **plt_format
     plt_title = 'Fraction of models X pp worse than best {} {}'.format(metric, parameter)
 
     if directory:
-        path_to_save = os.path.join(directory + f'/distance_from_best_{metric}{parameter}.png')
+        path_to_save = os.path.join(directory, f'/distance_from_best_{metric}{parameter}.png')
     else:
         path_to_save = None
 

--- a/src/triage/component/audition/distance_from_best.py
+++ b/src/triage/component/audition/distance_from_best.py
@@ -208,7 +208,7 @@ class DistanceFromBestTable(object):
 
 
 class BestDistancePlotter(object):
-    def __init__(self, distance_from_best_table):
+    def __init__(self, distance_from_best_table, directory=None):
         """Generate a plot illustrating the effect of different below-best maximum
         thresholds across the dataset.
 
@@ -217,6 +217,7 @@ class BestDistancePlotter(object):
                 A pre-populated distance-from-best database table
         """
         self.distance_from_best_table = distance_from_best_table
+        self.directory = directory
 
     def plot_bounds(self, metric, parameter):
         observed_min, observed_max = \
@@ -317,14 +318,16 @@ class BestDistancePlotter(object):
                 model_group_ids=model_group_ids,
                 train_end_times=train_end_times
             )
+
             plot_best_dist(
                 metric=metric_filter['metric'],
                 parameter=metric_filter['parameter'],
-                df_best_dist=df
+                df_best_dist=df,
+                directory=self.directory
             )
 
 
-def plot_best_dist(metric, parameter, df_best_dist, **plt_format_args):
+def plot_best_dist(metric, parameter, df_best_dist, directory=None, **plt_format_args):
     """Generates a plot of the percentage of time that a model group is
     within X percentage points of the best-performing model group using a
     given metric. At each point in time that a set of model groups is
@@ -354,6 +357,11 @@ def plot_best_dist(metric, parameter, df_best_dist, **plt_format_args):
     cat_col = 'model_type'
     plt_title = 'Fraction of models X pp worse than best {} {}'.format(metric, parameter)
 
+    if directory:
+        path_to_save = directory + f'/distance_from_best_{metric}{parameter}.png'
+    else:
+        path_to_save = directory
+
     plot_cats(
         frame=df_best_dist,
         x_col='distance',
@@ -363,5 +371,6 @@ def plot_best_dist(metric, parameter, df_best_dist, **plt_format_args):
         x_label='distance from best {}'.format(metric),
         y_label='fraction of models',
         x_ticks=np.arange(0, 1.1, 0.1),
+        path_to_save=path_to_save,
         **plt_format_args
     )

--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -9,7 +9,7 @@ from .utils import str_in_sql
 
 class ModelGroupPerformancePlotter(object):
 
-    def __init__(self, distance_from_best_table):
+    def __init__(self, distance_from_best_table, directory=None):
         """Generate a plot illustrating the performance of a model group over time
 
         Args:
@@ -17,6 +17,7 @@ class ModelGroupPerformancePlotter(object):
                 A pre-populated distance-from-best database table
         """
         self.distance_from_best_table = distance_from_best_table
+        self.directory = directory
 
     def plot_all(self, metric_filters, model_group_ids, train_end_times):
         """For each metric, plot the value of that metric over time
@@ -45,7 +46,8 @@ class ModelGroupPerformancePlotter(object):
                 metric=metric_filter['metric'],
                 parameter=metric_filter['parameter'],
                 df_metric=df,
-                train_end_times=train_end_times
+                train_end_times=train_end_times,
+                directory=self.directory
             )
 
     def generate_plot_data(self, metric, parameter, model_group_ids, train_end_times):
@@ -97,7 +99,7 @@ class ModelGroupPerformancePlotter(object):
         ]
         return df
 
-    def plot(self, metric, parameter, df_metric, train_end_times, **plt_format_args):
+    def plot(self, metric, parameter, df_metric, train_end_times, directory, **plt_format_args):
         """Draw the plot representing the given data
 
         Arguments:
@@ -126,6 +128,10 @@ class ModelGroupPerformancePlotter(object):
                     '{} (given time) does not equal {} (matrix time)'
                     .format(given_time_as_numpy, matrix_time)
                 )
+        if directory:
+            path_to_save = directory + f'/metric_over_time_{metric}{parameter}.png'
+        else:
+            path_to_save = directory
 
         plot_cats(
             frame=df_metric,
@@ -137,5 +143,6 @@ class ModelGroupPerformancePlotter(object):
             x_label='train end time',
             y_label='value of {}'.format(metric),
             x_ticks=train_end_times,
+            path_to_save=path_to_save,
             **plt_format_args
         )

--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -1,5 +1,5 @@
 import logging
-
+import os
 import pandas as pd
 import numpy as np
 
@@ -129,9 +129,9 @@ class ModelGroupPerformancePlotter(object):
                     .format(given_time_as_numpy, matrix_time)
                 )
         if directory:
-            path_to_save = directory + f'/metric_over_time_{metric}{parameter}.png'
+            path_to_save = os.path.join(directory + f'/metric_over_time_{metric}{parameter}.png')
         else:
-            path_to_save = directory
+            path_to_save = None
 
         plot_cats(
             frame=df_metric,

--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -129,7 +129,7 @@ class ModelGroupPerformancePlotter(object):
                     .format(given_time_as_numpy, matrix_time)
                 )
         if directory:
-            path_to_save = os.path.join(directory, f'/metric_over_time_{metric}{parameter}.png')
+            path_to_save = os.path.join(directory, f'metric_over_time_{metric}{parameter}.png')
         else:
             path_to_save = None
 

--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -129,7 +129,7 @@ class ModelGroupPerformancePlotter(object):
                     .format(given_time_as_numpy, matrix_time)
                 )
         if directory:
-            path_to_save = os.path.join(directory + f'/metric_over_time_{metric}{parameter}.png')
+            path_to_save = os.path.join(directory, f'/metric_over_time_{metric}{parameter}.png')
         else:
             path_to_save = None
 

--- a/src/triage/component/audition/plotting.py
+++ b/src/triage/component/audition/plotting.py
@@ -120,11 +120,11 @@ def _no_op(arg):
 
 
 def plot_cats(frame, x_col, y_col, cat_col='model_type', grp_col='model_group_id',
-              highlight_grp=None, title='', x_label='', y_label='', cmap_name='Vega10',
+              highlight_grp=None, title='', x_label='', y_label='', cmap_name='tab10',
               figsize=[12, 6], x_ticks=None, y_ticks=None, x_lim=None, y_lim=None,
               legend_loc=None, legend_fontsize=12,
               label_fontsize=12, title_fontsize=16,
-              label_fcn=None):
+              label_fcn=None, path_to_save=None):
     """Plot a line plot with each line colored by a category variable.
 
     Arguments:
@@ -192,3 +192,6 @@ def plot_cats(frame, x_col, y_col, cat_col='model_type', grp_col='model_group_id
     )
 
     plt.show()
+
+    if path_to_save:
+        plt.savefig(path_to_save)

--- a/src/triage/component/audition/regrets.py
+++ b/src/triage/component/audition/regrets.py
@@ -1,5 +1,5 @@
 import copy
-
+import os
 import numpy
 import pandas
 
@@ -221,9 +221,9 @@ class SelectionRulePlotter(object):
         (plot_min, plot_max) = self.plot_bounds(regret_metric, regret_parameter)
 
         if self.directory:
-            path_to_save = self.directory + f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png'
+            path_to_save = os.path.join(self.directory + f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png')
         else:
-            path_to_save = self.directory
+            path_to_save = None
 
         plot_cats(
             frame=df_regrets,

--- a/src/triage/component/audition/regrets.py
+++ b/src/triage/component/audition/regrets.py
@@ -65,7 +65,8 @@ class SelectionRulePicker(object):
                 bound_selection_rule,
                 model_group_ids,
                 train_end_time
-            )[0]
+            )
+            model_group_id = model_group_id[0]
             choice = df[
                 (df['model_group_id'] == model_group_id) &
                 (df['train_end_time'] == train_end_time) &
@@ -110,8 +111,9 @@ class SelectionRulePlotter(object):
     Args:
         selection_rule_picker (.SelectionRulePicker)
     """
-    def __init__(self, selection_rule_picker):
+    def __init__(self, selection_rule_picker, directory=None):
         self.selection_rule_picker = selection_rule_picker
+        self.directory = directory
 
     def plot_bounds(self, metric, parameter):
         """Compute the plot bounds for a given metric and parameter
@@ -218,6 +220,11 @@ class SelectionRulePlotter(object):
                      .format(regret_metric, regret_parameter))
         (plot_min, plot_max) = self.plot_bounds(regret_metric, regret_parameter)
 
+        if self.directory:
+            path_to_save = self.directory + f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png'
+        else:
+            path_to_save = self.directory
+
         plot_cats(
             frame=df_regrets,
             x_col='regret',
@@ -227,5 +234,6 @@ class SelectionRulePlotter(object):
             title=plt_title,
             x_label='distance from best {} next time'.format(regret_metric),
             y_label='fraction of models',
-            x_lim=self.plot_bounds(regret_metric, regret_parameter)
+            x_lim=self.plot_bounds(regret_metric, regret_parameter),
+            path_to_save=path_to_save
         )

--- a/src/triage/component/audition/regrets.py
+++ b/src/triage/component/audition/regrets.py
@@ -221,7 +221,7 @@ class SelectionRulePlotter(object):
         (plot_min, plot_max) = self.plot_bounds(regret_metric, regret_parameter)
 
         if self.directory:
-            path_to_save = os.path.join(self.directory + f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png')
+            path_to_save = os.path.join(self.directory, f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png')
         else:
             path_to_save = None
 

--- a/src/triage/component/audition/regrets.py
+++ b/src/triage/component/audition/regrets.py
@@ -221,7 +221,7 @@ class SelectionRulePlotter(object):
         (plot_min, plot_max) = self.plot_bounds(regret_metric, regret_parameter)
 
         if self.directory:
-            path_to_save = os.path.join(self.directory, f'/regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png')
+            path_to_save = os.path.join(self.directory, f'regret_distance_from_best_rules_{regret_metric}{regret_parameter}.png')
         else:
             path_to_save = None
 

--- a/src/triage/component/audition/selection_rule_performance.py
+++ b/src/triage/component/audition/selection_rule_performance.py
@@ -120,7 +120,7 @@ class SelectionRulePerformancePlotter(object):
         cat_col = 'selection_rule'
         plt_title = 'Regret for {} {} over time'.format(metric, parameter)
         if self.directory:
-            path_to_save = self.directory + f'/regret_over_time_{metric}{parameter}.png'
+            path_to_save = os.path.join(self.directory, f'/regret_over_time_{metric}{parameter}.png')
         else:
             path_to_save = None
         plot_cats(

--- a/src/triage/component/audition/selection_rule_performance.py
+++ b/src/triage/component/audition/selection_rule_performance.py
@@ -120,7 +120,7 @@ class SelectionRulePerformancePlotter(object):
         cat_col = 'selection_rule'
         plt_title = 'Regret for {} {} over time'.format(metric, parameter)
         if self.directory:
-            path_to_save = os.path.join(self.directory, f'/regret_over_time_{metric}{parameter}.png')
+            path_to_save = os.path.join(self.directory, f'regret_over_time_{metric}{parameter}.png')
         else:
             path_to_save = None
         plot_cats(

--- a/src/triage/component/audition/selection_rule_performance.py
+++ b/src/triage/component/audition/selection_rule_performance.py
@@ -1,5 +1,5 @@
 import pandas
-
+import os
 from .plotting import plot_cats
 
 
@@ -122,7 +122,7 @@ class SelectionRulePerformancePlotter(object):
         if self.directory:
             path_to_save = self.directory + f'/regret_over_time_{metric}{parameter}.png'
         else:
-            path_to_save = self.directory
+            path_to_save = None
         plot_cats(
             frame=df,
             x_col='train_end_time',
@@ -151,9 +151,9 @@ class SelectionRulePerformancePlotter(object):
         cat_col = 'selection_rule'
         plt_title = '{} {} next time'.format(metric, parameter)
         if self.directory:
-            path_to_save = self.directory + f'/{metric}{parameter}_next_time.png'
+            path_to_save = os.path.join(self.directory, f'{metric}{parameter}_next_time.png')
         else:
-            path_to_save = self.directory
+            path_to_save = None
         plot_cats(
             frame=df,
             x_col='train_end_time',

--- a/src/triage/component/audition/selection_rule_performance.py
+++ b/src/triage/component/audition/selection_rule_performance.py
@@ -14,9 +14,10 @@ class SelectionRulePerformancePlotter(object):
         selection_rule_picker (audition.SelectionRulePicker) An object that can
             simulate the effects of picking a selection rule
     """
-    def __init__(self, selection_rule_picker):
+    def __init__(self, selection_rule_picker, directory=None):
         self.selection_rule_picker = selection_rule_picker
         self.results_for_rule = None
+        self.directory = directory
 
     def plot(
         self,
@@ -118,6 +119,10 @@ class SelectionRulePerformancePlotter(object):
         """
         cat_col = 'selection_rule'
         plt_title = 'Regret for {} {} over time'.format(metric, parameter)
+        if self.directory:
+            path_to_save = self.directory + f'/regret_over_time_{metric}{parameter}.png'
+        else:
+            path_to_save = self.directory
         plot_cats(
             frame=df,
             x_col='train_end_time',
@@ -128,6 +133,7 @@ class SelectionRulePerformancePlotter(object):
             x_label='train end time',
             y_label='regret in {}'.format(metric),
             x_lim=(df['train_end_time'].min(), df['train_end_time'].max()),
+            path_to_save=path_to_save,
             **plt_format_args
         )
 
@@ -144,6 +150,10 @@ class SelectionRulePerformancePlotter(object):
         """
         cat_col = 'selection_rule'
         plt_title = '{} {} next time'.format(metric, parameter)
+        if self.directory:
+            path_to_save = self.directory + f'/{metric}{parameter}_next_time.png'
+        else:
+            path_to_save = self.directory
         plot_cats(
             frame=df,
             x_col='train_end_time',
@@ -154,5 +164,6 @@ class SelectionRulePerformancePlotter(object):
             x_label='train end time',
             y_label='value of {} next time'.format(metric),
             x_lim=(df['train_end_time'].min(), df['train_end_time'].max()),
+            path_to_save=path_to_save,
             **plt_format_args
         )


### PR DESCRIPTION
- An `Auditoin` class has two methods `run` and `validate`. 
    - `run` is wrapping a series of `Auditioner`'s functionality like what we do with Audition in ipython notebook.
    - `validate` is to validate the config file of audition like what validate in experiment. Currently not implemented.

- An basic cli commands for audition that takes `config` and `directory` as arguments. The `directory` is the location to store the figures and json files.

- Make all the plots in Audition storable locally. They will be using the `catwalk.storage` to store things more generally later. 
