### PR TITLE
Audition model group filter

### DIFF
--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -175,8 +175,6 @@ def test_Auditioner():
             model_group_ids,
             train_end_times,
             no_filtering,
-            distance_table='distance_table',
-
         )
         assert len(auditioner.thresholded_model_group_ids) == num_model_groups
         auditioner.plot_model_groups()

--- a/src/tests/audition_tests/test_audition.py
+++ b/src/tests/audition_tests/test_audition.py
@@ -175,6 +175,8 @@ def test_Auditioner():
             model_group_ids,
             train_end_times,
             no_filtering,
+            distance_table='distance_table',
+
         )
         assert len(auditioner.thresholded_model_group_ids) == num_model_groups
         auditioner.plot_model_groups()

--- a/src/tests/audition_tests/test_thresholding.py
+++ b/src/tests/audition_tests/test_thresholding.py
@@ -4,13 +4,13 @@ import testing.postgresql
 from sqlalchemy import create_engine
 
 from triage.component.audition.distance_from_best import DistanceFromBestTable
-from triage.component.audition.thresholding import ModelGroupChecker, ModelGroupThresholder
+from triage.component.audition.thresholding import model_groups_filter, ModelGroupThresholder
 from triage.component.catwalk.db import ensure_db
 
 from tests.results_tests.factories import ModelFactory, ModelGroupFactory, init_engine, session
 
-class ModelGroupCheckerTest(TestCase):
-    def setup_data(self, engine):
+class ModelGroupFilterTest(TestCase):
+    def filter_same_train_end_times(self, engine):
         ensure_db(engine)
         init_engine(engine)
         mg1 = ModelGroupFactory(model_group_id=1, model_type='modelType1')
@@ -36,20 +36,19 @@ class ModelGroupCheckerTest(TestCase):
         session.commit()
         train_end_times = ['2014-01-01', '2015-01-01', '2016-01-01', '2017-01-01']
         model_groups = [1, 2, 3, 4]
-        model_group_checker = ModelGroupChecker(
+        model_group_ids = model_groups_filter(
              train_end_times=train_end_times,
              initial_model_group_ids=model_groups,
              models_table='models',
              db_engine=engine
         )
 
-        return model_group_checker
+        return model_group_ids
 
     def test_have_same_train_end_times(self):
         with testing.postgresql.Postgresql() as postgresql:
             engine = create_engine(postgresql.url())
-            model_group_checker = self.setup_data(engine)
-            pass_model_groups = model_group_checker.have_same_train_end_times()
+            pass_model_groups = self.filter_same_train_end_times(engine)
             assert pass_model_groups == {1, 3}
 
 

--- a/src/tests/audition_tests/test_thresholding.py
+++ b/src/tests/audition_tests/test_thresholding.py
@@ -1,13 +1,56 @@
 from unittest import TestCase
-
+from datetime import datetime
 import testing.postgresql
 from sqlalchemy import create_engine
 
 from triage.component.audition.distance_from_best import DistanceFromBestTable
-from triage.component.audition.thresholding import ModelGroupThresholder
+from triage.component.audition.thresholding import ModelGroupChecker, ModelGroupThresholder
 from triage.component.catwalk.db import ensure_db
 
-from tests.results_tests.factories import ModelGroupFactory, init_engine, session
+from tests.results_tests.factories import ModelFactory, ModelGroupFactory, init_engine, session
+
+class ModelGroupCheckerTest(TestCase):
+    def setup_data(self, engine):
+        ensure_db(engine)
+        init_engine(engine)
+        mg1 = ModelGroupFactory(model_group_id=1, model_type='modelType1')
+        mg2 = ModelGroupFactory(model_group_id=2, model_type='modelType2')
+        mg3 = ModelGroupFactory(model_group_id=3, model_type='modelType3')
+        mg4 = ModelGroupFactory(model_group_id=4, model_type='modelType4')
+        # model group 1
+        ModelFactory(model_group_rel=mg1, train_end_time=datetime(2014, 1, 1))
+        ModelFactory(model_group_rel=mg1, train_end_time=datetime(2015, 1, 1))
+        ModelFactory(model_group_rel=mg1, train_end_time=datetime(2016, 1, 1))
+        ModelFactory(model_group_rel=mg1, train_end_time=datetime(2017, 1, 1))
+        # model group 2 only has three timestamps, should not pass
+        ModelFactory(model_group_rel=mg2, train_end_time=datetime(2014, 1, 1))
+        # model group 3
+        ModelFactory(model_group_rel=mg3, train_end_time=datetime(2014, 1, 1))
+        ModelFactory(model_group_rel=mg3, train_end_time=datetime(2015, 1, 1))
+        ModelFactory(model_group_rel=mg3, train_end_time=datetime(2016, 1, 1))
+        ModelFactory(model_group_rel=mg3, train_end_time=datetime(2017, 1, 1))
+        # model group 4 only has three timestamps, should not pass
+        ModelFactory(model_group_rel=mg4, train_end_time=datetime(2015, 1, 1))
+        ModelFactory(model_group_rel=mg4, train_end_time=datetime(2016, 1, 1))
+
+        session.commit()
+        train_end_times = ['2014-01-01', '2015-01-01', '2016-01-01', '2017-01-01']
+        model_groups = [1, 2, 3, 4]
+        model_group_checker = ModelGroupChecker(
+             train_end_times=train_end_times,
+             initial_model_group_ids=model_groups,
+             models_table='models',
+             db_engine=engine
+        )
+
+        return model_group_checker
+
+    def test_have_same_train_end_times(self):
+        with testing.postgresql.Postgresql() as postgresql:
+            engine = create_engine(postgresql.url())
+            model_group_checker = self.setup_data(engine)
+            pass_model_groups = model_group_checker.have_same_train_end_times()
+            assert pass_model_groups == {1, 3}
 
 
 class ModelGroupThresholderTest(TestCase):

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -6,7 +6,7 @@ import os
 from smart_open import smart_open
 
 from .distance_from_best import DistanceFromBestTable, BestDistancePlotter
-from .thresholding import ModelGroupChecker, ModelGroupThresholder
+from .thresholding import model_groups_filter, ModelGroupThresholder
 from .regrets import SelectionRulePicker, SelectionRulePlotter
 from .selection_rule_performance import SelectionRulePerformancePlotter
 from .model_group_performance import ModelGroupPerformancePlotter
@@ -86,14 +86,12 @@ class Auditioner(object):
         )
         self.best_distance_plotter = BestDistancePlotter(self.distance_from_best_table, self.directory)
 
