### PR TITLE
Verbose config check

### DIFF
--- a/src/triage/component/timechop/plotting.py
+++ b/src/triage/component/timechop/plotting.py
@@ -1,3 +1,5 @@
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.dates as md
 import numpy as np
 from triage.util.conf import convert_str_to_relativedelta
@@ -110,4 +112,5 @@ def visualize_chops(chopper, show_as_of_times=True, show_boundaries=True):
     ax[0].set_title("Timechop: Temporal cross-validation blocks")
     fig.subplots_adjust(hspace=0)
     plt.setp([a.get_xticklabels() for a in fig.axes[:-1]], visible=False)
+    plt.savefig('timechop.png')
     plt.show()

--- a/src/triage/component/timechop/plotting.py
+++ b/src/triage/component/timechop/plotting.py
@@ -9,7 +9,7 @@ import matplotlib.pyplot as plt
 FIG_SIZE = (32, 16)
 
 
-def visualize_chops(chopper, show_as_of_times=True, show_boundaries=True):
+def visualize_chops(chopper, show_as_of_times=True, show_boundaries=True, save_target=None):
     """Visualize time chops of a given Timechop object using matplotlib
 
     Args:
@@ -18,6 +18,8 @@ def visualize_chops(chopper, show_as_of_times=True, show_boundaries=True):
             for as-of-times
         show_boundaries (bool, default True) Whether or not to show a rectangle around matrices
             and dashed lines around feature/label boundaries
+        save_target (path or filehandle, default None) A save target for matplotlib to save
+            the figure to. Defaults to None, which won't save anything
     """
     chops = chopper.chop_time()
 
@@ -112,5 +114,6 @@ def visualize_chops(chopper, show_as_of_times=True, show_boundaries=True):
     ax[0].set_title("Timechop: Temporal cross-validation blocks")
     fig.subplots_adjust(hspace=0)
     plt.setp([a.get_xticklabels() for a in fig.axes[:-1]], visible=False)
-    plt.savefig('timechop.png')
+    if save_target:
+        plt.savefig(save_target)
     plt.show()

--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -328,16 +328,19 @@ class FeatureAggregationsValidator(Validator):
         agg_types = ["aggregates", "categoricals", "array_categoricals"]
 
         for agg_type in agg_types:
+            logging.info('agg_type:{}'.format(agg_type))
             # base_imp are the top-level rules, `such as aggregates_imputation`
             base_imp = aggregation_config.get(agg_type + "_imputation", {})
 
             # loop through the individual aggregates
             for agg in aggregation_config.get(agg_type, []):
+                logging.info('agg:{}'.format(agg))
                 # combine any aggregate-level imputation rules with top-level ones
                 imp_dict = dict(base_imp, **agg.get("imputation", {}))
 
                 # imputation rules are metric-specific, so check each metric's rule
                 for metric in agg["metrics"]:
+                    logging.info('metrics:{}'.format(metric))
                     # metric rules may be defined by the metric name (e.g., 'max')
                     # or with the 'all' catch-all, with named metrics taking
                     # precedence. If we fall back to {}, the rule validator will

--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -328,19 +328,19 @@ class FeatureAggregationsValidator(Validator):
         agg_types = ["aggregates", "categoricals", "array_categoricals"]
 
         for agg_type in agg_types:
-            logging.info('agg_type:{}'.format(agg_type))
+            logging.info('Checking imputation rules for aggregation type %s', agg_type)
             # base_imp are the top-level rules, `such as aggregates_imputation`
             base_imp = aggregation_config.get(agg_type + "_imputation", {})
 
             # loop through the individual aggregates
             for agg in aggregation_config.get(agg_type, []):
-                logging.info('agg:{}'.format(agg))
+                logging.info('Checking imputation rules for aggregation %s', agg)
                 # combine any aggregate-level imputation rules with top-level ones
                 imp_dict = dict(base_imp, **agg.get("imputation", {}))
 
                 # imputation rules are metric-specific, so check each metric's rule
                 for metric in agg["metrics"]:
-                    logging.info('metrics:{}'.format(metric))
+                    logging.info('Checking imputation rules for metric: %s', metric)
                     # metric rules may be defined by the metric name (e.g., 'max')
                     # or with the 'all' catch-all, with named metrics taking
                     # precedence. If we fall back to {}, the rule validator will


### PR DESCRIPTION
This PR adds:

- verbose output for the config validator to better check errors
- outputs the timechop figure to a png