### PR TITLE
Label Generation Replace Flag [Resolves #499]

### DIFF
--- a/docs/sources/experiments/running.md
+++ b/docs/sources/experiments/running.md
@@ -151,7 +151,14 @@ We'd like to add more validations for common misconfiguration problems over time
 
 ## Restarting an Experiment
 
-If an experiment fails for any reason, you can restart it. Each matrix and each model file is saved with a filename matching a hash of its unique attributes, so when the experiment is rerun, it will by default reuse the matrix or model instead of rebuilding it. If you would like to change this behavior and replace existing versions of matrices and models, set the 'replace' flag. 
+If an experiment fails for any reason, you can restart it.
+
+By default, all work will be recreated. This includes label queries, feature queries, matrix building, model training, etc. However, if you pass the `replace=False` keyword argument, the Experiment will reuse what work it can.
+
+- Labels Table: The Experiment keeps a labels table namespaced by its experiment hash, and within that will check on a per-`as_of_date`/`label timespan` level whether or not there are *any* existing rows, and skip the label query if so. For this reason, it is *not* aware of specific entities or source events so if the label query has changed or the source data has changed, you will not want to set `replace` to False. Don't expect too much reuse from this, however, as the table is experiment-namespaced. Essentially, this will only reuse data if the same experiment was run prior and failed part of the way through label generation. 
+- Features Tables: The Experiment will check on a per-table basis whether or not it exists, and skip the feature generation if so. Each 'table' maps to a feature aggregation in your experiment config, so if you have modified any source data that affects that feature aggregation, added any features to that aggregation, or changed any `temporal_config` so there are more `as_of_dates`, you won't want to set `replace` to False.
+- Matrix Building: Each matrix's metadata is hashed to create a unique id. If a file exists in storage with that hash, it will be reused.
+- Model Training: Each model's metadata (which includes its train matrix's hash) is hashed to create a unique id. If a file exists in storage with that hash, it will be reused.
 
 
 ### CLI

--- a/src/tests/architect_tests/test_label_generators.py
+++ b/src/tests/architect_tests/test_label_generators.py
@@ -7,6 +7,8 @@ from triage.component.architect.label_generators import LabelGenerator
 
 from .utils import create_binary_outcome_events
 
+
+# Sample events data to use for all tests
 events_data = [
     # entity id, event_date, outcome
     [1, date(2014, 1, 1), True],
@@ -24,23 +26,30 @@ events_data = [
 ]
 
 
+# An example label generation query to use for all tests.
+# Since this is expected to be passed in properly by the user
+# we don't need to test variations. Just reuse this one.
+LABEL_GENERATE_QUERY = """select
+    events.entity_id,
+    bool_or(outcome::bool)::integer as outcome
+from events
+where
+    '{as_of_date}' <= outcome_date
+    and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
+    group by entity_id
+"""
+
+LABELS_TABLE_NAME = "labels"
+
+
 def test_label_generation():
+    # Generate labels for one as-of-date/label timespan combo
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         create_binary_outcome_events(engine, "events", events_data)
 
-        labels_table_name = "labels"
-        query = """select
-            events.entity_id,
-            bool_or(outcome::bool)::integer as outcome
-        from events
-        where
-            '{as_of_date}' <= outcome_date
-            and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
-            group by entity_id
-        """
-        label_generator = LabelGenerator(db_engine=engine, query=query)
-        label_generator._create_labels_table(labels_table_name)
+        label_generator = LabelGenerator(db_engine=engine, query=LABEL_GENERATE_QUERY)
+        label_generator._create_labels_table(LABELS_TABLE_NAME)
         label_generator.generate(
             start_date="2014-09-30", label_timespan="6months", labels_table="labels"
         )
@@ -52,32 +61,22 @@ def test_label_generation():
             (4, date(2014, 9, 30), timedelta(180), "outcome", "binary", False),
         ]
         result = engine.execute(
-            "select * from {} order by entity_id, as_of_date".format(labels_table_name)
+            "select * from {} order by entity_id, as_of_date".format(LABELS_TABLE_NAME)
         )
         records = [row for row in result]
         assert records == expected
 
 