-        self.model_group_checker = ModelGroupChecker(
-            train_end_times = train_end_times,
-            initial_model_group_ids = model_group_ids,
-            models_table = models_table,
-            db_engine = db_engine
+        self.first_pass_model_groups = model_groups_filter(
+                train_end_times-train_end_times,
+                initial_model_group_ids=model_group_ids,
+                models_table=models_table,
+                db_engine=db_engine
         )
-
-        self.first_pass_model_groups = self.model_group_checker.have_same_train_end_times()
 
         self.model_group_thresholder = ModelGroupThresholder(
             distance_from_best_table=self.distance_from_best_table,

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -87,7 +87,7 @@ class Auditioner(object):
         self.best_distance_plotter = BestDistancePlotter(self.distance_from_best_table, self.directory)
 
         self.first_pass_model_groups = model_groups_filter(
-                train_end_times-train_end_times,
+                train_end_times=train_end_times,
                 initial_model_group_ids=model_group_ids,
                 models_table=models_table,
                 db_engine=db_engine

--- a/src/triage/component/audition/__init__.py
+++ b/src/triage/component/audition/__init__.py
@@ -84,13 +84,12 @@ class Auditioner(object):
             models_table=models_table,
             distance_table=distance_table,
         )
-
         self.best_distance_plotter = BestDistancePlotter(self.distance_from_best_table, self.directory)
 
         self.model_group_checker = ModelGroupChecker(
             train_end_times = train_end_times,
             initial_model_group_ids = model_group_ids,
-            distance_table = distance_table,
+            models_table = models_table,
             db_engine = db_engine
         )
 

--- a/src/triage/component/audition/distance_from_best.py
+++ b/src/triage/component/audition/distance_from_best.py
@@ -58,6 +58,7 @@ class DistanceFromBestTable(object):
                 All models should have the test_results.evaluations table populated
                 for all given model group ids, train end times, and metric/param combos
         """
+        logging.info("Polulating data to distance table")
         for metric in metrics:
             self.db_engine.execute('''
                 insert into {new_table}

--- a/src/triage/component/audition/thresholding.py
+++ b/src/triage/component/audition/thresholding.py
@@ -1,7 +1,6 @@
 import logging
 
 from .metric_directionality import is_better_operator
-# from .pre_audition import PreAudition
 import pandas as pd
 from datetime import datetime
 
@@ -44,7 +43,7 @@ def model_groups_filter(
                                       schema of a completed modeling run
     """
 
-    if not isinstance(train_end_times, list) or not all(isinstance(e, str) for e in train_end_times):
+    if isinstance(train_end_times, str) or not hasattr(train_end_times, '__iter__'):
         raise TypeError("train_end_times should be a list of str or timestamp")
 
     if not bool(train_end_times):
@@ -53,7 +52,7 @@ def model_groups_filter(
     end_times_sql = "ARRAY[{}]".format(
         ', '.join(
             "'{}'".format(
-                end_time.strftime('%Y -%m-%d') if isinstance(end_time, datetime) else end_time
+                end_time.strftime('%Y-%m-%d') if isinstance(end_time, datetime) else end_time
             ) for end_time in train_end_times
         )
     )
@@ -79,7 +78,6 @@ def model_groups_filter(
     logging.info(f"Found {len(model_group_ids)} total model groups past the checker")
 
     return set(model_group_ids)
-
 
 class ModelGroupThresholder(object):
 


### PR DESCRIPTION
Add a new function `model_groups_filter` in `thresholding.py` to make sure that those model groups have different train end times won't make it to distance table. This will fix the confusion of seeing lots of model being filtered where there's no filter when we first call `plot_model_groups()` as well as the issue of non-existent best cases (#365 the gap of best cases in the plot before).

![screen shot 2018-08-10 at 5 41 55 pm](https://user-images.githubusercontent.com/9650575/43984247-f5e958b8-9cc4-11e8-8ee9-41a976a74b17.png)
