### PR TITLE
added pytest fixtures to simplify and clean up (architect) tests

### DIFF
--- a/src/tests/architect_tests/test_feature_generators.py
+++ b/src/tests/architect_tests/test_feature_generators.py
@@ -1,12 +1,9 @@
 import copy
 from datetime import date
-from unittest import TestCase
 
 import pandas
 import pytest
 import sqlalchemy
-import testing.postgresql
-from sqlalchemy import create_engine
 
 from triage.component.architect.feature_generators import FeatureGenerator
 from triage.component.collate import Aggregate, Categorical, SpacetimeAggregation
@@ -34,9 +31,14 @@ INPUT_STATES = [
 ]
 
 
-def setup_db(engine):
-    engine.execute(
-        """
+@pytest.fixture(name='test_engine', scope='function')
+def fixture_test_engine(db_engine):
+    """Local extension to the shared db_engine fixture to set up test
+    database tables.
+
+    """
+    db_engine.execute(
+        """\
         create table data (
             entity_id int,
             knowledge_date date,
@@ -44,24 +46,26 @@ def setup_db(engine):
             cat_one varchar,
             quantity_one float
         )
-    """
+        """
     )
     for row in INPUT_DATA:
-        engine.execute("insert into data values (%s, %s, %s, %s, %s)", row)
+        db_engine.execute("insert into data values (%s, %s, %s, %s, %s)", row)
 
-    engine.execute(
-        """
+    db_engine.execute(
+        """\
         create table states (
             entity_id int,
             as_of_date date
         )
-    """
+        """
     )
     for row in INPUT_STATES:
-        engine.execute("insert into states values (%s, %s)", row)
+        db_engine.execute("insert into states values (%s, %s)", row)
+
+    return db_engine
 
 
-def test_feature_generation():
+def test_feature_generation(test_engine):
     aggregate_config = [
         {
             "prefix": "aprefix",
@@ -186,31 +190,31 @@ def test_feature_generation():
         ]
     }
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
 