-def test_generate_all_labels():
+def test_generate_all_labels_replace():
+    # Generate labels for combinations of as-of-date and label timespan
+    # use replace=True
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         create_binary_outcome_events(engine, "events", events_data)
 
-        labels_table_name = "labels"
-
-        query = """select
-            events.entity_id,
-            bool_or(outcome::bool)::integer as outcome
-        from events
-        where
-            '{as_of_date}' <= outcome_date
-            and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
-            group by entity_id
-        """
-
-        label_generator = LabelGenerator(db_engine=engine, query=query)
+        label_generator = LabelGenerator(db_engine=engine, query=LABEL_GENERATE_QUERY, replace=True)
         label_generator.generate_all_labels(
-            labels_table=labels_table_name,
+            labels_table=LABELS_TABLE_NAME,
             as_of_dates=["2014-09-30", "2015-03-30"],
             label_timespans=["6month", "3month"],
         )
@@ -87,7 +86,73 @@ def test_generate_all_labels():
             select * from {}
             order by entity_id, as_of_date, label_timespan desc
         """.format(
-                labels_table_name
+                LABELS_TABLE_NAME
+            )
+        )
+        records = [row for row in result]
+
+        expected = [
+            # entity_id, as_of_date, label_timespan, name, type, label
+            (1, date(2014, 9, 30), timedelta(180), "outcome", "binary", False),
+            (1, date(2014, 9, 30), timedelta(90), "outcome", "binary", False),
+            (2, date(2015, 3, 30), timedelta(180), "outcome", "binary", False),
+            (2, date(2015, 3, 30), timedelta(90), "outcome", "binary", False),
+            (3, date(2014, 9, 30), timedelta(180), "outcome", "binary", True),
+            (3, date(2015, 3, 30), timedelta(180), "outcome", "binary", False),
+            (4, date(2014, 9, 30), timedelta(180), "outcome", "binary", False),
+            (4, date(2014, 9, 30), timedelta(90), "outcome", "binary", False),
+        ]
+        assert records == expected
+
+
+def test_generate_all_labels_noreplace():
+    # test the 'replace=False' functionality
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        create_binary_outcome_events(engine, "events", events_data)
+
+        label_generator = LabelGenerator(
+            db_engine=engine,
+            query=LABEL_GENERATE_QUERY,
+            replace=False
+        )
+        label_generator.generate_all_labels(
+            labels_table=LABELS_TABLE_NAME,
+            as_of_dates=["2014-09-30"],
+            label_timespans=["6month"],
+        )
+
+        result = engine.execute(
+            """
+            select * from {}
+            order by entity_id, as_of_date, label_timespan desc
+        """.format(
+                LABELS_TABLE_NAME
+            )
+        )
+        records = [row for row in result]
+
+        expected = [
+            # entity_id, as_of_date, label_timespan, name, type, label
+            (1, date(2014, 9, 30), timedelta(180), "outcome", "binary", False),
+            (3, date(2014, 9, 30), timedelta(180), "outcome", "binary", True),
+            (4, date(2014, 9, 30), timedelta(180), "outcome", "binary", False),
+        ]
+        assert records == expected
+
+        # round 2
+        label_generator.generate_all_labels(
+            labels_table=LABELS_TABLE_NAME,
+            as_of_dates=["2014-09-30", "2015-03-30"],
+            label_timespans=["6month", "3month"],
+        )
+
+        result = engine.execute(
+            """
+            select * from {}
+            order by entity_id, as_of_date, label_timespan desc
+        """.format(
+                LABELS_TABLE_NAME
             )
         )
         records = [row for row in result]

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -173,6 +173,7 @@ class ExperimentBase(ABC):
             self.label_generator = LabelGenerator(
                 label_name=self.config["label_config"].get("name", None),
                 query=self.config["label_config"]["query"],
+                replace=self.replace,
                 db_engine=self.db_engine,
             )
         else:


### PR DESCRIPTION
Make label generation respect the `replace` Flag. It only looks in the
same labels table it's using, which is experiment-namespaced, so it
won't often benefit from this, but it's a start.