### PR TITLE
Closes #502

### DIFF
--- a/example_experiment_config.yaml
+++ b/example_experiment_config.yaml
@@ -175,6 +175,7 @@ feature_aggregations:
                 metrics:
                     - 'count'
                     - 'sum'
+                coltype: 'smallint'   # Optional, if you want to control the column type in the generated features tables
             -
                 # since we're specifying `aggregates_imputation` above,
                 # a feature-specific imputation rule can be omitted

--- a/src/tests/collate_tests/test_collate.py
+++ b/src/tests/collate_tests/test_collate.py
@@ -24,6 +24,13 @@ def test_aggregate_when():
         "count(1) FILTER (WHERE date < '2012-01-01')"
     ]
 
+def test_aggregate_when_cast():
+    agg = Aggregate("", "mode", {}, "x", coltype="SMALLINT")
+    assert list(map(str, agg.get_columns(when="date < '2012-01-01'"))) == [
+        "mode() WITHIN GROUP (ORDER BY x) FILTER (WHERE date < '2012-01-01')::SMALLINT"
+    ]
+
+
 def test_ordered_aggregate():
     agg = Aggregate("", "mode", {}, "x")
     (expression,) = agg.get_columns()
@@ -36,6 +43,8 @@ def test_ordered_aggregate_when():
     assert list(map(str, agg.get_columns(when="date < '2012-01-01'"))) == [
         "mode() WITHIN GROUP (ORDER BY x) FILTER (WHERE date < '2012-01-01')"
     ]
+
+
 
 
 def test_aggregate_tuple_quantity():