-        features_schema_name = "features"
-        output_tables = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).create_all_tables(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
+    output_tables = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).create_all_tables(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
 
-        for output_table in output_tables:
-            records = pandas.read_sql(
-                "select * from {}.{} order by entity_id, as_of_date".format(
-                    features_schema_name, output_table
-                ),
-                engine,
-            ).to_dict("records")
-            for record, expected_record in zip(records, expected_output[output_table]):
-                assert record == expected_record
+    for output_table in output_tables:
+        records = pandas.read_sql(
+            "select * from {}.{} order by entity_id, as_of_date".format(
+                features_schema_name,
+                output_table,
+            ),
+            test_engine,
+        ).to_dict("records")
+
+        for record, expected_record in zip(records, expected_output[output_table]):
+            assert record == expected_record
 
 
-def test_index_column_lookup():
+def test_index_column_lookup(test_engine):
     aggregations = [
         SpacetimeAggregation(
             prefix="prefix1",
@@ -252,22 +256,20 @@ def test_index_column_lookup():
             from_obj="data",
         ),
     ]
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
 
-        features_schema_name = "features"
-        feature_generator = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        )
-        lookup = feature_generator.index_column_lookup(aggregations)
-        assert lookup == {
-            "prefix1_aggregation_imputed": ["as_of_date", "entity_id"],
-            "prefix2_aggregation_imputed": ["as_of_date", "entity_id", "zip_code"],
-        }
+    features_schema_name = "features"
+    feature_generator = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    )
+    lookup = feature_generator.index_column_lookup(aggregations)
+    assert lookup == {
+        "prefix1_aggregation_imputed": ["as_of_date", "entity_id"],
+        "prefix2_aggregation_imputed": ["as_of_date", "entity_id", "zip_code"],
+    }
 
 
-def test_feature_generation_feature_start_time():
+def test_feature_generation_feature_start_time(test_engine):
     aggregate_config = [
         {
             "prefix": "aprefix",
@@ -300,32 +302,30 @@ def test_feature_generation_feature_start_time():
         ]
     }
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
+    output_tables = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+        feature_start_time="2013-01-01",
+    ).create_all_tables(
+        feature_dates=["2015-01-01"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
 
-        features_schema_name = "features"
-        output_tables = FeatureGenerator(
-            db_engine=engine,
-            features_schema_name=features_schema_name,
-            feature_start_time="2013-01-01",
-        ).create_all_tables(
-            feature_dates=["2015-01-01"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
+    for output_table in output_tables:
+        records = pandas.read_sql(
+            "select * from {}.{} order by as_of_date, entity_id".format(
+                features_schema_name,
+                output_table,
+            ),
+            test_engine,
+        ).to_dict("records")
 
-        for output_table in output_tables:
-            records = pandas.read_sql(
-                "select * from {}.{} order by as_of_date, entity_id".format(
-                    features_schema_name, output_table
-                ),
-                engine,
-            ).to_dict("records")
-            assert records == expected_output[output_table]
+        assert records == expected_output[output_table]
 
 
-def test_dynamic_categoricals():
+def test_dynamic_categoricals(test_engine):
     aggregate_config = [
         {
             "prefix": "aprefix",
@@ -388,31 +388,29 @@ def test_dynamic_categoricals():
         ]
     }
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
 
-        features_schema_name = "features"
+    output_tables = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).create_all_tables(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
 
-        output_tables = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).create_all_tables(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
+    for output_table in output_tables:
+        records = pandas.read_sql(
+            "select * from {}.{} order by as_of_date, entity_id".format(
+                features_schema_name, output_table
+            ),
+            test_engine,
+        ).to_dict("records")
 
-        for output_table in output_tables:
-            records = pandas.read_sql(
-                "select * from {}.{} order by as_of_date, entity_id".format(
-                    features_schema_name, output_table
-                ),
-                engine,
-            ).to_dict("records")
-            assert records == expected_output[output_table]
+        assert records == expected_output[output_table]
 
 
-def test_array_categoricals():
+def test_array_categoricals(db_engine):
     aggregate_config = [
         {
             "prefix": "aprefix",
@@ -475,62 +473,62 @@ def test_array_categoricals():
         ]
     }
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        input_data = [
-            # entity_id, knowledge_date, cat_one, quantity_one
-            (1, date(2014, 1, 1), ["good", "good"], 10000),
-            (1, date(2014, 10, 11), ["good"], None),
-            (3, date(2012, 6, 8), ["bad"], 342),
-            (3, date(2014, 12, 21), ["inbetween"], 600),
-            (4, date(2014, 4, 4), ["bad"], 1236),
-        ]
+    input_data = [
+        # entity_id, knowledge_date, cat_one, quantity_one
+        (1, date(2014, 1, 1), ["good", "good"], 10000),
+        (1, date(2014, 10, 11), ["good"], None),
+        (3, date(2012, 6, 8), ["bad"], 342),
+        (3, date(2014, 12, 21), ["inbetween"], 600),
+        (4, date(2014, 4, 4), ["bad"], 1236),
+    ]
 
-        engine.execute(
-            """
-            create table data (
-                entity_id int,
-                knowledge_date date,
-                cat_one varchar[],
-                quantity_one float
-            )
+    db_engine.execute(
+        """\
+        create table data (
+            entity_id int,
+            knowledge_date date,
+            cat_one varchar[],
+            quantity_one float
+        )
         """
-        )
-        for row in input_data:
-            engine.execute("insert into data values (%s, %s, %s, %s)", row)
+    )
+    for row in input_data:
+        db_engine.execute("insert into data values (%s, %s, %s, %s)", row)
 
-        engine.execute(
-            """
-            create table states (
-                entity_id int,
-                as_of_date date
-            )
+    db_engine.execute(
+        """\
+        create table states (
+            entity_id int,
+            as_of_date date
+        )
         """
-        )
-        for row in INPUT_STATES:
-            engine.execute("insert into states values (%s, %s)", row)
+    )
+    for row in INPUT_STATES:
+        db_engine.execute("insert into states values (%s, %s)", row)
 
-        features_schema_name = "features"
+    features_schema_name = "features"
 
-        output_tables = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).create_all_tables(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
+    output_tables = FeatureGenerator(
+        db_engine=db_engine,
+        features_schema_name=features_schema_name,
+    ).create_all_tables(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
 
-        for output_table in output_tables:
-            records = pandas.read_sql(
-                "select * from {}.{} order by as_of_date, entity_id".format(
-                    features_schema_name, output_table
-                ),
-                engine,
-            ).to_dict("records")
-            assert records == expected_output[output_table]
+    for output_table in output_tables:
+        records = pandas.read_sql(
+            "select * from {}.{} order by as_of_date, entity_id".format(
+                features_schema_name, output_table
+            ),
+            db_engine,
+        ).to_dict("records")
+
+        assert records == expected_output[output_table]
 
 
-def test_generate_table_tasks():
+def test_generate_table_tasks(test_engine):
     aggregations = [
         SpacetimeAggregation(
             prefix="prefix1",
@@ -572,37 +570,37 @@ def test_generate_table_tasks():
             from_obj="data",
         ),
     ]
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
 
-        features_schema_name = "features"
+    table_tasks = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).generate_all_table_tasks(aggregations, task_type="aggregation")
+    for table_name, task in table_tasks.items():
+        assert "DROP TABLE" in task["prepare"][0]
+        assert "CREATE TABLE" in str(task["prepare"][1])
+        assert "CREATE INDEX" in task["finalize"][0]
+        assert isinstance(task["inserts"], list)
 
-        table_tasks = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).generate_all_table_tasks(aggregations, task_type="aggregation")
-        for table_name, task in table_tasks.items():
-            assert "DROP TABLE" in task["prepare"][0]
-            assert "CREATE TABLE" in str(task["prepare"][1])
-            assert "CREATE INDEX" in task["finalize"][0]
-            assert isinstance(task["inserts"], list)
+    # build the aggregation tables to check the imputation tasks
+    FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).process_table_tasks(table_tasks)
 
-        # build the aggregation tables to check the imputation tasks
-        FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).process_table_tasks(table_tasks)
+    table_tasks = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).generate_all_table_tasks(aggregations, task_type="imputation")
 
