### PR TITLE
Issue 408 reloaded

### DIFF
--- a/src/tests/architect_tests/test_state_table_generators.py
+++ b/src/tests/architect_tests/test_state_table_generators.py
@@ -190,7 +190,7 @@ def test_sparse_states_from_query():
         engine = create_engine(postgresql.url())
         utils.create_binary_outcome_events(engine, 'events', input_data)
         table_generator = StateTableGeneratorFromQuery(
-            query=f"select entity_id from events where outcome_date < '{as_of_date}'::date",
+            query="select entity_id from events where outcome_date < '{as_of_date}'::date",
             db_engine=engine,
             experiment_hash='exp_hash',
         )

--- a/src/tests/architect_tests/test_state_table_generators.py
+++ b/src/tests/architect_tests/test_state_table_generators.py
@@ -190,7 +190,7 @@ def test_sparse_states_from_query():
         engine = create_engine(postgresql.url())
         utils.create_binary_outcome_events(engine, 'events', input_data)
         table_generator = StateTableGeneratorFromQuery(
-            query='select entity_id from events where outcome_date < {as_of_date}',
+            query=f"select entity_id from events where outcome_date < '{as_of_date}'::date",
             db_engine=engine,
             experiment_hash='exp_hash',
         )
@@ -234,4 +234,3 @@ def test_sparse_states_from_query():
         assert results == expected_output
         utils.assert_index(engine, table_generator.sparse_table_name, 'entity_id')
         utils.assert_index(engine, table_generator.sparse_table_name, 'as_of_date')
-

--- a/src/triage/component/architect/state_table_generators.py
+++ b/src/triage/component/architect/state_table_generators.py
@@ -151,22 +151,20 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
         """
 
         self.db_engine.execute(
-            '''create table {sparse_state_table} (
+            f'''create table {self.sparse_table_name} (
                 entity_id integer,
                 as_of_date timestamp,
-                {active_state} boolean
+                {DEFAULT_ACTIVE_STATE} boolean
             )
-            '''.format(
-                sparse_state_table=self.sparse_table_name,
-                active_state=DEFAULT_ACTIVE_STATE
-            )
+            '''
         )
         logging.info('Created sparse state table, now inserting rows')
+
         for as_of_date in as_of_dates:
-            formatted_date = f"'{as_of_date.isoformat()}'"
+            formatted_date = f"{as_of_date.isoformat()}"
             dated_query = self.query.replace('{as_of_date}', formatted_date)
-            full_query = f'''insert into {self.sparse_state_table}
-                select q.entity_id, {formatted_date}::timestamp, true
+            full_query = f'''insert into {self.sparse_table_name}
+                select q.entity_id, '{formatted_date}'::timestamp, true
                 from ({dated_query}) q
                 group by 1, 2, 3
             '''

--- a/src/triage/component/architect/state_table_generators.py
+++ b/src/triage/component/architect/state_table_generators.py
@@ -163,21 +163,15 @@ class StateTableGeneratorFromQuery(StateTableGeneratorBase):
         )
         logging.info('Created sparse state table, now inserting rows')
         for as_of_date in as_of_dates:
-            formatted_date = "'{}'::timestamp".format(as_of_date.isoformat())
+            formatted_date = f"'{as_of_date.isoformat()}'"
             dated_query = self.query.replace('{as_of_date}', formatted_date)
-            full_query = '''insert into {sparse_state_table}
-                select q.entity_id, {as_of_date}, true
-                from ({query}) q
+            full_query = f'''insert into {self.sparse_state_table}
+                select q.entity_id, {formatted_date}::timestamp, true
+                from ({dated_query}) q
                 group by 1, 2, 3
-            '''.format(
-                sparse_state_table=self.sparse_table_name,
-                query=dated_query,
-                as_of_date=formatted_date
-            )
+            '''
             logging.info(
-                'Running state query for date: %s, %s',
-                as_of_date,
-                full_query
+                f'Running state query for date: {as_of_date}, {full_query}',
             )
             self.db_engine.execute(full_query)
 


### PR DESCRIPTION
I reopened this issue (#408) because the same error happened in `architect`. Now the validation and `architect` behave exactly the same