--- a/src/tests/collate_tests/test_collate.py
+++ b/src/tests/collate_tests/test_collate.py
@@ -4,26 +4,25 @@
 Unit tests for `collate` module.
 
 """
-from triage.component.collate import Aggregate, Aggregation
-
+from triage.component.collate import Aggregate, Aggregation, Categorical
 
 def test_aggregate():
     agg = Aggregate("*", "count", {})
     assert list(map(str, agg.get_columns())) == ["count(*)"]
 
-
 def test_aggregate_cast():
     agg = Aggregate("*", "count", {}, coltype="REAL")
     assert list(map(str, agg.get_columns())) == ["count(*)::REAL"]
 
-
+def test_categorical_cast():
+    cat = Categorical("c", ['A','B','C'], "sum", {}, coltype="SMALLINT")
+    assert list(map(str, cat.get_columns())) == ["sum((c = 'A')::INT)::SMALLINT","sum((c = 'B')::INT)::SMALLINT","sum((c = 'C')::INT)::SMALLINT"]
 
 def test_aggregate_when():
     agg = Aggregate("1", "count", {})
     assert list(map(str, agg.get_columns(when="date < '2012-01-01'"))) == [
         "count(1) FILTER (WHERE date < '2012-01-01')"
     ]
-
 
 def test_ordered_aggregate():
     agg = Aggregate("", "mode", {}, "x")

--- a/src/tests/collate_tests/test_collate.py
+++ b/src/tests/collate_tests/test_collate.py
@@ -12,6 +12,12 @@ def test_aggregate():
     assert list(map(str, agg.get_columns())) == ["count(*)"]
 
 
+def test_aggregate_cast():
+    agg = Aggregate("*", "count", {}, coltype="REAL")
+    assert list(map(str, agg.get_columns())) == ["count(*)::REAL"]
+
+
+
 def test_aggregate_when():
     agg = Aggregate("1", "count", {})
     assert list(map(str, agg.get_columns(when="date < '2012-01-01'"))) == [

--- a/src/tests/collate_tests/test_collate.py
+++ b/src/tests/collate_tests/test_collate.py
@@ -16,7 +16,11 @@ def test_aggregate_cast():
 
 def test_categorical_cast():
     cat = Categorical("c", ['A','B','C'], "sum", {}, coltype="SMALLINT")
-    assert list(map(str, cat.get_columns())) == ["sum((c = 'A')::INT)::SMALLINT","sum((c = 'B')::INT)::SMALLINT","sum((c = 'C')::INT)::SMALLINT"]
+    assert list(map(str, cat.get_columns())) == [
+        "sum((c = 'A')::INT)::SMALLINT",
+        "sum((c = 'B')::INT)::SMALLINT",
+        "sum((c = 'C')::INT)::SMALLINT"
+    ]
 
 def test_aggregate_when():
     agg = Aggregate("1", "count", {})

--- a/src/tests/collate_tests/test_imputations.py
+++ b/src/tests/collate_tests/test_imputations.py
@@ -20,7 +20,7 @@ from triage.component.collate.imputations import (
 def test_impute_flag():
     imp = BaseImputation(column="a", coltype="aggregate")
     assert (
-        imp.imputed_flag_sql() == 'CASE WHEN "a" IS NULL THEN TRUE ELSE FALSE END AS "a_imp" '
+        imp.imputed_flag_sql() == 'CASE WHEN "a" IS NULL THEN 1::SMALLINT ELSE 0::SMALLINT END AS "a_imp" '
     )
 
 

--- a/src/tests/collate_tests/test_imputations.py
+++ b/src/tests/collate_tests/test_imputations.py
@@ -31,16 +31,16 @@ def test_impute_flag_categorical():
 
 def test_mean_imputation():
     imp = ImputeMean(column="a", coltype="aggregate")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (), 0::REAL) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER ()::REAL, 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="aggregate", partitionby="date")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (PARTITION BY date), 0::REAL) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date)::REAL, 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (), 0::REAL) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER ()::REAL, 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="aggregate", partitionby="date")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (PARTITION BY date), 0::REAL) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date)::REAL, 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a__NULL_mean", coltype="categorical")
     assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
@@ -51,13 +51,13 @@ def test_constant_imputation():
     assert imp.to_sql() == 'COALESCE("a", 3.14) AS "a" '
 
     imp = ImputeConstant(column="a_myval_max", coltype="categorical", value="myval")
-    assert imp.to_sql() == 'COALESCE("a_myval_max", 1) AS "a_myval_max" '
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 1::SMALLINT) AS "a_myval_max" '
 
     imp = ImputeConstant(column="a_otherval_max", coltype="categorical", value="myval")
-    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0::SMALLINT) AS "a_otherval_max" '
 
     imp = ImputeConstant(column="a__NULL_mean", coltype="categorical", value="myval")
-    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1::SMALLINT) AS "a__NULL_mean" '
 
 
 def test_impute_zero():
@@ -76,18 +76,18 @@ def test_impute_zero():
 
 def test_impute_zero_noflag():
     imp = ImputeZeroNoFlag(column="a", coltype="aggregate")
-    assert imp.to_sql() == 'COALESCE("a", 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", 0::SMALLINT) AS "a" '
     assert imp.imputed_flag_sql() is None
     assert imp.noflag
 
     imp = ImputeZeroNoFlag(column="a_myval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0::SMALLINT) AS "a_myval_max" '
 
     imp = ImputeZeroNoFlag(column="a_otherval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0::SMALLINT) AS "a_otherval_max" '
 
     imp = ImputeZeroNoFlag(column="a__NULL_mean", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 0) AS "a__NULL_mean" '
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 0::SMALLINT) AS "a__NULL_mean" '
 
 
 def test_impute_null_cat():

--- a/src/tests/collate_tests/test_imputations.py
+++ b/src/tests/collate_tests/test_imputations.py
@@ -20,7 +20,7 @@ from triage.component.collate.imputations import (
 def test_impute_flag():
     imp = BaseImputation(column="a", coltype="aggregate")
     assert (
-        imp.imputed_flag_sql() == 'CASE WHEN "a" IS NULL THEN 1 ELSE 0 END AS "a_imp" '
+        imp.imputed_flag_sql() == 'CASE WHEN "a" IS NULL THEN TRUE ELSE FALSE END AS "a_imp" '
     )
 
 

--- a/src/tests/collate_tests/test_imputations.py
+++ b/src/tests/collate_tests/test_imputations.py
@@ -31,16 +31,16 @@ def test_impute_flag_categorical():
 
 def test_mean_imputation():
     imp = ImputeMean(column="a", coltype="aggregate")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (), 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="aggregate", partitionby="date")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (PARTITION BY date), 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (), 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a", coltype="aggregate", partitionby="date")
-    assert imp.to_sql() == 'COALESCE("a", AVG("a") OVER (PARTITION BY date), 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", AVG("a")::REAL OVER (PARTITION BY date), 0::REAL) AS "a" '
 
     imp = ImputeMean(column="a__NULL_mean", coltype="categorical")
     assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
@@ -62,16 +62,16 @@ def test_constant_imputation():
 
 def test_impute_zero():
     imp = ImputeZero(column="a", coltype="aggregate")
-    assert imp.to_sql() == 'COALESCE("a", 0) AS "a" '
+    assert imp.to_sql() == 'COALESCE("a", 0::REAL) AS "a" '
 
     imp = ImputeZero(column="a_myval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0::SMALLINT) AS "a_myval_max" '
 
     imp = ImputeZero(column="a_otherval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0::SMALLINT) AS "a_otherval_max" '
 
     imp = ImputeZero(column="a__NULL_mean", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1::SMALLINT) AS "a__NULL_mean" '
 
 
 def test_impute_zero_noflag():
@@ -92,13 +92,13 @@ def test_impute_zero_noflag():
 
 def test_impute_null_cat():
     imp = ImputeNullCategory(column="a_myval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_myval_max", 0) AS "a_myval_max" '
+    assert imp.to_sql() == 'COALESCE("a_myval_max", 0::SMALLINT) AS "a_myval_max" '
 
     imp = ImputeNullCategory(column="a_otherval_max", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0) AS "a_otherval_max" '
+    assert imp.to_sql() == 'COALESCE("a_otherval_max", 0::SMALLINT) AS "a_otherval_max" '
 
     imp = ImputeNullCategory(column="a__NULL_mean", coltype="categorical")
-    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1) AS "a__NULL_mean" '
+    assert imp.to_sql() == 'COALESCE("a__NULL_mean", 1::SMALLINT) AS "a__NULL_mean" '
 
     try:
         imp = ImputeNullCategory(column="a", coltype="aggregate")

--- a/src/triage/component/architect/feature_generators.py
+++ b/src/triage/component/architect/feature_generators.py
@@ -232,6 +232,7 @@ class FeatureGenerator(object):
                     **categorical.get("imputation", {})
                 ),
                 include_null=True,
+                coltype=aggregate.get('coltype', None),
             )
             for categorical in categorical_config
         ]
@@ -255,6 +256,7 @@ class FeatureGenerator(object):
                 op_in_name=False,
                 quote_choices=False,
                 include_null=True,
+                coltype=aggregate.get('coltype', None)
             )
             for categorical in categorical_config
         ]
@@ -278,6 +280,7 @@ class FeatureGenerator(object):
                 aggregate["quantity"],
                 aggregate["metrics"],
                 dict(agimp, coltype="aggregate", **aggregate.get("imputation", {})),
+                coltype=aggregate.get('coltype', None)
             )
             for aggregate in aggregation_config.get("aggregates", [])
         ]

--- a/src/triage/component/architect/feature_generators.py
+++ b/src/triage/component/architect/feature_generators.py
@@ -232,7 +232,7 @@ class FeatureGenerator(object):
                     **categorical.get("imputation", {})
                 ),
                 include_null=True,
-                coltype=aggregate.get('coltype', None),
+                coltype=categorical.get('coltype', None),
             )
             for categorical in categorical_config
         ]

--- a/src/triage/component/architect/feature_generators.py
+++ b/src/triage/component/architect/feature_generators.py
@@ -256,7 +256,7 @@ class FeatureGenerator(object):
                 op_in_name=False,
                 quote_choices=False,
                 include_null=True,
-                coltype=aggregate.get('coltype', None)
+                coltype=categorical.get('coltype', None)
             )
             for categorical in categorical_config
         ]

--- a/src/triage/component/collate/collate.py
+++ b/src/triage/component/collate/collate.py
@@ -213,7 +213,7 @@ class Aggregate(AggregateExpression):
 
         name_template = "{prefix}{quantity_name}_{function}"
         coltype_template = ""
-        column_template = "{function}({distinct}{args}){coltype_cast}{order_clause}{filter}"
+        column_template = "{function}({distinct}{args}){order_clause}{filter}{coltype_cast}"
         arg_template = "{quantity}"
         order_template = ""
         filter_template = ""

--- a/src/triage/component/collate/collate.py
+++ b/src/triage/component/collate/collate.py
@@ -384,7 +384,7 @@ class Compare(Aggregate):
             for i, k in enumerate(list(d.keys())):
                 d["%s_%02d" % (k[: maxlen - 3], i)] = d.pop(k)
 
-        Aggregate.__init__(self, d, function, impute_rules, order)
+        Aggregate.__init__(self, d, function, impute_rules, order, coltype)
 
 
 class Categorical(Compare):

--- a/src/triage/component/collate/collate.py
+++ b/src/triage/component/collate/collate.py
@@ -170,6 +170,7 @@ class Aggregate(AggregateExpression):
             function: SQL aggregate function
             impute_rules: dictionary of rules mapping functions to imputation methods
             order: SQL for order by clause in an ordered set aggregate
+            coltype: SQL type for the column in the generated features table
 
         Notes:
             quantity, function, and order can also be lists of the above,

--- a/src/triage/component/collate/imputations.py
+++ b/src/triage/component/collate/imputations.py
@@ -61,7 +61,7 @@ class ImputeMean(BaseImputation):
         if not self.catcol:
             # aggregate columm
             return sql.format(
-                imp="""AVG("%s") OVER (%s), 0""" % (self.column, self.partitionby)
+                imp="""AVG("%s")::REAL OVER (%s), 0::REAL""" % (self.column, self.partitionby)
             )
         elif self.null_cat_pattern in self.column:
             # categorical NULL category
@@ -69,7 +69,7 @@ class ImputeMean(BaseImputation):
         else:
             # categorical
             return sql.format(
-                imp="""AVG("%s") OVER (%s), 0""" % (self.column, self.partitionby)
+                imp="""AVG("%s")::REAL OVER (%s), 0::REAL""" % (self.column, self.partitionby)
             )
 
 
@@ -126,7 +126,7 @@ class ImputeZero(BaseImputation):
     def to_sql(self):
         sql = self._base_sql()
         return sql.format(
-            imp=1 if self.catcol and self.null_cat_pattern in self.column else 0
+            imp="1::SMALLINT" if self.catcol and self.null_cat_pattern in self.column else ("0::SMALLINT" if self.catcol else "0::REAL")
         )
 
 
@@ -151,7 +151,7 @@ class ImputeZeroNoFlag(BaseImputation):
 
     def to_sql(self):
         sql = self._base_sql()
-        return sql.format(imp=0)
+        return sql.format(imp="0")
 
 
 class ImputeNullCategory(BaseImputation):
@@ -176,7 +176,7 @@ class ImputeNullCategory(BaseImputation):
 
     def to_sql(self):
         sql = self._base_sql()
-        return sql.format(imp=1 if self.null_cat_pattern in self.column else 0)
+        return sql.format(imp="1::SMALLINT" if self.null_cat_pattern in self.column else "0::SMALLINT")
 
 
 class ImputeBinaryMode(BaseImputation):

--- a/src/triage/component/collate/imputations.py
+++ b/src/triage/component/collate/imputations.py
@@ -24,7 +24,7 @@ class BaseImputation(object):
 
     def imputed_flag_sql(self):
         if not self.noflag:
-            return """CASE WHEN "{col}" IS NULL THEN 1 ELSE 0 END AS "{col}_imp" """.format(
+            return """CASE WHEN "{col}" IS NULL THEN TRUE ELSE FALSE END AS "{col}_imp" """.format(
                 col=self.column
             )
         else:

--- a/src/triage/component/collate/imputations.py
+++ b/src/triage/component/collate/imputations.py
@@ -24,7 +24,7 @@ class BaseImputation(object):
 
     def imputed_flag_sql(self):
         if not self.noflag:
-            return """CASE WHEN "{col}" IS NULL THEN TRUE ELSE FALSE END AS "{col}_imp" """.format(
+            return """CASE WHEN "{col}" IS NULL THEN 1::SMALLINT ELSE 0::SMALLINT END AS "{col}_imp" """.format(
                 col=self.column
             )
         else:

--- a/src/triage/component/collate/imputations.py
+++ b/src/triage/component/collate/imputations.py
@@ -61,7 +61,7 @@ class ImputeMean(BaseImputation):
         if not self.catcol:
             # aggregate columm
             return sql.format(
-                imp="""AVG("%s")::REAL OVER (%s), 0::REAL""" % (self.column, self.partitionby)
+                imp="""AVG("%s") OVER (%s)::REAL, 0::REAL""" % (self.column, self.partitionby)
             )
         elif self.null_cat_pattern in self.column:
             # categorical NULL category
@@ -69,7 +69,7 @@ class ImputeMean(BaseImputation):
         else:
             # categorical
             return sql.format(
-                imp="""AVG("%s")::REAL OVER (%s), 0::REAL""" % (self.column, self.partitionby)
+                imp="""AVG("%s") OVER (%s)::REAL, 0::REAL""" % (self.column, self.partitionby)
             )
 
 
@@ -101,9 +101,9 @@ class ImputeConstant(BaseImputation):
         else:
             # categorical column
             return sql.format(
-                imp=1
+                imp="1::SMALLINT"
                 if self.value in self.column or self.null_cat_pattern in self.column
-                else 0
+                else "0::SMALLINT"
             )
 
 
@@ -151,7 +151,7 @@ class ImputeZeroNoFlag(BaseImputation):
 
     def to_sql(self):
         sql = self._base_sql()
-        return sql.format(imp="0")
+        return sql.format(imp="0::SMALLINT")
 
 
 class ImputeNullCategory(BaseImputation):

--- a/src/triage/util/pandas.py
+++ b/src/triage/util/pandas.py
@@ -1,5 +1,6 @@
 from functools import partial
 import pandas as pd
+import numpy as np
 import logging
 
 
@@ -17,7 +18,7 @@ def downcast_matrix(df):
     """
     logging.debug("Downcasting matrix. Starting memory usage: %s", df.memory_usage())
 
