### PR TITLE
Change config to v6 [Resolves #468]

### DIFF
--- a/docs/sources/experiments/upgrade-to-v6.md
+++ b/docs/sources/experiments/upgrade-to-v6.md
@@ -1,0 +1,55 @@
+# Upgrading your experiment configuration to v6
+
+
+This document details the steps needed to update a triage v5 configuration to
+v6, mimicking the old behavior.
+
+Experiment configuration v6 includes only one change from v5: When specifying
+the `cohort_config`, if a `query` is given , the `{af_of_date}` is no longer
+quoted or casted by Triage. Instead, the user must perform the quoting and
+casting, as is done already for the `label_config`.
+
+Old:
+
+```
+cohort_config:
+    query: |
+        SELECT DISTINCT entity_id
+          FROM semantic.events
+         WHERE event = 'booking'
+           AND startdt <@ daterange(({as_of_date} - '3 years'::interval)::date, {as_of_date})
+           AND enddt < {as_of_date}
+         LIMIT 100
+    name: 'booking_last_3_years_limit_100'
+```
+
+New:
+
+```
+cohort_config:
+    query: |
+        SELECT DISTINCT entity_id
+          FROM semantic.events
+         WHERE event = 'booking'
+           AND startdt <@ daterange(('{as_of_date}'::date - '3 years'::interval)::date, '{as_of_date}'::date)
+           AND enddt < '{as_of_date}'
+         LIMIT 100
+    name: 'booking_last_3_years_limit_100'
+```
+
+## Upgrading the experiment config version
+
+At this point, you should be able to bump the top-level experiment config version to v6:
+
+Old:
+
+```
+config_version: 'v5'
+```
+
+New:
+
+```
+config_version: 'v6'
+```
+

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -18,6 +18,7 @@ The first phase implemented in triage is the `Experiment`. An experiment represe
 See the [Running an Experiment](experiments/running.md) documentation.
 
 ## Upgrading an Experiment config
+[v5 -> v6](experiments/upgrade-to-v6.md)
 [v3/v4 -> v5](experiments/upgrade-to-v5.md)
 
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,3 +1,0 @@
----
-project: 'myproject'
-shared_bucket: 'shared'

--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -5,7 +5,7 @@
 # old configuration files are released. Be sure to assign the config version
 # that matches the triage.experiments.CONFIG_VERSION in the triage release
 # you are developing against!
-config_version: 'v5'
+config_version: 'v6'
 
 # EXPERIMENT METADATA
 # model_comment (optional) will end up in the model_comment column of the

--- a/src/triage/experiments/__init__.py
+++ b/src/triage/experiments/__init__.py
@@ -1,5 +1,5 @@
 # Avoid circular import (required by base)
-CONFIG_VERSION = 'v5'  # noqa: E402
+CONFIG_VERSION = 'v6'  # noqa: E402
 
 from .base import ExperimentBase
 from .multicore import MultiCoreExperiment


### PR DESCRIPTION
This commit changes the config version to v6 and updates the documentation in response to changes to the interpretation of the `cohort_config`.