-        table_tasks = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).generate_all_table_tasks(aggregations, task_type="imputation")
-        for table_name, task in table_tasks.items():
-            assert "DROP TABLE" in task["prepare"][0]
-            assert "CREATE TABLE" in str(task["prepare"][1])
-            assert "CREATE INDEX" in task["finalize"][0]
-            assert isinstance(task["inserts"], list)
+    for table_name, task in table_tasks.items():
+        assert "DROP TABLE" in task["prepare"][0]
+        assert "CREATE TABLE" in str(task["prepare"][1])
+        assert "CREATE INDEX" in task["finalize"][0]
+        assert isinstance(task["inserts"], list)
 
 
-def test_aggregations():
+def test_aggregations(test_engine):
     aggregate_config = [
         {
             "prefix": "prefix1",
@@ -629,24 +627,21 @@ def test_aggregations():
             "from_obj": "data",
         },
     ]
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
 
-        features_schema_name = "features"
-
-        aggregations = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name
-        ).aggregations(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
-        for aggregation in aggregations:
-            assert isinstance(aggregation, SpacetimeAggregation)
+    aggregations = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+    ).aggregations(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
+    for aggregation in aggregations:
+        assert isinstance(aggregation, SpacetimeAggregation)
 
 
-def test_replace():
+def test_replace(test_engine):
     aggregate_config = [
         {
             "prefix": "aprefix",
@@ -667,46 +662,46 @@ def test_replace():
         }
     ]
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    features_schema_name = "features"
+    feature_tables = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+        replace=False,
+    ).create_all_tables(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
 
-        features_schema_name = "features"
-        feature_tables = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name, replace=False
-        ).create_all_tables(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
+    assert len(feature_tables) == 1
+    assert list(feature_tables)[0] == "aprefix_aggregation_imputed"
 
-        assert len(feature_tables) == 1
-        assert list(feature_tables)[0] == "aprefix_aggregation_imputed"
+    feature_generator = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name=features_schema_name,
+        replace=False,
+    )
+    aggregations = feature_generator.aggregations(
+        feature_dates=["2013-09-30", "2014-09-30"],
+        feature_aggregation_config=aggregate_config,
+        state_table="states",
+    )
+    table_tasks = feature_generator.generate_all_table_tasks(
+        aggregations,
+        task_type="aggregation",
+    )
 
-        feature_generator = FeatureGenerator(
-            db_engine=engine, features_schema_name=features_schema_name, replace=False
-        )
-        aggregations = feature_generator.aggregations(
-            feature_dates=["2013-09-30", "2014-09-30"],
-            feature_aggregation_config=aggregate_config,
-            state_table="states",
-        )
-        table_tasks = feature_generator.generate_all_table_tasks(
-            aggregations, task_type="aggregation"
-        )
+    assert len(table_tasks["aprefix_entity_id"]) == 0
 