-    new_df = df.apply(lambda x:x.astype(float32))
+    new_df = df.apply(lambda x: x.astype(np.float32))
 
     logging.debug("Downcasted matrix. Final memory usage: %s", new_df.memory_usage())
     return new_df

--- a/src/triage/util/pandas.py
+++ b/src/triage/util/pandas.py
@@ -16,10 +16,8 @@ def downcast_matrix(df):
     and save memory on the index storage.
     """
     logging.debug("Downcasting matrix. Starting memory usage: %s", df.memory_usage())
-    new_df = (
-        df.apply(partial(pd.to_numeric, downcast="float"))
-        .apply(partial(pd.to_numeric, downcast="integer"))
-    )
+
+    new_df = df.apply(lambda x:x.astype(float32))
 
     logging.debug("Downcasted matrix. Final memory usage: %s", new_df.memory_usage())
     return new_df

--- a/src/triage/util/pandas.py
+++ b/src/triage/util/pandas.py
@@ -18,7 +18,12 @@ def downcast_matrix(df):
     """
     logging.debug("Downcasting matrix. Starting memory usage: %s", df.memory_usage())
 
+    logging.debug(df.dtypes)
+
     new_df = df.apply(lambda x: x.astype(np.float32))
 
+    logging.debug(new_df.dtypes)
+
     logging.debug("Downcasted matrix. Final memory usage: %s", new_df.memory_usage())
+
     return new_df


### PR DESCRIPTION
Closes #502 

Added option `coltype` to `Aggregates` so you can specify the column type.

Besides that, the imputation makes some educated guesses about the type of the column `_imp` in particular is a `smallint`(*)


(*) I tried to use a `boolean` but the `COPY` to csv was storing an `f`/`t` instead of `0`/`1` ... :(