### PR TITLE
Audition model group filter [Resovles #494]

### DIFF
--- a/src/triage/component/audition/thresholding.py
+++ b/src/triage/component/audition/thresholding.py
@@ -27,10 +27,14 @@ def _of_metric(df, metric_filter):
 def model_groups_filter(
     train_end_times, initial_model_group_ids, models_table, db_engine
 ):
-    """Before creating the distance table, we want to filter the model_group_ids
-    and train_end_times only if they are reasonable -- every model group should
-    have the same train_end_times -- to prevent incomparable model groups from
-    being populated to the distance table.
+    """Filter the models which related train end times don't contain the user-input
+    train_end_times
+
+    Before creating the distance table, we want to make sure the model_group_ids
+    and train_end_times are reasonable:
+        1. the input train_end_times should exisit in the database
+        2. every model group should have the same train_end_times
+    to prevent incomparable model groups from being populated to the distance table.
 
     Args:
         train_end_times (list) The set of train_end_times to consider during
@@ -77,12 +81,12 @@ def model_groups_filter(
 
     dropped_model_groups = len(initial_model_group_ids) - len(model_group_ids)
     logging.info(
-        f"Dropped {dropped_model_groups} model groups which don't have the same train end times"
+        f"Dropped {dropped_model_groups} model groups which don't match the train end times"
     )
     logging.info(f"Found {len(model_group_ids)} total model groups past the checker")
 
     if len(set(model_group_ids)) == 0:
-        raise ValueError("The train_end_times passed in is not a subset of any train end times of any model group. Please double check all the model groups have the specified train end times.")
+        raise ValueError("The train_end_times passed in is not a subset of train end times of any model group. Please double check that all the model groups have the specified train end times.")
     return set(model_group_ids)
 
 

--- a/src/triage/component/audition/thresholding.py
+++ b/src/triage/component/audition/thresholding.py
@@ -70,7 +70,7 @@ def model_groups_filter(
             WHERE model_group_id in {tuple(initial_model_group_ids)}
             GROUP BY model_group_id
         ) as t
-        WHERE train_end_time_list = {end_times_sql}
+        WHERE train_end_time_list @> {end_times_sql}
         """
     model_groups_df = pd.read_sql(query, con=db_engine)
     model_group_ids = list(model_groups_df["model_group_id"])
@@ -81,6 +81,8 @@ def model_groups_filter(
     )
     logging.info(f"Found {len(model_group_ids)} total model groups past the checker")
 
+    if len(set(model_group_ids)) == 0:
+        raise ValueError("The train_end_times passed in is not a subset of any train end times of any model group. Please double check all the model groups have the specified train end times.")
     return set(model_group_ids)
 
 


### PR DESCRIPTION
- The `model_group_filter` now is more flexible for the model groups and train end times that if the model's train end times contain the input `train_end_times` (no matter if it's by query or user input) , we let the model pass. In other words, the input `train_end_times` should be the same or a subset of models' train end times.
- In order to be verbose, the `model_group_filter` will raise an error if no models pass the filter. 