### PR TITLE
Refactor Storage, allow HDF support [Resolves #266]

### DIFF
--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -18,7 +18,8 @@ from triage.component.architect.features import (
 from triage.component.architect.label_generators import LabelGenerator
 from triage.component.architect.state_table_generators import StateTableGeneratorFromDense
 from triage.component.architect.planner import Planner
-from triage.component.architect.builders import HighMemoryCSVBuilder
+from triage.component.architect.builders import MatrixBuilder
+from triage.component.catwalk.storage import ProjectStorage
 
 from tests.utils import sample_config
 
@@ -210,17 +211,16 @@ def basic_integration_test(
                 feature_group_create_rules)
 
             feature_group_mixer = FeatureGroupMixer(feature_group_mix_rules)
-
+            project_storage = ProjectStorage(temp_dir)
             planner = Planner(
                 feature_start_time=datetime(2010, 1, 1),
                 label_names=['outcome'],
                 label_types=['binary'],
-                matrix_directory=os.path.join(temp_dir, 'matrices'),
                 states=state_filters,
                 user_metadata={},
             )
 
-            builder = HighMemoryCSVBuilder(
+            builder = MatrixBuilder(
                 engine=db_engine,
                 db_config={
                     'features_schema_name': 'features',
@@ -228,7 +228,7 @@ def basic_integration_test(
                     'labels_table_name': 'labels',
                     'sparse_state_table_name': 'tmp_sparse_states_abcd',
                 },
-                matrix_directory=os.path.join(temp_dir, 'matrices'),
+                matrix_storage_engine=project_storage.matrix_storage_engine(),
                 replace=True
             )
 

--- a/src/tests/architect_tests/test_planner.py
+++ b/src/tests/architect_tests/test_planner.py
@@ -77,7 +77,6 @@ def test_Planner():
         cohort_name='prior_bookings',
         states=['state_one AND state_two'],
         user_metadata={},
-        matrix_directory='',  # this test won't write anything
     )
 
     updated_matrix_definitions, build_tasks = \
@@ -97,7 +96,6 @@ def test_Planner():
 
     assert sum(1 for task in build_tasks if task['matrix_type'] == 'train') == 4
     assert sum(1 for task in build_tasks if task['matrix_type'] == 'test') == 4
-    assert all(task for task in build_tasks if task['matrix_directory'] == '')
     assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_one) == 4
     assert sum(1 for task in build_tasks if task['feature_dictionary'] == feature_dict_two) == 4
     assert sum(

--- a/src/tests/architect_tests/utils.py
+++ b/src/tests/architect_tests/utils.py
@@ -180,31 +180,6 @@ def fake_labels(length):
     return numpy.array([random.choice([True, False]) for i in range(0, length)])
 
 
-class MockTrainedModel(object):
-    def predict_proba(self, dataset):
-        return numpy.random.rand(len(dataset), len(dataset))
-
-
-def fake_trained_model(project_path, model_storage_engine, db_engine):
-    """Creates and stores a trivial trained model
-
-    Args:
-        project_path (string) a desired fs/s3 project path
-        model_storage_engine (triage.storage.ModelStorageEngine)
-        db_engine (sqlalchemy.engine)
-
-    Returns:
-        (int) model id for database retrieval
-    """
-    trained_model = MockTrainedModel()
-    model_storage_engine.get_store('abcd').write(trained_model)
-    session = sessionmaker(db_engine)()
-    db_model = Model(model_hash='abcd')
-    session.add(db_model)
-    session.commit()
-    return trained_model, db_model.model_id
-
-
 def assert_index(engine, table, column):
     """Assert that a table has an index on a given column
 

--- a/src/tests/catwalk_tests/test_evaluation.py
+++ b/src/tests/catwalk_tests/test_evaluation.py
@@ -6,7 +6,6 @@ import numpy
 from sqlalchemy import create_engine
 from triage.component.catwalk.db import ensure_db
 from tests.utils import fake_labels, fake_trained_model, MockMatrixStore
-from triage.component.catwalk.storage import InMemoryModelStorageEngine
 import datetime
 
 
@@ -53,11 +52,7 @@ def test_evaluating_early_warning():
         fake_train_matrix_store = MockMatrixStore('train', 'efgh', 5, db_engine, labels)
         fake_test_matrix_store = MockMatrixStore('test', '1234', 5, db_engine, labels)
 
-        trained_model, model_id = fake_trained_model(
-            'myproject',
-            InMemoryModelStorageEngine('myproject'),
-            db_engine
-        )
+        trained_model, model_id = fake_trained_model(db_engine)
 
         # Evaluate the testing metrics and test for all of them.
         model_evaluator.evaluate(
@@ -154,11 +149,7 @@ def test_model_scoring_inspections():
         fake_train_matrix_store = MockMatrixStore('train', 'efgh', 5, db_engine, training_labels)
         fake_test_matrix_store = MockMatrixStore('test', '1234', 5, db_engine, testing_labels)
 
-        trained_model, model_id = fake_trained_model(
-            'myproject',
-            InMemoryModelStorageEngine('myproject'),
-            db_engine
-        )
+        trained_model, model_id = fake_trained_model(db_engine)
 
         # Evaluate testing matrix and test the results
         model_evaluator.evaluate(

--- a/src/tests/catwalk_tests/test_model_trainers.py
+++ b/src/tests/catwalk_tests/test_model_trainers.py
@@ -1,4 +1,3 @@
-import boto3
 import pandas
 import testing.postgresql
 import sqlalchemy
@@ -6,16 +5,13 @@ import unittest
 from unittest.mock import patch
 import pytest
 
-from moto import mock_s3
 from sqlalchemy import create_engine
 from triage.component.catwalk.db import ensure_db
+from tests.results_tests.factories import init_engine
 
 from triage.component.catwalk.model_grouping import ModelGrouper
 from triage.component.catwalk.model_trainers import ModelTrainer
-from triage.component.catwalk.storage import InMemoryModelStorageEngine,\
-    S3ModelStorageEngine, MatrixStore
-from .utils import sample_matrix_store, sample_metadata
-from tests.results_tests.factories import init_engine, session, MatrixFactory
+from tests.utils import rig_engines, get_matrix_store
 
 
 @pytest.fixture
@@ -23,233 +19,196 @@ def grid_config():
     return {
         'sklearn.tree.DecisionTreeClassifier': {
             'min_samples_split': [10, 100],
-            'max_depth': [3,5],
+            'max_depth': [3, 5],
             'criterion': ['gini']
         }
     }
 
 
-def test_model_trainer(sample_matrix_store, grid_config):
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
+def test_model_trainer(grid_config):
+    with rig_engines() as (db_engine, project_storage):
+        # Creates a matrix entry in the matrices table with uuid from metadata above
+        model_storage_engine = project_storage.model_storage_engine()
+        trainer = ModelTrainer(
+            experiment_hash=None,
+            model_storage_engine=model_storage_engine,
+            model_grouper=ModelGrouper(),
+            db_engine=db_engine,
+        )
+        model_ids = trainer.train_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage),
+        )
 
-        with mock_s3():
-            s3_conn = boto3.resource('s3')
-            s3_conn.create_bucket(Bucket='econ-dev')
+        # assert
+        # 1. that the models and feature importances table entries are present
+        records = [
+            row for row in
+            db_engine.execute('select * from train_results.feature_importances')
+        ]
+        assert len(records) == 4 * 2  # maybe exclude entity_id? yes
 
-            # Creates a matrix entry in the matrices table with uuid from metadata above
-            MatrixFactory(matrix_uuid = "1234")
-            session.commit()
-            project_path = 'econ-dev/inspections'
-            model_storage_engine = S3ModelStorageEngine(project_path)
-            trainer = ModelTrainer(
-                project_path=project_path,
-                experiment_hash=None,
-                model_storage_engine=model_storage_engine,
-                model_grouper=ModelGrouper(),
-                db_engine=db_engine,
-            )
-            model_ids = trainer.train_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store
-            )
+        records = [
+            row for row in
+            db_engine.execute('select model_hash from model_metadata.models')
+        ]
+        assert len(records) == 4
+        hashes = [row[0] for row in records]
 
-            # assert
-            # 1. that the models and feature importances table entries are present
-            records = [
-                row for row in
-                db_engine.execute('select * from train_results.feature_importances')
-            ]
-            assert len(records) == 4 * 2  # maybe exclude entity_id? yes
+        # 2. that the model groups are distinct
+        records = [
+            row for row in
+            db_engine.execute('select distinct model_group_id from model_metadata.models')
+        ]
+        assert len(records) == 4
 
-            records = [
-                row for row in
-                db_engine.execute('select model_hash from model_metadata.models')
-            ]
-            assert len(records) == 4
-            hashes = [row[0] for row in records]
+        # 3. that the model sizes are saved in the table and all are < 1 kB
+        records = [
+            row for row in
+            db_engine.execute('select model_size from model_metadata.models')
+        ]
+        assert len(records) == 4
+        for i in records:
+            size = i[0]
+            assert size < 1
 
-            # 2. that the model groups are distinct
-            records = [
-                row for row in
-                db_engine.execute('select distinct model_group_id from model_metadata.models')
-            ]
-            assert len(records) == 4
+        # 4. that all four models are cached
+        model_pickles = [
+            model_storage_engine.load(model_hash)
+            for model_hash in hashes
+        ]
+        assert len(model_pickles) == 4
+        assert len([x for x in model_pickles if x is not None]) == 4
 
-            # 3. that the model sizes are saved in the table and all are < 1 kB
-            records = [
-                row for row in
-                db_engine.execute('select model_size from model_metadata.models')
-            ]
-            assert len(records) == 4
-            for i in records:
-                size = i[0]
-                assert size < 1
-
-            # 4. that all four models are cached
-            model_pickles = [
-                model_storage_engine.get_store(model_hash).load()
-                for model_hash in hashes
-            ]
-            assert len(model_pickles) == 4
-            assert len([x for x in model_pickles if x is not None]) == 4
-
-            # 5. that their results can have predictions made on it
-            test_matrix = pandas.DataFrame.from_dict({
-                'entity_id': [3, 4],
-                'feature_one': [4, 4],
-                'feature_two': [6, 5],
-            }).set_index('entity_id')
+        # 5. that their results can have predictions made on it
+        test_matrix = pandas.DataFrame.from_dict({
+            'entity_id': [3, 4],
+            'feature_one': [4, 4],
+            'feature_two': [6, 5],
+        }).set_index('entity_id')
 
 
-            for model_pickle in model_pickles:
-                predictions = model_pickle.predict(test_matrix)
-                assert len(predictions) == 2
+        for model_pickle in model_pickles:
+            predictions = model_pickle.predict(test_matrix)
+            assert len(predictions) == 2
 
-            # 6. when run again, same models are returned
-            new_model_ids = trainer.train_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store
-            )
-            assert len([
-                row for row in
-                db_engine.execute('select model_hash from model_metadata.models')
-            ]) == 4
-            assert model_ids == new_model_ids
+        # 6. when run again, same models are returned
+        new_model_ids = trainer.train_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage)
+        )
+        assert len([
+            row for row in
+            db_engine.execute('select model_hash from model_metadata.models')
+        ]) == 4
+        assert model_ids == new_model_ids
 
-            # 7. if replace is set, update non-unique attributes and feature importances
-            max_batch_run_time = [
-                row[0] for row in
-                db_engine.execute('select max(batch_run_time) from model_metadata.models')
-            ][0]
-            trainer = ModelTrainer(
-                project_path=project_path,
-                experiment_hash=None,
-                model_storage_engine=model_storage_engine,
-                model_grouper=ModelGrouper(model_group_keys=['label_name', 'label_timespan']),
-                db_engine=db_engine,
-                replace=True
-            )
-            new_model_ids = trainer.train_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store,
-            )
-            assert model_ids == new_model_ids
-            assert [
-                row['model_id'] for row in
-                db_engine.execute('select model_id from model_metadata.models order by 1 asc')
-            ] == model_ids
-            new_max_batch_run_time = [
-                row[0] for row in
-                db_engine.execute('select max(batch_run_time) from model_metadata.models')
-            ][0]
-            assert new_max_batch_run_time > max_batch_run_time
+        # 7. if replace is set, update non-unique attributes and feature importances
+        max_batch_run_time = [
+            row[0] for row in
+            db_engine.execute('select max(batch_run_time) from model_metadata.models')
+        ][0]
+        trainer = ModelTrainer(
+            experiment_hash=None,
+            model_storage_engine=model_storage_engine,
+            model_grouper=ModelGrouper(model_group_keys=['label_name', 'label_timespan']),
+            db_engine=db_engine,
+            replace=True
+        )
+        new_model_ids = trainer.train_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage)
+        )
+        assert model_ids == new_model_ids
+        assert [
+            row['model_id'] for row in
+            db_engine.execute('select model_id from model_metadata.models order by 1 asc')
+        ] == model_ids
+        new_max_batch_run_time = [
+            row[0] for row in
+            db_engine.execute('select max(batch_run_time) from model_metadata.models')
+        ][0]
+        assert new_max_batch_run_time > max_batch_run_time
 
-            records = [
-                row for row in
-                db_engine.execute('select * from train_results.feature_importances')
-            ]
-            assert len(records) == 4 * 2  # maybe exclude entity_id? yes
+        records = [
+            row for row in
+            db_engine.execute('select * from train_results.feature_importances')
+        ]
+        assert len(records) == 4 * 2  # maybe exclude entity_id? yes
 
-            # 8. if the cache is missing but the metadata is still there, reuse the metadata
-            for row in db_engine.execute('select model_hash from model_metadata.models'):
-                model_storage_engine.get_store(row[0]).delete()
-            new_model_ids = trainer.train_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store
-            )
-            assert model_ids == sorted(new_model_ids)
+        # 8. if the cache is missing but the metadata is still there, reuse the metadata
+        for row in db_engine.execute('select model_hash from model_metadata.models'):
+            model_storage_engine.delete(row[0])
+        new_model_ids = trainer.train_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage)
+        )
+        assert model_ids == sorted(new_model_ids)
 
-            # 9. that the generator interface works the same way
-            new_model_ids = trainer.generate_trained_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store
-            )
-            assert model_ids == \
-                sorted([model_id for model_id in new_model_ids])
+        # 9. that the generator interface works the same way
+        new_model_ids = trainer.generate_trained_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage)
+        )
+        assert model_ids == \
+            sorted([model_id for model_id in new_model_ids])
 
-def test_baseline_exception_handling(sample_matrix_store):
+def test_baseline_exception_handling():
     grid_config = {
         'triage.component.catwalk.baselines.rankers.PercentileRankOneFeature': {
             'feature': ['feature_one', 'feature_three']
         }
     }
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        project_path = 'econ-dev/inspections'
-        model_storage_engine = S3ModelStorageEngine(project_path)
-        ensure_db(db_engine)
-        init_engine(db_engine)
-        with mock_s3():
-            s3_conn = boto3.resource('s3')
-            s3_conn.create_bucket(Bucket='econ-dev')
-            trainer = ModelTrainer(
-                project_path='econ-dev/inspections',
-                experiment_hash=None,
-                model_storage_engine = model_storage_engine,
-                db_engine=db_engine,
-                model_grouper=ModelGrouper()
-            )
+    with rig_engines() as (db_engine, project_storage):
+        trainer = ModelTrainer(
+            experiment_hash=None,
+            model_storage_engine=project_storage.model_storage_engine(),
+            db_engine=db_engine,
+            model_grouper=ModelGrouper()
+        )
 
-            train_tasks = trainer.generate_train_tasks(
-                grid_config,
-                dict(),
-                sample_matrix_store
-            )
-            # Creates a matrix entry in the matrices table with uuid from train_metadata
-            MatrixFactory(matrix_uuid = "1234")
-            session.commit()
+        train_tasks = trainer.generate_train_tasks(
+            grid_config,
+            dict(),
+            get_matrix_store(project_storage)
+        )
 
-            model_ids = []
-            for train_task in train_tasks:
-                model_ids.append(trainer.process_train_task(**train_task))
-            assert model_ids == [1, None]
+        model_ids = []
+        for train_task in train_tasks:
+            model_ids.append(trainer.process_train_task(**train_task))
+        assert model_ids == [1, None]
 
 
-def test_custom_groups(sample_matrix_store, grid_config):
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        ensure_db(engine)
-        init_engine(engine)
-
-        with mock_s3():
-            s3_conn = boto3.resource('s3')
-            s3_conn.create_bucket(Bucket='econ-dev')
-
-            MatrixFactory(matrix_uuid = "1234")
-            session.commit()
-            # create training set
-            project_path = 'econ-dev/inspections'
-            model_storage_engine = S3ModelStorageEngine(project_path)
-            trainer = ModelTrainer(
-                project_path=project_path,
-                experiment_hash=None,
-                model_storage_engine=model_storage_engine,
-                model_grouper=ModelGrouper(['class_path']),
-                db_engine=engine,
-            )
-            model_ids = trainer.train_models(
-                grid_config=grid_config,
-                misc_db_parameters=dict(),
-                matrix_store=sample_matrix_store
-            )
-            # expect only one model group now
-            records = [
-                row[0] for row in
-                engine.execute('select distinct model_group_id from model_metadata.models')
-            ]
-            assert len(records) == 1
-            assert records[0] == model_ids[0]
+def test_custom_groups(grid_config):
+    with rig_engines() as (db_engine, project_storage):
+        # create training set
+        model_storage_engine = project_storage.model_storage_engine()
+        trainer = ModelTrainer(
+            experiment_hash=None,
+            model_storage_engine=model_storage_engine,
+            model_grouper=ModelGrouper(['class_path']),
+            db_engine=db_engine,
+        )
+        model_ids = trainer.train_models(
+            grid_config=grid_config,
+            misc_db_parameters=dict(),
+            matrix_store=get_matrix_store(project_storage)
+        )
+        # expect only one model group now
+        records = [
+            row[0] for row in
+            db_engine.execute('select distinct model_group_id from model_metadata.models')
+        ]
+        assert len(records) == 1
+        assert records[0] == model_ids[0]
 
 
-def test_n_jobs_not_new_model(sample_matrix_store):
+def test_n_jobs_not_new_model():
     grid_config = {
         'sklearn.ensemble.AdaBoostClassifier': {
             'n_estimators': [10, 100, 1000]
@@ -263,43 +222,34 @@ def test_n_jobs_not_new_model(sample_matrix_store):
         }
     }
 
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
-        with mock_s3():
-            s3_conn = boto3.resource('s3')
-            s3_conn.create_bucket(Bucket='econ-dev')
-            trainer = ModelTrainer(
-                project_path='econ-dev/inspections',
-                experiment_hash=None,
-                model_storage_engine=S3ModelStorageEngine('econ-dev/inspections'),
-                db_engine=db_engine,
-                model_grouper=ModelGrouper()
-            )
+    with rig_engines() as (db_engine, project_storage):
+        model_storage_engine = project_storage.model_storage_engine()
+        trainer = ModelTrainer(
+            experiment_hash=None,
+            model_storage_engine=model_storage_engine,
+            db_engine=db_engine,
+            model_grouper=ModelGrouper()
+        )
 
-            train_tasks = trainer.generate_train_tasks(
-                grid_config,
-                dict(),
-                sample_matrix_store,
-            )
-            # Creates a matrix entry in the matrices table with uuid from train_metadata
-            MatrixFactory(matrix_uuid = "1234")
-            session.commit()
+        train_tasks = trainer.generate_train_tasks(
+            grid_config,
+            dict(),
+            get_matrix_store(project_storage),
+        )
 
-            assert len(train_tasks) == 35 # 32+3, would be (32*2)+3 if we didn't remove
-            assert len([
-                task for task in train_tasks
-                if 'n_jobs' in task['parameters']
-            ]) == 32
+        assert len(train_tasks) == 35 # 32+3, would be (32*2)+3 if we didn't remove
+        assert len([
+            task for task in train_tasks
+            if 'n_jobs' in task['parameters']
+        ]) == 32
 
-            for train_task in train_tasks:
-                trainer.process_train_task(**train_task)
+        for train_task in train_tasks:
+            trainer.process_train_task(**train_task)
 
-            for row in db_engine.execute(
-                'select hyperparameters from model_metadata.model_groups'
-            ):
-                assert 'n_jobs' not in row[0]
+        for row in db_engine.execute(
+            'select hyperparameters from model_metadata.model_groups'
+        ):
+            assert 'n_jobs' not in row[0]
 
 
 class RetryTest(unittest.TestCase):
@@ -307,25 +257,19 @@ class RetryTest(unittest.TestCase):
         db_engine = None
         trainer = None
         # set up a basic model training run
-        # TODO abstract the setup of a basic model training run where
-        # we don't worry about the specific values used? it would make
-        # tests like this require a bit less noise to read past
-        with testing.postgresql.Postgresql() as postgresql:
-            db_engine = create_engine(postgresql.url())
-            ensure_db(db_engine)
-            init_engine(db_engine)
+        with rig_engines() as (db_engine, project_storage):
             trainer = ModelTrainer(
-                project_path='econ-dev/inspections',
                 experiment_hash=None,
-                model_storage_engine=InMemoryModelStorageEngine(project_path=''),
+                model_storage_engine=project_storage.model_storage_engine(),
                 db_engine=db_engine,
                 model_grouper=ModelGrouper()
             )
+            matrix_store = get_matrix_store(project_storage)
 
         # the postgres server goes out of scope here and thus no longer exists
         with patch('time.sleep') as time_mock:
             with self.assertRaises(sqlalchemy.exc.OperationalError):
-                trainer.train_models(grid_config(), dict(), sample_matrix_store())
+                trainer.train_models(grid_config(), dict(), matrix_store)
             # we want to make sure that we are using the retrying module sanely
             # as opposed to matching the exact # of calls specified by the code
             assert len(time_mock.mock_calls) > 5
@@ -334,18 +278,15 @@ class RetryTest(unittest.TestCase):
         db_engine = None
         trainer = None
         port = None
-        with testing.postgresql.Postgresql() as postgresql:
-            port = postgresql.settings['port']
-            db_engine = create_engine(postgresql.url())
-            ensure_db(db_engine)
-            init_engine(db_engine)
+        with rig_engines() as (db_engine, project_storage):
+            port = db_engine.url.port
             trainer = ModelTrainer(
-                project_path='econ-dev/inspections',
                 experiment_hash=None,
-                model_storage_engine=InMemoryModelStorageEngine(project_path=''),
+                model_storage_engine=project_storage.model_storage_engine(),
                 db_engine=db_engine,
                 model_grouper=ModelGrouper()
             )
+            matrix_store = get_matrix_store(project_storage)
 
         # start without a database server
         # then bring it back up after the first sleep
@@ -357,15 +298,12 @@ class RetryTest(unittest.TestCase):
             db_engine = create_engine(self.new_server.url())
             ensure_db(db_engine)
             init_engine(db_engine)
-
-            # Creates a matrix entry in the matrices table with uuid from train_metadata
-            MatrixFactory(matrix_uuid = "1234")
-            session.commit()
+            get_matrix_store(project_storage)
 
         with patch('time.sleep') as time_mock:
             time_mock.side_effect = replace_db
             try:
-                trainer.train_models(grid_config(), dict(), sample_matrix_store())
+                trainer.train_models(grid_config(), dict(), matrix_store)
             finally:
                 if self.new_server is not None:
                     self.new_server.stop()

--- a/src/tests/catwalk_tests/test_predictors.py
+++ b/src/tests/catwalk_tests/test_predictors.py
@@ -1,207 +1,132 @@
-import boto3
-import testing.postgresql
-from moto import mock_s3
-from sqlalchemy import create_engine
+from contextlib import contextmanager
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.orm.session import make_transient
 import datetime
 from unittest.mock import Mock
 from numpy.testing import assert_array_equal
-import tempfile
 import pandas
 
-from triage.component.results_schema import TestPrediction, TrainPrediction
-from triage.component.catwalk.db import ensure_db
+from triage.component.results_schema import TestPrediction, Matrix, Model
 
 from triage.component.catwalk.predictors import Predictor
-from tests.utils import fake_trained_model, sample_metta_csv_diff_order
-from triage.component.catwalk.storage import (
-    InMemoryModelStorageEngine,
-    S3ModelStorageEngine,
-    MatrixStore
-    )
-from tests.results_tests.factories import init_engine, session, MatrixFactory
+from tests.utils import MockTrainedModel, matrix_creator, matrix_metadata_creator, get_matrix_store, rig_engines
 
 
 AS_OF_DATE = datetime.date(2016, 12, 21)
 
 
-def test_predictor():
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
+@contextmanager
+def prepare():
+    with rig_engines() as (db_engine, project_storage):
+        train_matrix_uuid = '1234'
+        session = sessionmaker(db_engine)()
+        session.add(Matrix(matrix_uuid=train_matrix_uuid))
 
-        with mock_s3():
-            s3_conn = boto3.resource('s3')
-            s3_conn.create_bucket(Bucket='econ-dev')
-            project_path = 'econ-dev/inspections'
-            model_storage_engine = S3ModelStorageEngine(project_path)
-
-            _, model_id = \
-                fake_trained_model(project_path, model_storage_engine, db_engine, train_matrix_uuid='1234')
-
-            predictor = Predictor(project_path, model_storage_engine, db_engine)
-
-            # create prediction set
-            matrix = pandas.DataFrame.from_dict({
-                'entity_id': [1, 2],
-                'feature_one': [3, 4],
-                'feature_two': [5, 6],
-                'label': [7, 8]
-            }).set_index('entity_id')
-
-            metadata = {
-                'label_name': 'label',
-                'end_time': AS_OF_DATE,
-                'label_timespan': '3month',
-                'metta-uuid': '1234',
-                'indices': ['entity_id'],
-            }
-
-            train_matrix_columns = ['feature_one', 'feature_two']
-
-            # Runs the same test for training and testing predictions
-            for mat_type in ("train", "test"):
-                # Create the matrix to be tested and store in db
-                metadata['matrix_type'] = mat_type
-
-                matrix_store = MatrixStore()
-                matrix_store.matrix = matrix
-                matrix_store.metadata = metadata
-
-                # Note, the first time 'matrix' is used, the label column is popped.
-                # It must be added back in to 'matrix' to create another matrix_store.
-                matrix['label'] = [7, 8]
-
-                predict_proba = predictor.predict(
-                    model_id,
-                    matrix_store,
-                    misc_db_parameters=dict(),
-                    train_matrix_columns=train_matrix_columns
-                )
-
-                # assert
-                # 1. that the returned predictions are of the desired length
-                assert len(predict_proba) == 2
-
-                # 2. that the predictions table entries are present and
-                # can be linked to the original models
-                records = [
-                    row for row in
-                    db_engine.execute('''select entity_id, as_of_date
-                    from {}_results.predictions
-                    join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
-                ]
-                assert len(records) == 2
-
-                # 3. that the contained as_of_dates match what we sent in
-                for record in records:
-                    assert record[1].date() == AS_OF_DATE
-
-                # 4. that the entity ids match the given dataset
-                assert sorted([record[0] for record in records]) == [1, 2]
+        # Create the fake trained model and store in db
+        trained_model = MockTrainedModel()
+        model_hash = 'abcd'
+        project_storage.model_storage_engine().write(trained_model, model_hash)
+        db_model = Model(model_hash=model_hash, train_matrix_uuid=train_matrix_uuid)
+        session.add(db_model)
+        session.commit()
+        yield project_storage, db_engine, db_model.model_id
 
 
-            # 5. running with same model_id, different as of date
-            # then with same as of date only replaces the records
-            # with the same date
-            new_matrix = pandas.DataFrame.from_dict({
-                'entity_id': [1, 2],
-                'feature_one': [3, 4],
-                'feature_two': [5, 6],
-                'label': [7, 8]
-            }).set_index('entity_id')
-            new_metadata = {
-                'label_name': 'label',
-                'end_time': AS_OF_DATE + datetime.timedelta(days=1),
-                'label_timespan': '3month',
-                'metta-uuid': '1234',
-                'indices': ['entity_id'],
-            }
+def test_predictor_entity_index():
+    with prepare() as (project_storage, db_engine, model_id):
+        predictor = Predictor(project_storage.model_storage_engine(), db_engine)
 
-            # Runs the same test for training and testing predictions
-            for mat_type in ("train", "test"):
+        # Runs the same test for training and testing predictions
+        for mat_type in ("train", "test"):
+            matrix = matrix_creator(index='entity_id')
+            metadata = matrix_metadata_creator(end_time=AS_OF_DATE, matrix_type=mat_type, indices=['entity_id'])
 
-                # Create the matrix to be tested and store in db
-                new_metadata['matrix_type'] = mat_type
+            matrix_store = get_matrix_store(project_storage, matrix, metadata)
+            train_matrix_columns = matrix.columns[0:-1].tolist()
 
-                new_matrix_store = MatrixStore()
-                new_matrix_store.matrix = new_matrix
-                new_matrix_store.metadata = new_metadata
+            predict_proba = predictor.predict(
+                model_id,
+                matrix_store,
+                misc_db_parameters=dict(),
+                train_matrix_columns=train_matrix_columns
+            )
 
-                # Adding 'label' column back into new_matrix
-                new_matrix['label'] = [7, 8]
+            # assert
+            # 1. that the returned predictions are of the desired length
+            assert len(predict_proba) == 2
 
-                predictor.predict(
-                    model_id,
-                    new_matrix_store,
-                    misc_db_parameters=dict(),
-                    train_matrix_columns=train_matrix_columns
-                )
-                predictor.predict(
-                    model_id,
-                    matrix_store,
-                    misc_db_parameters=dict(),
-                    train_matrix_columns=train_matrix_columns
-                )
-                records = [
-                    row for row in
-                    db_engine.execute('''select entity_id, as_of_date
-                    from {}_results.predictions
-                    join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
-                ]
-                assert len(records) == 4
+            # 2. that the predictions table entries are present and
+            # can be linked to the original models
+            records = [
+                row for row in
+                db_engine.execute('''select entity_id, as_of_date
+                from {}_results.predictions
+                join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
+            ]
+            assert len(records) == 2
 
-            # 6. That we can delete the model when done prediction on it
-            predictor.delete_model(model_id)
-            assert predictor.load_model(model_id) == None
+            # 3. that the contained as_of_dates match what we sent in
+            for record in records:
+                assert record[1].date() == AS_OF_DATE
+
+            # 4. that the entity ids match the given dataset
+            assert sorted([record[0] for record in records]) == [1, 2]
+
+        # 5. running with same model_id, different as of date
+        # then with same as of date only replaces the records
+        # with the same date
+
+        # Runs the same test for training and testing predictions
+        for mat_type in ("train", "test"):
+            new_matrix = matrix_creator(index='entity_id')
+            new_metadata = matrix_metadata_creator(end_time=AS_OF_DATE + datetime.timedelta(days=1), matrix_type=mat_type, indices=['entity_id'])
+            new_matrix_store = get_matrix_store(project_storage, new_matrix, new_metadata)
+
+            predictor.predict(
+                model_id,
+                new_matrix_store,
+                misc_db_parameters=dict(),
+                train_matrix_columns=train_matrix_columns
+            )
+            predictor.predict(
+                model_id,
+                matrix_store,
+                misc_db_parameters=dict(),
+                train_matrix_columns=train_matrix_columns
+            )
+            records = [
+                row for row in
+                db_engine.execute('''select entity_id, as_of_date
+                from {}_results.predictions
+                join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
+            ]
+            assert len(records) == 4
+
+        # 6. That we can delete the model when done prediction on it
+        predictor.delete_model(model_id)
+        assert predictor.load_model(model_id) is None
 
 
 def test_predictor_composite_index():
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
-
-        project_path = 'econ-dev/inspections'
-        model_storage_engine = InMemoryModelStorageEngine(project_path)
-
-        _, model_id = \
-            fake_trained_model(project_path, model_storage_engine, db_engine, train_matrix_uuid='1234')
-
-        predictor = Predictor(project_path, model_storage_engine, db_engine)
+    with prepare() as (project_storage, db_engine, model_id):
+        predictor = Predictor(project_storage.model_storage_engine(), db_engine)
 
         dayone = datetime.datetime(2011, 1, 1)
         daytwo = datetime.datetime(2011, 1, 2)
-
-        # create prediction set
-        matrix = pandas.DataFrame.from_dict({
+        source_dict = {
             'entity_id': [1, 2, 1, 2],
             'as_of_date': [dayone, dayone, daytwo, daytwo],
             'feature_one': [3, 4, 5, 6],
             'feature_two': [5, 6, 7, 8],
             'label': [7, 8, 8, 7]
-        }).set_index(['entity_id', 'as_of_date'])
-        metadata = {
-            'label_name': 'label',
-            'end_time': AS_OF_DATE,
-            'label_timespan': '3month',
-            'metta-uuid': '1234',
-            'indices': ['entity_id', 'as_of_date'],
         }
 
         # Runs the same test for training and testing predictions
         for mat_type in ("train", "test"):
 
-            # Create the matrix to be tested and store in db
-            metadata['matrix_type'] = mat_type
-            matrix_store = MatrixStore()
-            matrix_store.matrix = matrix
-            matrix_store.metadata = metadata
-
-            # Adding 'label' column back into matrix
-            matrix['label'] = [7, 8, 8, 7]
+            matrix = pandas.DataFrame.from_dict(source_dict).set_index(['entity_id', 'as_of_date'])
+            metadata = matrix_metadata_creator(matrix_type=mat_type)
+            matrix_store = get_matrix_store(project_storage, matrix, metadata)
 
             predict_proba = predictor.predict(
                 model_id,
@@ -226,97 +151,62 @@ def test_predictor_composite_index():
 
 
 def test_predictor_get_train_columns():
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
+    with prepare() as (project_storage, db_engine, model_id):
+        predictor = Predictor(project_storage.model_storage_engine(), db_engine)
+        train_store = get_matrix_store(
+            project_storage=project_storage,
+            matrix=matrix_creator(),
+            metadata=matrix_metadata_creator(matrix_type='train'),
+        )
 
-        project_path = 'econ-dev/inspections'
-        with tempfile.TemporaryDirectory() as temp_dir:
-            train_store, test_store = sample_metta_csv_diff_order(temp_dir)
+        # flip the order of some feature columns in the test matrix
+        other_order_matrix = matrix_creator()
+        order = other_order_matrix.columns.tolist()
+        order[0], order[1] = order[1], order[0]
+        other_order_matrix = other_order_matrix[order]
+        test_store = get_matrix_store(
+            project_storage=project_storage,
+            matrix=other_order_matrix,
+            metadata=matrix_metadata_creator(matrix_type='test'),
+        )
 
-            model_storage_engine = InMemoryModelStorageEngine(project_path)
-            _, model_id = \
-                fake_trained_model(
-                    project_path,
-                    model_storage_engine,
-                    db_engine,
-                    train_matrix_uuid=train_store.uuid
-                )
-            predictor = Predictor(project_path, model_storage_engine, db_engine)
+        # Runs the same test for training and testing predictions
+        for store, mat_type in zip((train_store, test_store), ("train", "test")):
+            predict_proba = predictor.predict(
+                model_id,
+                store,
+                misc_db_parameters=dict(),
+                train_matrix_columns=train_store.columns()
+            )
+            # assert
+            # 1. that we calculated predictions
+            assert len(predict_proba) > 0
 
-            # The train_store uuid is stored in fake_trained_model. Storing the other
-            MatrixFactory(matrix_uuid = test_store.uuid)
-            session.commit()
-
-            # Runs the same test for training and testing predictions
-            for store, mat_type in zip((train_store,test_store),("train", "test")):
-                predict_proba = predictor.predict(
-                    model_id,
-                    store,
-                    misc_db_parameters=dict(),
-                    train_matrix_columns=train_store.columns()
-                )
-                # assert
-                # 1. that we calculated predictions
-                assert len(predict_proba) > 0
-
-                # 2. that the predictions table entries are present and
-                # can be linked to the original models
-                records = [
-                    row for row in
-                    db_engine.execute('''select entity_id, as_of_date
-                    from {}_results.predictions
-                    join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
-                ]
-                assert len(records) > 0
+            # 2. that the predictions table entries are present and
+            # can be linked to the original models
+            records = [
+                row for row in
+                db_engine.execute('''select entity_id, as_of_date
+                from {}_results.predictions
+                join model_metadata.models using (model_id)'''.format(mat_type, mat_type))
+            ]
+            assert len(records) > 0
 
 
 def test_predictor_retrieve():
-    with testing.postgresql.Postgresql() as postgresql:
-        db_engine = create_engine(postgresql.url())
-        ensure_db(db_engine)
-        init_engine(db_engine)
-
-        project_path = 'econ-dev/inspections'
-        model_storage_engine = InMemoryModelStorageEngine(project_path)
-
-        _, model_id = \
-            fake_trained_model(project_path, model_storage_engine, db_engine, train_matrix_uuid='1234')
-
-        predictor = Predictor(project_path, model_storage_engine, db_engine, replace=False)
-
-        dayone = datetime.date(2011, 1, 1).strftime(predictor.expected_matrix_ts_format)
-        daytwo = datetime.date(2011, 1, 2).strftime(predictor.expected_matrix_ts_format)
+    with prepare() as (project_storage, db_engine, model_id):
+        predictor = Predictor(project_storage.model_storage_engine(), db_engine, replace=False)
 
         # create prediction set
-        matrix_data = {
-            'entity_id': [1, 2, 1, 2],
-            'as_of_date': [dayone, dayone, daytwo, daytwo],
-            'feature_one': [3, 4, 5, 6],
-            'feature_two': [5, 6, 7, 8],
-            'label': [7, 8, 8, 7]
-        }
-        matrix = pandas.DataFrame.from_dict(matrix_data)\
-            .set_index(['entity_id', 'as_of_date'])
-        metadata = {
-            'label_name': 'label',
-            'end_time': AS_OF_DATE,
-            'label_timespan': '3month',
-            'metta-uuid': '1234',
-            'indices': ['entity_id', 'as_of_date'],
-            'matrix_type': 'test'
-        }
-
-        matrix_store = MatrixStore()
-        matrix_store.matrix = matrix
-        matrix_store.metadata = metadata
+        matrix = matrix_creator()
+        metadata = matrix_metadata_creator()
+        matrix_store = get_matrix_store(project_storage, matrix, metadata)
 
         predict_proba = predictor.predict(
             model_id,
             matrix_store,
             misc_db_parameters=dict(),
-            train_matrix_columns=['feature_one', 'feature_two']
+            train_matrix_columns=matrix.columns[0:-1].tolist()
         )
 
         # When run again, the predictions retrieved from the database
@@ -355,7 +245,7 @@ def test_predictor_retrieve():
             model_id,
             matrix_store,
             misc_db_parameters=dict(),
-            train_matrix_columns=['feature_one', 'feature_two']
+            train_matrix_columns=matrix.columns[0:-1].tolist()
         )
         assert_array_equal(new_predict_proba, predict_proba)
         assert not predictor.load_model.called

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -11,8 +11,9 @@ from triage.component.catwalk.storage import (
     CSVMatrixStore,
     FSStore,
     HDFMatrixStore,
-    MemoryStore,
     S3Store,
+    MatrixStorageEngine,
+    ProjectStorage,
 )
 
 
@@ -26,7 +27,7 @@ def test_S3Store():
         import boto3
         client = boto3.client('s3')
         client.create_bucket(Bucket='test_bucket', ACL='public-read-write')
-        store = S3Store(path=f"s3://test_bucket/a_path")
+        store = S3Store(f"s3://test_bucket/a_path")
         assert not store.exists()
         store.write('val'.encode('utf-8'))
         assert store.exists()
@@ -49,17 +50,6 @@ def test_FSStore():
         assert not store.exists()
 
 
-def test_MemoryStore():
-    store = MemoryStore(None)
-    assert not store.exists()
-    store.write('val'.encode('utf-8'))
-    assert store.exists()
-    newVal = store.load()
-    assert newVal.decode('utf-8') == 'val'
-    store.delete()
-    assert not store.exists()
-
-
 class MatrixStoreTest(unittest.TestCase):
     data_dict = OrderedDict([
         ('entity_id', [1, 2]),
@@ -77,15 +67,16 @@ class MatrixStoreTest(unittest.TestCase):
         df = pd.DataFrame.from_dict(self.data_dict).set_index(['entity_id'])
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            project_storage = ProjectStorage(tmpdir)
             tmpcsv = os.path.join(tmpdir, 'df.csv')
-            tmpyaml = os.path.join(tmpdir, 'metadata.yaml')
+            tmpyaml = os.path.join(tmpdir, 'df.yaml')
             tmphdf = os.path.join(tmpdir, 'df.h5')
             with open(tmpyaml, 'w') as outfile:
                 yaml.dump(self.metadata, outfile, default_flow_style=False)
                 df.to_csv(tmpcsv)
                 df.to_hdf(tmphdf, 'matrix')
-                csv = CSVMatrixStore(matrix_path=tmpcsv, metadata_path=tmpyaml)
-                hdf = HDFMatrixStore(matrix_path=tmphdf, metadata_path=tmpyaml)
+                csv = CSVMatrixStore(project_storage, [], 'df')
+                hdf = HDFMatrixStore(project_storage, [], 'df')
                 assert csv.matrix.equals(hdf.matrix)
                 yield from [csv, hdf]
 
@@ -165,17 +156,25 @@ class MatrixStoreTest(unittest.TestCase):
                     .values\
                     .tolist()
 
+    def test_MatrixStore_save(self):
+        for matrix_store in self.matrix_stores():
+            original_dict = matrix_store.matrix.to_dict()
+            matrix_store.save()
+            assert matrix_store._load().to_dict() == original_dict
+
     def test_as_of_dates_entity_index(self):
         data = {
             'entity_id': [1, 2],
             'feature_one': [0.5, 0.6],
             'feature_two': [0.5, 0.6],
         }
-        inmemory = CSVMatrixStore(matrix_path='memory://', metadata_path='memory://')
-        inmemory.matrix = pd.DataFrame.from_dict(data)
-        inmemory.metadata = {'end_time': '2016-01-01', 'indices': ['entity_id']}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_storage = ProjectStorage(tmpdir)
+            matrix_store = CSVMatrixStore(project_storage, [], 'test')
+            matrix_store.matrix = pd.DataFrame.from_dict(data)
+            matrix_store.metadata = {'end_time': '2016-01-01', 'indices': ['entity_id']}
 
-        self.assertEqual(inmemory.as_of_dates, ['2016-01-01'])
+            self.assertEqual(matrix_store.as_of_dates, ['2016-01-01'])
 
     def test_as_of_dates_entity_date_index(self):
         data = {
@@ -184,11 +183,13 @@ class MatrixStoreTest(unittest.TestCase):
             'feature_two': [0.5, 0.6, 0.5, 0.6],
             'as_of_date': ['2016-01-01', '2016-01-01', '2017-01-01', '2017-01-01']
         }
-        inmemory = CSVMatrixStore(matrix_path='memory://', metadata_path='memory://')
-        inmemory.matrix = pd.DataFrame.from_dict(data).set_index(['entity_id', 'as_of_date'])
-        inmemory.metadata = {'indices': ['entity_id', 'as_of_date']}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            project_storage = ProjectStorage(tmpdir)
+            matrix_store = CSVMatrixStore(project_storage, [], 'test')
+            matrix_store.matrix = pd.DataFrame.from_dict(data).set_index(['entity_id', 'as_of_date'])
+            matrix_store.metadata = {'indices': ['entity_id', 'as_of_date']}
 
-        self.assertEqual(inmemory.as_of_dates, ['2016-01-01', '2017-01-01'])
+        self.assertEqual(matrix_store.as_of_dates, ['2016-01-01', '2017-01-01'])
 
     def test_s3_save(self):
         with mock_s3():
@@ -196,18 +197,13 @@ class MatrixStoreTest(unittest.TestCase):
             client = boto3.client('s3')
             client.create_bucket(Bucket='fake-matrix-bucket', ACL='public-read-write')
             example = next(self.matrix_stores())
+            project_storage = ProjectStorage('s3://fake-matrix-bucket')
 
-            tosave = CSVMatrixStore(
-                matrix_path='s3://fake-matrix-bucket/test.csv',
-                metadata_path='s3://fake-matrix-bucket/test.yaml'
-            )
+            tosave = CSVMatrixStore(project_storage, [], 'test')
             tosave.matrix = example.matrix
             tosave.metadata = example.metadata
             tosave.save()
 
-            tocheck = CSVMatrixStore(
-                matrix_path='s3://fake-matrix-bucket/test.csv',
-                metadata_path='s3://fake-matrix-bucket/test.yaml'
-            )
+            tocheck = CSVMatrixStore(project_storage, [], 'test')
             assert tocheck.metadata == example.metadata
             assert tocheck.matrix.to_dict() == example.matrix.to_dict()

--- a/src/tests/test_partial_experiments.py
+++ b/src/tests/test_partial_experiments.py
@@ -176,7 +176,7 @@ class Matrices(TestCase):
     def test_run(self):
         with prepare_experiment(self.config) as experiment:
             experiment.run()
-            matrices_path = experiment.matrices_directory
+            matrices_path = join(experiment.project_path, 'matrices')
             matrices_and_metadata = [f for f in os.listdir(matrices_path) if isfile(join(matrices_path, f))]
             matrices = experiment.matrix_build_tasks
             assert len(matrices) > 0

--- a/src/triage/component/architect/planner.py
+++ b/src/triage/component/architect/planner.py
@@ -15,7 +15,6 @@ class Planner(object):
         label_names,
         label_types,
         states,
-        matrix_directory,
         user_metadata,
         cohort_name='default',
     ):
@@ -24,7 +23,6 @@ class Planner(object):
         self.label_types = label_types
         self.cohort_name = cohort_name
         self.states = states or [state_table_generators.DEFAULT_ACTIVE_STATE]
-        self.matrix_directory = matrix_directory
         self.user_metadata = user_metadata
 
     def _generate_build_task(
@@ -39,7 +37,6 @@ class Planner(object):
             'label_name': matrix_metadata['label_name'],
             'label_type': matrix_metadata['label_type'],
             'feature_dictionary': feature_dictionary,
-            'matrix_directory': self.matrix_directory,
             'matrix_uuid': matrix_uuid,
             'matrix_metadata': matrix_metadata,
             'matrix_type': matrix_metadata['matrix_type']

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -221,7 +221,7 @@ def fake_trained_model(project_path, model_storage_engine, db_engine):
         (int) model id for database retrieval
     """
     trained_model = MockTrainedModel()
-    model_storage_engine.get_store('abcd').write(trained_model)
+    model_storage_engine.write(trained_model, 'abcd')
     session = sessionmaker(db_engine)()
     db_model = Model(model_hash='abcd')
     session.add(db_model)

--- a/src/triage/component/catwalk/model_testers.py
+++ b/src/triage/component/catwalk/model_testers.py
@@ -7,11 +7,11 @@ from triage.component.catwalk.evaluation import ModelEvaluator
 
 
 class ModelTester(object):
-    def __init__(self, db_engine, project_path, model_storage_engine, replace, evaluator_config, individual_importance_config):
+    def __init__(self, db_engine, model_storage_engine, matrix_storage_engine, replace, evaluator_config, individual_importance_config):
+        self.matrix_storage_engine = matrix_storage_engine
         self.predictor = Predictor(
             db_engine=db_engine,
             model_storage_engine=model_storage_engine,
-            project_path=project_path,
             replace=replace
         )
 
@@ -29,13 +29,13 @@ class ModelTester(object):
             training_metric_groups=evaluator_config.get('training_metric_groups', [])
         )
 
-    def generate_model_test_tasks(self, split, train_store, model_ids, matrix_store_creator):
+    def generate_model_test_tasks(self, split, train_store, model_ids):
         test_tasks = []
         for test_matrix_def, test_uuid in zip(
             split['test_matrices'],
             split['test_uuids']
         ):
-            test_store = matrix_store_creator(test_uuid)
+            test_store = self.matrix_storage_engine.get_store(test_uuid)
 
             if test_store.empty:
                 logging.warning('''Test matrix for uuid %s

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -37,14 +37,12 @@ class ModelTrainer(object):
     """
     def __init__(
         self,
-        project_path,
         experiment_hash,
         model_storage_engine,
         db_engine,
         model_grouper=None,
         replace=True
     ):
-        self.project_path = project_path
         self.experiment_hash = experiment_hash
         self.model_storage_engine = model_storage_engine
         self.model_grouper = model_grouper or ModelGrouper()
@@ -78,7 +76,7 @@ class ModelTrainer(object):
         unique = {
             'className': class_path,
             'parameters': self.unique_parameters(parameters),
-            'project_path': self.project_path,
+            'project_path': self.model_storage_engine.project_storage.project_path,
             'training_metadata': matrix_metadata
         }
         logging.info('Creating model hash from unique data %s', unique)
@@ -245,7 +243,6 @@ class ModelTrainer(object):
         class_path,
         parameters,
         model_hash,
-        model_store,
         misc_db_parameters
     ):
         """Train a model, cache it, and write metadata to a database
@@ -255,7 +252,6 @@ class ModelTrainer(object):
             class_path (string) A full classpath to the model class
             parameters (dict) hyperparameters to give to the model constructor
             model_hash (string) a unique id for the model
-            model_store (catwalk.storage.Store) the place in which to store the model
             misc_db_parameters (dict) params to pass through to the database
 
         Returns: (int) a database id for the model
@@ -278,7 +274,7 @@ class ModelTrainer(object):
         )
         logging.info('Trained model: hash %s, model group id %s ', model_hash, model_group_id)
         #Writing the model to storage, then getting its size in kilobytes.
-        model_store.write(trained_model)
+        self.model_storage_engine.write(trained_model, model_hash)
         model_size = sys.getsizeof(trained_model)/(1024.0)
 
         logging.info('Cached model: %s', model_hash)
@@ -371,15 +367,14 @@ class ModelTrainer(object):
             misc_db_parameters (dict) params to pass through to the database
         Returns: (int) model id
         """
-        model_store = self.model_storage_engine.get_store(model_hash)
         saved_model_id = retrieve_model_id_from_hash(self.db_engine, model_hash)
-        if not self.replace and model_store.exists() and saved_model_id:
+        if not self.replace and self.model_storage_engine.exists(model_hash) and saved_model_id:
             logging.info('Skipping %s/%s', class_path, parameters)
             return saved_model_id
 
         if self.replace:
             reason = 'replace flag has been set'
-        elif not model_store.exists():
+        elif not self.model_storage_engine.exists(model_hash):
             reason = 'model pickle not found in store'
         elif not saved_model_id:
             reason = 'model metadata not found'
@@ -392,7 +387,6 @@ class ModelTrainer(object):
                 class_path,
                 parameters,
                 model_hash,
-                model_store,
                 misc_db_parameters
             )
         except BaselineFeatureNotInMatrix:

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -16,20 +16,30 @@ import yaml
 
 
 class Store(object):
-    def __init__(self, path):
-        self.path = path
+    """Base class for classes which know how to access a file in a preset medium.
+
+    Used to hold references to persisted objects with knowledge about how they can be accessed.
+    without loading them into memory. In this way, they can be easily and quickly serialized
+    across processes but centralize the reading/writing code.
+
+    Each subclass be scoped to a specific storage medium (e.g. Filesystem, S3)
+        and implement the access methods for that medium.
+
+    Implements write/load methods for interacting directly using bytestreams,
+        plus an open method that works as an open filehandle.
+    """
+    def __init__(self, *pathparts):
+        self.pathparts = pathparts
 
     @classmethod
-    def factory(self, path):
-        path_parsed = urlparse(path)
+    def factory(self, *pathparts):
+        path_parsed = urlparse(pathparts[0])
         scheme = path_parsed.scheme
 
         if scheme in ('', 'file'):
-            return FSStore(path)
+            return FSStore(*pathparts)
         elif scheme == 's3':
-            return S3Store(path)
-        elif scheme == 'memory':
-            return MemoryStore(path)
+            return S3Store(*pathparts)
         else:
             raise ValueError('Unable to infer correct Store from project path')
 
@@ -55,6 +65,20 @@ class Store(object):
 
 
 class S3Store(Store):
+    """Store an object in S3.
+    
+    Example:
+    ```
+    store = S3Store('s3://my-bucket', 'models', 'model.pkl')
+    return store.load()
+    ```
+
+    Args:
+        *pathparts: A variable length list of components of the path, to be processed in order.
+            All components will be joined using PurePosixPath to create the final path.
+    """
+    def __init__(self, *pathparts):
+        self.path = str(pathlib.PurePosixPath(pathparts[0].replace('s3://', ''), *pathparts[1:]))
 
     def exists(self):
         s3 = s3fs.S3FileSystem()
@@ -70,6 +94,24 @@ class S3Store(Store):
 
 
 class FSStore(Store):
+    """Store an object on the local filesystem.
+    
+    Example:
+    ```
+    store = FSStore('/mnt', 'models', 'model.pkl')
+    return store.load()
+    ```
+
+    Args:
+        *pathparts: A variable length list of components of the path, to be processed in order. 
+            All components will be joined using pathlib.Path to create the final path
+                using the correct separator for the operating system. However, if you pass
+                components that already contain a separator, those separators won't be modified
+    """
+    def __init__(self, *pathparts):
+        self.path = pathlib.Path(*pathparts)
+        os.makedirs(dirname(self.path), exist_ok=True)
+
     def exists(self):
         return os.path.isfile(self.path)
 
@@ -77,107 +119,159 @@ class FSStore(Store):
         os.remove(self.path)
 
     def open(self, *args, **kwargs):
-        os.makedirs(dirname(self.path), exist_ok=True)
         return open(self.path, *args, **kwargs)
 
 
-class MemoryStore(Store):
-    store = None
+class ProjectStorage(object):
+    """Store and access files associated with a project.
+    
+    Args:
+        project_path (string): The base path for all files in the project.
+            The scheme prefix of the path will determine the storage medium.
+    """
+    def __init__(self, project_path):
+        self.project_path = project_path
+        self.storage_class = Store.factory(self.project_path).__class__
 
-    def exists(self):
-        return self.store is not None
+    def get_store(self, directories, leaf_filename):
+        """Return a storage object for one filename
 
-    def delete(self):
-        self.store = None
+        Args:
+        directories (list): A list of subdirectories
+        leaf_filename (string): The filename without any directory information
 
-    def write(self, bytestream):
-        self.store = bytestream
+        Returns:
+            triage.component.catwalk.storage.Store object
+        """
+        return self.storage_class(self.project_path, *directories, leaf_filename)
+   
+    def matrix_storage_engine(self, matrix_storage_class=None, matrix_directory=None):
+        """Return a matrix storage engine bound to this project's storage
 
-    def load(self):
-        return self.store
+        Args:
+            matrix_storage_class (class) A subclass of MatrixStore
+            matrix_directory (string, optional) A directory to store matrices.
+                If not passed will allow the MatrixStorageEngine to decide
+        Returns: triage.component.catwalk.storage.MatrixStorageEngine
+        """
+        return MatrixStorageEngine(self, matrix_storage_class, matrix_directory)
 
-    def open(self, *args, **kwargs):
-        raise ValueError('MemoryStore objects cannot be opened and closed like files'
-                         'Use write/load methods instead.')
+    def model_storage_engine(self, model_directory=None):
+        """Return a model storage engine bound to this project's storage
 
-
-class ModelStore():
-    def __init__(self, store):
-        self.store = store
-
-    def write(self, obj):
-        with self.store.open('wb') as fd:
-            joblib.dump(obj, fd, compress=True)
-
-    def load(self):
-        with self.store.open('rb') as fd:
-            return joblib.load(fd)
-
-    def exists(self):
-        return self.store.exists()
-
-    def delete(self):
-        return self.store.delete()
+        Args:
+            model_directory (string, optional) A directory to store models
+                If not passed will allow the ModelStorageEngine to decide
+        Returns: triage.component.catwalk.storage.ModelStorageEngine
+        """
+        return ModelStorageEngine(self, model_directory)
 
 
 class ModelStorageEngine(object):
-    def __init__(self, project_path):
-        self.project_path = project_path
-        self.model_dir = 'trained_models'
+    """Store arbitrary models in a given project storage using joblib
 
-    @classmethod
-    def factory(self, path):
-        path_parsed = urlparse(path)
-        scheme = path_parsed.scheme
+    Args:
+        project_storage (triage.component.catwalk.storage.ProjectStorage) A project file storage engine
+        model_directory (string, optional) A directory name for models. Defaults to 'trained_models'
+    
+    """
+    def __init__(self, project_storage, model_directory=None):
+        self.project_storage = project_storage
+        self.directories = [model_directory or 'trained_models']
 
-        if scheme in ('', 'file'):
-            return FSModelStorageEngine(path)
-        elif scheme == 's3':
-            return S3ModelStorageEngine(path)
-        elif scheme == 'memory':
-            return InMemoryModelStorageEngine(path)
-        else:
-            raise ValueError('Unable to infer correct ModelStorageEngine from path')
+    def write(self, obj, model_hash):
+        """Persist a model object using joblib. Also performs compression
+
+        Args:
+            obj (object) A picklable model object
+            model_hash (string) An identifier, unique within this project, for the model
+        """
+        with self._get_store(model_hash).open('wb') as fd:
+            joblib.dump(obj, fd, compress=True)
+
+    def load(self, model_hash):
+        """Load a model object using joblib
+
+        Args:
+            model_hash (string) An identifier, unique within this project, for the model
+
+        Returns: (object) A model object
+        """
+        with self._get_store(model_hash).open('rb') as fd:
+            return joblib.load(fd)
+
+    def exists(self, model_hash):
+        """Check whether the model is persisted
+
+        Args:
+            model_hash (string) An identifier, unique within this project, for the model
+
+        Returns: (bool) Whether or not a model by that identifier exists in project storage
+        """
+        return self._get_store(model_hash).exists()
+
+    def delete(self, model_hash):
+        """Delete the model identified by this hash from project storage
+
+        Args:
+            model_hash (string) An identifier, unique within this project, for the model
+        """
+        return self._get_store(model_hash).delete()
+
+    def _get_store(self, model_hash):
+        return self.project_storage.get_store(self.directories, model_hash)
 
 
-    def get_store(self, model_hash):
-        pass
+class MatrixStorageEngine(object):
+    """Store matrices in a given project storage
 
+    Args:
+        project_storage (triage.component.catwalk.storage.ProjectStorage) A project file storage engine
+        matrix_storage_class (class) A subclass of MatrixStore
+        matrix_directory (string, optional) A directory to store matrices. Defaults to 'matrices'
+    """
+    def __init__(self, project_storage, matrix_storage_class=None, matrix_directory=None):
+        self.project_storage = project_storage
+        self.matrix_storage_class = matrix_storage_class or CSVMatrixStore
+        self.directories = [matrix_directory or 'matrices']
 
-class S3ModelStorageEngine(ModelStorageEngine):
-    def get_store(self, model_hash):
-        return ModelStore(S3Store(str(pathlib.PurePosixPath(self.project_path, self.model_dir, model_hash))))
+    def get_store(self, matrix_uuid):
+        """Return a storage object for a given matrix uuid.
 
+        Args:
+            matrix_uuid (string) A unique identifier within the project for a matrix.
 
-class FSModelStorageEngine(ModelStorageEngine):
-    def get_store(self, model_hash):
-        return ModelStore(FSStore(pathlib.Path(self.project_path, self.model_dir, model_hash)))
-
-
-class InMemoryModelStorageEngine(ModelStorageEngine):
-    stores = {}
-
-    def get_store(self, model_hash):
-        if model_hash not in self.stores:
-            self.stores[model_hash] = MemoryStore(model_hash)
-        return self.stores[model_hash]
+        Returns: (MatrixStore) a reference to the matrix and its companion metadata
+        """
+        return self.matrix_storage_class(self.project_storage, self.directories, matrix_uuid)
 
 
 class MatrixStore(object):
+    """Base class for classes that allow access of a matrix and its metadata.
+
+    Subclasses should be scoped to a storage format (e.g. CSV, HDF)
+        and implement the _load, save, and head_of_matrix methods for that storage format
+
+    Args:
+        project_storage (triage.component.catwalk.storage.ProjectStorage) A project file storage engine
+        directories (list): A list of subdirectories
+        matrix_uuid (string): A unique identifier within the project for a matrix.
+        matrix (pandas.DataFrame, optional): The raw matrix. Defaults to None, which means it will be loaded from storage on demand
+        metadata (dict, optional). The matrix' metadata. Defaults to None, which means it will be loaded from storage on demand.
+    """
     _labels = None
 
-    def __init__(self, matrix_path='memory://', metadata_path='memory://', matrix=None, metadata=None):
-        self.matrix_path = matrix_path
-        self.metadata_path = metadata_path
-
-        self.matrix_base_store = Store.factory(self.matrix_path)
-        self.metadata_base_store = Store.factory(self.metadata_path)
+    def __init__(self, project_storage, directories, matrix_uuid, matrix=None, metadata=None):
+        self.matrix_uuid = matrix_uuid
+        self.matrix_base_store = project_storage.get_store(directories, f'{matrix_uuid}.{self.suffix}')
+        self.metadata_base_store = project_storage.get_store(directories, f'{matrix_uuid}.yaml')
 
         self.matrix = matrix
         self.metadata = metadata
 
     @property
     def matrix(self):
+        """The raw matrix. Will load from storage into memory if not already loaded"""
         if self.__matrix is None:
             self.__matrix = self._load()
         return self.__matrix
@@ -188,6 +282,7 @@ class MatrixStore(object):
 
     @property
     def metadata(self):
+        """The raw metadata. Will load from storage into memory if not already loaded"""
         if self.__metadata is None:
             self.__metadata = self.load_metadata()
         return self.__metadata
@@ -198,10 +293,17 @@ class MatrixStore(object):
 
     @property
     def head_of_matrix(self):
+        """The first line of the matrix"""
         return self.matrix.head(1)
 
     @property
+    def exists(self):
+        """Whether or not the matrix and metadata exist in storage"""
+        return self.matrix_base_store.exists() and self.metadata_base_store.exists()
+
+    @property
     def empty(self):
+        """Whether or not the matrix has at least one row"""
         if not self.matrix_base_store.exists():
             return True
         else:
@@ -209,6 +311,7 @@ class MatrixStore(object):
             return head_of_matrix.empty
 
     def columns(self, include_label=False):
+        """The matrix's column list"""
         head_of_matrix = self.head_of_matrix
         columns = head_of_matrix.columns.tolist()
         if include_label:
@@ -220,6 +323,7 @@ class MatrixStore(object):
             ]
 
     def labels(self):
+        """The matrix's label column."""
         if self._labels is not None:
             logging.debug('using stored labels')
             return self._labels
@@ -230,10 +334,12 @@ class MatrixStore(object):
 
     @property
     def uuid(self):
-        return self.metadata['metta-uuid']
+        """The matrix's unique id within the project"""
+        return self.matrix_uuid
 
     @property
     def as_of_dates(self):
+        """The list of as-of-dates in the matrix"""
         if 'as_of_date' in self.matrix.index.names:
             return sorted(list(set([as_of_date for entity_id, as_of_date in self.matrix.index])))
         else:
@@ -241,6 +347,7 @@ class MatrixStore(object):
 
     @property
     def num_entities(self):
+        """The number of entities in the matrix"""
         if self.matrix.index.names == ['entity_id']:
             return len(self.matrix.index.values)
         elif 'entity_id' in self.matrix.index.names:
@@ -248,6 +355,12 @@ class MatrixStore(object):
 
     @property
     def matrix_type(self):
+        """The MatrixType (train or test). Returns an object with:
+            a string name,
+            evaluation ORM class
+            prediction ORM class
+            a boolean `is_test`
+        """
         if self.metadata['matrix_type'] == 'train':
             return TrainMatrixType
         elif self.metadata['matrix_type'] == 'test':
@@ -257,6 +370,12 @@ class MatrixStore(object):
              = "train" or "test" '''.format(self.uuid))
 
     def matrix_with_sorted_columns(self, columns):
+        """Return the matrix with columns sorted in the given column order
+
+        Args:
+            columns (list) The order of column names to return.
+                Will error if this list does not contain the same elements as the matrix's columns
+        """
         columnset = set(self.columns())
         desired_columnset = set(columns)
         if columnset == desired_columnset:
@@ -278,6 +397,7 @@ class MatrixStore(object):
                 ''', columnset ^ desired_columnset)
 
     def load_metadata(self):
+        """Load metadata from storage"""
         with self.metadata_base_store.open('rb') as fd:
             return yaml.load(fd)
 
@@ -285,9 +405,10 @@ class MatrixStore(object):
         raise NotImplementedError
 
     def __getstate__(self):
-        # when we serialize (say, for multiprocessing),
-        # we don't want the cached members to show up
-        # as they can be enormous
+        """Remove object of a large size upon serialization. 
+
+        This helps in a multiprocessing context.
+        """
         self.matrix = None
         self._labels = None
         self.metadata = None
@@ -295,19 +416,20 @@ class MatrixStore(object):
 
 
 class HDFMatrixStore(MatrixStore):
+    """Store and access matrices using HDF"""
+    suffix = 'h5'
 
-    def __init__(self, matrix_path=None, metadata_path=None):
-        super().__init__(matrix_path, metadata_path)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         if isinstance(self.matrix_base_store, S3Store):
             raise ValueError('HDFMatrixStore cannot be used with S3')
-        self.metadata = self.load_metadata()
 
     @property
     def head_of_matrix(self):
         try:
-            head_of_matrix = pd.read_hdf(self.matrix_path, start=0, stop=1)
+            head_of_matrix = pd.read_hdf(self.matrix_base_store.path, start=0, stop=1)
             # Is the index already in place?
-            if head_of_matrix.index.name not in self.metadata['indices']:
+            if head_of_matrix.index.names != self.metadata['indices']:
                 head_of_matrix.set_index(self.metadata['indices'], inplace=True)
         except pd.errors.EmptyDataError:
             head_of_matrix = None
@@ -315,26 +437,30 @@ class HDFMatrixStore(MatrixStore):
         return head_of_matrix
 
     def _load(self):
-        matrix = pd.read_hdf(self.matrix_path)
+        matrix = pd.read_hdf(self.matrix_base_store.path)
 
         # Is the index already in place?
-        if matrix.index.name not in self.metadata['indices']:
+        if matrix.index.names != self.metadata['indices']:
             matrix.set_index(self.metadata['indices'], inplace=True)
 
         return matrix
 
     def save(self):
-        with self.matrix_base_store.open('wb') as fd:
-            self.matrix.to_hdf(fd, format='table', mode='wb')
+        hdf = pd.HDFStore(self.matrix_base_store.path,
+                          mode='w',
+                          complevel=4,
+                          complib="zlib",
+                          format='table')
+        hdf.put(self.matrix_uuid, self.matrix.apply(pd.to_numeric), data_columns=True)
+        hdf.close()
 
         with self.metadata_base_store.open('wb') as fd:
             yaml.dump(self.metadata, fd, encoding='utf-8')
 
 
 class CSVMatrixStore(MatrixStore):
-
-    def __init__(self, matrix_path=None, metadata_path=None):
-        super().__init__(matrix_path, metadata_path)
+    """Store and access matrices using CSV"""
+    suffix = 'csv'
 
     @property
     def head_of_matrix(self):
@@ -350,8 +476,9 @@ class CSVMatrixStore(MatrixStore):
         return head_of_matrix
 
     def _load(self):
+        parse_dates_argument = ['as_of_date'] if 'as_of_date' in self.metadata['indices'] else False
         with self.matrix_base_store.open('rb') as fd:
-            matrix = pd.read_csv(fd)
+            matrix = pd.read_csv(fd, parse_dates=parse_dates_argument)
 
         matrix.set_index(self.metadata['indices'], inplace=True)
 

--- a/src/triage/experiments/multicore.py
+++ b/src/triage/experiments/multicore.py
@@ -4,7 +4,6 @@ from functools import partial
 from multiprocessing import Pool
 
 from triage.component.catwalk.utils import Batch
-from triage.component.catwalk.storage import InMemoryModelStorageEngine
 
 from triage.experiments import ExperimentBase
 
@@ -22,10 +21,6 @@ class MultiCoreExperiment(ExperimentBase):
                             'consider using the SingleThreadedExperiment class instead')
         self.n_processes = n_processes
         self.n_db_processes = n_db_processes
-        if isinstance(self.model_storage_engine, InMemoryModelStorageEngine):
-            raise ValueError('''
-                InMemoryModelStorageEngine not compatible with MultiCoreExperiment
-            ''')
 
     def generated_chunked_parallelized_results(
         self,


### PR DESCRIPTION
The Storage module needed some refactoring to allow different types of
data to come under the storage classes' purview. Matrix saving was
handled outside of the storage class in Experiments, which itself is a
problem but the problem will greatly expand in scope with the storing of
other artifacts like plots and notebooks. There were other
small problems, like the storage medium (s3/fs) logic being split
between two different class hierarchies.

To fix this, the Storage classes have been redesigned, a new one
(ProjectStorage) introduced, and the Experiment changed to use them
everywhere that storage is needed. The Storage changes were big enough
that many tests (particularly in catwalk, which already heavily used
Storage) broke in ways that were cumbersome to change one-by-one, and
some test functions are introduced to reduce the amount of boilerplate
on each test.

Basic Refactorings:

- Introduces ProjectStorage, a class to handle the saving and loading of
all project files at a given place. It delegates requests for individual
files to the correct storage class (S3 or FS).
- Make base Store objects take in multiple path parts, not just the main
path, so they can perform the correct join logic for the storage
medium.
- Refactor ModelStorageEngine to use ProjectStorage, and to no longer
have its own inheritance tree. Now, it only adds logic relevant to its
role of storing models: what the model subdirectory is called, and what
approach is used to serialize/deserialize models (e.g. joblib).
- Introduce MatrixStorageEngine with a similar scope as
ModelStorageEngine.
- Remove InMemory options as they are harder to fit into this structure,
and aren't really used.

Using Storage throughout experiment:

- Change HDFStore to use the saving HDF logic outlined in Klaus' pull request
to metta.
- The HDFStore change bubbled up some problems with string vs object
representation of the as-of-date, because HDF will load as an object vs CSV
which will load as a string. Centralize on object representation, which
involves maybe converting the string to an object
- Rename HighMemoryCSVBuilder to MatrixBuilder, and have it take in a MatrixStorageEngine and save the matrix using that method, instead of metta_io.
- Remove some unnecessary filehandle logic in MatrixBuilder, having the
class create intermediate DataFrames instead of intermediate BytesIOs

Test Changes:

- Introduce some factory functions to src/tests/utils.py to make it
easier to create a valid project store/matrix/metadata/matrix store, allowing tests to configure what they need but hiding everything else.