### PR TITLE
Prevent experiment hanging when worker is killed by OS [Resolves #501]

### DIFF
--- a/docs/sources/experiments/running.md
+++ b/docs/sources/experiments/running.md
@@ -55,7 +55,7 @@ experiment.run()
 
 ## Multicore example
 
-Triage also offers the ability to parallelize both CPU-heavy and database-heavy tasks. Triage uses the multiprocessing library to perform both of these, but they are separately configurable as the database tasks will more likely be bounded by the number of connections/cores available on the database server instead of the number of cores available on the experiment running machine.
+Triage also offers the ability to locally parallelize both CPU-heavy and database-heavy tasks. Triage uses the [pebble](https://pythonhosted.org/Pebble) library to perform both of these, but they are separately configurable as the database tasks will more likely be bounded by the number of connections/cores available on the database server instead of the number of cores available on the experiment running machine.
 
 ### CLI
 
@@ -84,6 +84,8 @@ experiment = MultiCoreExperiment(
 experiment.run()
 
 ```
+
+The [pebble](https://pythonhosted.org/Pebble) library offers an interface around Python3's `concurrent.futures` module that adds in a very helpful tool: watching for killed subprocesses . Model training (and sometimes, matrix building) can be a memory-hungry task, and Triage can not guarantee that the operating system you're running on won't kill the worker processes in a way that prevents them from reporting back to the parent Experiment process. With Pebble, this occurrence is caught like a regular Exception, which allows the Process pool to recover and include the information in the Experiment's log.
 
 ## Using S3 to store matrices and models
 
@@ -291,5 +293,5 @@ Before you run an experiment, you can inspect properties of the Experiment objec
 ## Experiment Classes
 
 - *SingleThreadedExperiment*: An experiment that performs all tasks serially in a single thread. Good for simple use on small datasets, or for understanding the general flow of data through a pipeline.
-- *MultiCoreExperiment*: An experiment that makes use of the multiprocessing library to parallelize various time-consuming steps. Takes an `n_processes` keyword argument to control how many workers to use.
+- *MultiCoreExperiment*: An experiment that makes use of the pebble library to parallelize various time-consuming steps. Takes an `n_processes` keyword argument to control how many workers to use.
 - *RQExperiment*: An experiment that makes use of the python-rq library to enqueue individual tasks onto the default queue, and wait for the jobs to be finished before moving on. python-rq requires Redis and any number of worker processes running the Triage codebase. Triage does not set up any of this needed infrastructure for you. Available through the RQ extra ( `pip install triage[rq]` )

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -21,3 +21,4 @@ s3fs==0.1.6
 wrapt==1.10.11
 argcmdr==0.6.0
 sqlparse==0.2.4
+pebble==4.3.9

--- a/src/tests/catwalk_tests/test_utils.py
+++ b/src/tests/catwalk_tests/test_utils.py
@@ -1,8 +1,13 @@
 from triage.component.catwalk.utils import (
     filename_friendly_hash,
     save_experiment_and_get_hash,
+    associate_models_with_experiment,
+    associate_matrices_with_experiment,
+    missing_model_hashes,
+    missing_matrix_uuids,
     sort_predictions_and_labels,
 )
+from triage.component.results_schema.schema import Matrix, Model
 from triage.component.catwalk.db import ensure_db
 from sqlalchemy import create_engine
 import testing.postgresql
@@ -60,6 +65,48 @@ def test_save_experiment_and_get_hash():
         assert isinstance(exp_hash, str)
         new_hash = save_experiment_and_get_hash(experiment_config, engine)
         assert new_hash == exp_hash
+
+
+def test_missing_model_hashes():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+
+        experiment_hash = save_experiment_and_get_hash({}, db_engine)
+        model_hashes = ['abcd', 'bcde', 'cdef']
+
+        # if we associate model hashes with an experiment but don't actually train the models
+        # they should show up as missing
+        associate_models_with_experiment(experiment_hash, model_hashes, db_engine)
+        assert missing_model_hashes(experiment_hash, db_engine) == model_hashes
+
+        # if we insert a model row they should no longer be considered missing
+        db_engine.execute(
+            f"insert into {Model.__table__.fullname} (model_hash) values (%s)",
+            model_hashes[0]
+        )
+        assert missing_model_hashes(experiment_hash, db_engine) == model_hashes[1:]
+
+
+def test_missing_matrix_uuids():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+
+        experiment_hash = save_experiment_and_get_hash({}, db_engine)
+        matrix_uuids = ['abcd', 'bcde', 'cdef']
+
+        # if we associate matrix uuids with an experiment but don't actually build the matrices
+        # they should show up as missing
+        associate_matrices_with_experiment(experiment_hash, matrix_uuids, db_engine)
+        assert missing_matrix_uuids(experiment_hash, db_engine) == matrix_uuids
+
+        # if we insert a matrix row they should no longer be considered missing
+        db_engine.execute(
+            f"insert into {Matrix.__table__.fullname} (matrix_uuid) values (%s)",
+            matrix_uuids[0]
+        )
+        assert missing_matrix_uuids(experiment_hash, db_engine) == matrix_uuids[1:]
 
 
 def test_sort_predictions_and_labels():


### PR DESCRIPTION
Converts the MulticoreExperiment to use Pebble instead of
multiprocessing.

This allows us to wrap the ProcessExpired exception in the case of
the operating system (or something else) killing the subprocess. This
ensures the process pool can keep going and provide useful information
in the logs.