### PR TITLE
Added an argument for a pythonic entrypoint for setting an arbitrary initial configuration

### DIFF
--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -123,16 +123,14 @@ class Experiment(Command):
             help="config file for Experiment"
         )
         parser.add_argument(
+            '-s', '--setup',
+            help="python module to import before running the Experiment",
+        )
+        parser.add_argument(
             '--project-path',
             default=os.path.curdir,
             help="path to store matrices and trained models"
         )
-
-        parser.add_argument(
-            '-s', '--setup',
-            help="python module to import before running the Experiment",
-        )
-
         parser.add_argument(
             '--n-db-processes',
             type=natural_number,

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -48,7 +48,7 @@ class Triage(RootCommand):
         )
         parser.add_argument(
             '-s', '--setup',
-            help="triage setup file",
+            help="python module to import before running the command",
         )
 
     def __call__(self, args):

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -55,7 +55,7 @@ class Triage(RootCommand):
         if self.args.setup is not None:
             logging.info(f"Loading configurations from {self.args.setup}")
             importlib.import_module(
-                self.args.setup.rsplit('.', maxsplit=1)[-1]
+                self.args.setup.rsplit('.', maxsplit=1)[0]
             )
 
 

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -127,6 +127,12 @@ class Experiment(Command):
             default=os.path.curdir,
             help="path to store matrices and trained models"
         )
+
+        parser.add_argument(
+            '-s', '--setup',
+            help="python module to import before running the Experiment",
+        )
+
         parser.add_argument(
             '--n-db-processes',
             type=natural_number,
@@ -159,11 +165,6 @@ class Experiment(Command):
             '--validate-only',
             action='store_true',
             help="only validate the config file not running Experiment"
-        )
-
-        parser.add_argument(
-            '-s', '--setup',
-            help="python module to import before running the command",
         )
 
         parser.set_defaults(

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -51,9 +51,8 @@ class Triage(RootCommand):
             help="file path to Python module to import before running the Experiment",
         )
 
-    @cachedproperty
     def setup(self):
-        setup_path = self.args.setup or os.path.exists('experiment.py')
+        setup_path = self.args.setup or os.path.abspath('experiment.py')
         if setup_path is not None:
             logging.info(f"Loading configurations from {setup_path}")
             spec = importlib.util.spec_from_file_location("triage_config", setup_path)
@@ -117,7 +116,7 @@ class FeatureTest(Command):
         )
 
     def __call__(self, args):
-        _ = self.root.setup  # Loading configuration (if exists)
+        self.root.setup  # Loading configuration (if exists)
         db_engine = create_engine(self.root.db_url)
         feature_config = yaml.load(args.feature_config_file)
 
@@ -184,7 +183,7 @@ class Experiment(Command):
 
     @cachedproperty
     def experiment(self):
-        _ = self.root.setup  # Loading configuration (if exists)
+        self.root.setup  # Loading configuration (if exists)
         db_url = self.root.db_url
         config = yaml.load(self.args.config)
         db_engine = create_engine(db_url)
@@ -232,7 +231,7 @@ class Audition(Command):
 
     @cachedproperty
     def runner(self):
-        _ = self.root.setup # Loading configuration (if exists)
+        self.root.setup # Loading configuration (if exists)
         db_url = self.root.db_url
         dir_plot = self.args.directory
         config = yaml.load(self.args.config)

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -46,19 +46,6 @@ class Triage(RootCommand):
             type=argparse.FileType('r'),
             help="database connection file",
         )
-        parser.add_argument(
-            '-s', '--setup',
-            help="python module to import before running the command",
-        )
-
-    def __call__(self, args):
-        if self.args.setup is not None:
-            logging.info(f"Loading configurations from {self.args.setup}")
-            spec = importlib.util.spec_from_file_location("triage_config", self.args.setup)
-            triage_config = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(triage_config)
-            logging.info(f"Configuration loaded")
-
 
     @cachedproperty
     def db_url(self):
@@ -174,6 +161,11 @@ class Experiment(Command):
             help="only validate the config file not running Experiment"
         )
 
+        parser.add_argument(
+            '-s', '--setup',
+            help="python module to import before running the command",
+        )
+
         parser.set_defaults(
             validate=True,
             validate_only=False,
@@ -201,6 +193,14 @@ class Experiment(Command):
         return experiment
 
     def __call__(self, args):
+
+        if args.setup is not None:
+            logging.info(f"Loading configurations from {args.setup}")
+            spec = importlib.util.spec_from_file_location("triage_config", args.setup)
+            triage_config = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(triage_config)
+            logging.info(f"Configuration loaded")
+
         if args.validate_only:
             self.experiment.validate()
         elif args.validate:

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -19,6 +19,8 @@ from triage.util.db import create_engine
 
 logging.basicConfig(level=logging.INFO)
 
+import importlib
+
 
 def natural_number(value):
     natural = int(value)
@@ -44,6 +46,18 @@ class Triage(RootCommand):
             type=argparse.FileType('r'),
             help="database connection file",
         )
+        parser.add_argument(
+            '-s', '--setup',
+            help="triage setup file",
+        )
+
+    def __call__(self, args):
+        if self.args.setup is not None:
+            logging.info(f"Loading configurations from {self.args.setup}")
+            importlib.import_module(
+                self.args.setup.rsplit('.', maxsplit=1)[-1]
+            )
+
 
     @cachedproperty
     def db_url(self):
@@ -254,7 +268,7 @@ class Db(Command):
     @cmdmethod('configversion', choices=REVISION_MAPPING.keys(), help='config version of last experiment you ran')
     def stamp(self, args):
         """Instruct the triage results database to mark itself as updated to a known version without doing any upgrading.
-        
+
         Use this if the database was created without an 'alembic_version' table. Uses the config version of your experiment to infer what database version is suitable.
         """
         revision = REVISION_MAPPING[args.configversion]

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -19,7 +19,7 @@ from triage.util.db import create_engine
 
 logging.basicConfig(level=logging.INFO)
 
-import importlib
+import importlib.util
 
 
 def natural_number(value):
@@ -54,9 +54,10 @@ class Triage(RootCommand):
     def __call__(self, args):
         if self.args.setup is not None:
             logging.info(f"Loading configurations from {self.args.setup}")
-            importlib.import_module(
-                self.args.setup.rsplit('.', maxsplit=1)[0]
-            )
+            spec = importlib.util.spec_from_file_location("triage_config", self.args.setup)
+            triage_config = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(triage_config)
+            logging.info(f"Configuration loaded")
 
 
     @cachedproperty

--- a/src/triage/util/db.py
+++ b/src/triage/util/db.py
@@ -1,3 +1,5 @@
+# coding: utf-8
+
 import sqlalchemy
 import wrapt
 


### PR DESCRIPTION
This is the first step in order to close the issue #450 . At this moment it only loads the configuration file from CLI.

It would be nice to extend this in order to centralize the configuration of the db and the use of environment variables as suggested in #450.

In order to use it:

```
triage -dbfile database.yaml --setup my_triage_config.py
```

In `my_triage_config.py` for example you could connect a listener  in order to set a role in the connection to the database:

```
# coding: utf-8

from sqlalchemy.event import listens_for
from sqlalchemy.pool import Pool


@listens_for(Pool, "connect")
def assume_role(dbapi_con, connection_record):
    dbapi_con.cursor().execute('set role my_role;')
```