-        assert len(table_tasks["aprefix_entity_id"].keys()) == 0
+    imp_tasks = feature_generator.generate_all_table_tasks(
+        aggregations,
+        task_type="imputation",
+    )
 
-        imp_tasks = feature_generator.generate_all_table_tasks(
-            aggregations, task_type="imputation"
-        )
-
-        assert len(imp_tasks["aprefix_aggregation_imputed"].keys()) == 0
-
-        engine.dispose()
+    assert len(imp_tasks["aprefix_aggregation_imputed"]) == 0
 
 
-def test_transaction_error():
+def test_transaction_error(test_engine):
     """Database connections are cleaned up regardless of in-transaction
     query errors.
 
@@ -731,40 +726,33 @@ def test_transaction_error():
         }
     ]
 
-    with testing.postgresql.Postgresql() as postgresql:
-        engine = create_engine(postgresql.url())
-        setup_db(engine)
+    feature_generator = FeatureGenerator(
+        db_engine=test_engine,
+        features_schema_name="features",
+    )
 
-        feature_generator = FeatureGenerator(
-            db_engine=engine, features_schema_name="features"
+    with pytest.raises(sqlalchemy.exc.ProgrammingError):
+        feature_generator.create_all_tables(
+            feature_dates=["2013-09-30", "2014-09-30"],
+            feature_aggregation_config=aggregate_config,
+            state_table="statez",  # WRONG!
         )
-        with pytest.raises(sqlalchemy.exc.ProgrammingError):
-            feature_generator.create_all_tables(
-                feature_dates=["2013-09-30", "2014-09-30"],
-                feature_aggregation_config=aggregate_config,
-                state_table="statez",  # WRONG!
-            )
 
-        (query_count,) = engine.execute(
-            """\
+    ((query_count,),) = test_engine.execute(
+        """\
             select count(*) from pg_stat_activity
             where query not ilike '%%pg_stat_activity%%'
         """
-        ).fetchone()
+    )
 
-        assert query_count == 0
-
-        engine.dispose()
+    assert query_count == 0
 
 
-class TestValidations(TestCase):
-    def setUp(self):
-        self.postgresql = testing.postgresql.Postgresql()
-        engine = create_engine(self.postgresql.url())
-        setup_db(engine)
-        self.feature_generator = FeatureGenerator(engine, "features")
+class TestValidations:
 
-        self.base_config = {
+    @pytest.fixture
+    def base_config(self):
+        return {
             "prefix": "aprefix",
             "categoricals": [
                 {
@@ -780,95 +768,89 @@ class TestValidations(TestCase):
             "from_obj": "data",
         }
 
-    def tearDown(self):
-        self.postgresql.stop()
+    @pytest.fixture
+    def feature_generator(self, test_engine):
+        return FeatureGenerator(test_engine, "features")
 
-    def test_correct_keys(self):
-        self.feature_generator.validate([self.base_config])
+    def test_correct_keys(self, base_config, feature_generator):
+        feature_generator.validate([base_config])
 
-        with self.assertRaises(ValueError):
-            no_group = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_group = copy.deepcopy(base_config)
             del no_group["groups"]
-            self.feature_generator.validate([no_group])
+            feature_generator.validate([no_group])
 
-        with self.assertRaises(ValueError):
-            no_intervals = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_intervals = copy.deepcopy(base_config)
             del no_intervals["intervals"]
-            self.feature_generator.validate([no_intervals])
+            feature_generator.validate([no_intervals])
 
-        with self.assertRaises(ValueError):
-            no_kdate = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_kdate = copy.deepcopy(base_config)
             del no_kdate["knowledge_date_column"]
-            self.feature_generator.validate([no_kdate])
+            feature_generator.validate([no_kdate])
 
-        with self.assertRaises(ValueError):
-            no_from_obj = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_from_obj = copy.deepcopy(base_config)
             del no_from_obj["from_obj"]
-            self.feature_generator.validate([no_from_obj])
+            feature_generator.validate([no_from_obj])
 
-        with self.assertRaises(ValueError):
-            no_aggs = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_aggs = copy.deepcopy(base_config)
             del no_aggs["categoricals"]
-            self.feature_generator.validate([no_aggs])
+            feature_generator.validate([no_aggs])
 
-        with self.assertRaises(ValueError):
-            no_imps = copy.deepcopy(self.base_config)
+        with pytest.raises(ValueError):
+            no_imps = copy.deepcopy(base_config)
             del no_imps["categoricals"][0]["imputation"]
-            self.feature_generator.validate([no_imps])
+            feature_generator.validate([no_imps])
 
-    def test_bad_from_obj(self):
-        bad_from_obj = copy.deepcopy(self.base_config)
+    def test_bad_from_obj(self, base_config, feature_generator):
+        bad_from_obj = copy.deepcopy(base_config)
         bad_from_obj["from_obj"] = "where thing is other_thing"
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([bad_from_obj])
+        with pytest.raises(ValueError):
+            feature_generator.validate([bad_from_obj])
 
-    def test_bad_interval(self):
-        bad_interval = copy.deepcopy(self.base_config)
-        bad_interval["intervals"] = ["1y", "1fortnight"]
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([bad_interval])
+    def test_bad_interval(self, base_config, feature_generator):
+        base_config["intervals"] = ["1y", "1fortnight"]
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_bad_group(self):
-        bad_group = copy.deepcopy(self.base_config)
-        bad_group["groups"] = ["zip_code", "otherthing"]
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([bad_group])
+    def test_bad_group(self, base_config, feature_generator):
+        base_config["groups"] = ["zip_code", "otherthing"]
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_bad_choice_query(self):
-        bad_choice_query = copy.deepcopy(self.base_config)
-        del bad_choice_query["categoricals"][0]["choices"]
-        bad_choice_query["categoricals"][0][
+    def test_bad_choice_query(self, base_config, feature_generator):
+        del base_config["categoricals"][0]["choices"]
+        base_config["categoricals"][0][
             "choice_query"
         ] = "select distinct cat_two from data"
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([bad_choice_query])
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_wrong_imp_fcn(self):
-        wrong_imp_fcn = copy.deepcopy(self.base_config)
-        del wrong_imp_fcn["categoricals"][0]["imputation"]["all"]
-        wrong_imp_fcn["categoricals"][0]["imputation"]["max"] = {
+    def test_wrong_imp_fcn(self, base_config, feature_generator):
+        del base_config["categoricals"][0]["imputation"]["all"]
+        base_config["categoricals"][0]["imputation"]["max"] = {
             "type": "null_category"
         }
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([wrong_imp_fcn])
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_bad_imp_rule(self):
-        bad_imp_rule = copy.deepcopy(self.base_config)
-        bad_imp_rule["categoricals"][0]["imputation"]["all"] = {
+    def test_bad_imp_rule(self, base_config, feature_generator):
+        base_config["categoricals"][0]["imputation"]["all"] = {
             "type": "bad_rule_doesnt_exist"
         }
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([bad_imp_rule])
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_no_imp_rule_type(self):
-        no_imp_rule_type = copy.deepcopy(self.base_config)
-        no_imp_rule_type["categoricals"][0]["imputation"]["all"] = {"value": "good"}
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([no_imp_rule_type])
+    def test_no_imp_rule_type(self, base_config, feature_generator):
+        base_config["categoricals"][0]["imputation"]["all"] = {"value": "good"}
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])
 
-    def test_missing_imp_arg(self):
-        missing_imp_arg = copy.deepcopy(self.base_config)
+    def test_missing_imp_arg(self, base_config, feature_generator):
         # constant value imputation requires a 'value' parameter
-        missing_imp_arg["categoricals"][0]["imputation"]["all"] = {"type": "constant"}
-        with self.assertRaises(ValueError):
-            self.feature_generator.validate([missing_imp_arg])
+        base_config["categoricals"][0]["imputation"]["all"] = {"type": "constant"}
+        with pytest.raises(ValueError):
+            feature_generator.validate([base_config])

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+import testing.postgresql
+from sqlalchemy import create_engine
+
+
+@pytest.fixture(name='db_engine', scope='function')
+def fixture_db_engine():
+    """pytest fixture provider to set up and teardown a "test" database
+    and provide the test function a connection engine with which to
+    query that database.
+
+    """
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        yield engine
+        engine.dispose()


### PR DESCRIPTION
* a project-wide fixture, `db_engine`, provides the testing postgresql
database and the generic sqlalchemy connection engine with which to
query it, (and tears these down automatically)

* a test module-wide fixture, `test_engine`, extends `db_engine` with
database setup tasks, (replacing the module utility function,
`setup_db`)

* unittest.TestCase is replaced by a vanilla test class, such that test
class fixtures can be defined, (rather than xunit-style setUp)