### PR TITLE
Fix db engine check in Experiment [Resolves #538]

### DIFF
--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -9,6 +9,7 @@ import fakeredis
 import pytest
 import testing.postgresql
 from triage import create_engine
+import sqlalchemy
 
 from tests.utils import sample_config, populate_source_data
 from triage.component.catwalk.storage import HDFMatrixStore, CSVMatrixStore
@@ -480,3 +481,17 @@ def test_baselines_with_missing_features(experiment_class):
             )
         ]
         assert len(individual_importances) == num_predictions * 2  # only 2 features
+
+
+def test_serializable_engine_check_sqlalchemy_fail():
+    """If we pass a vanilla sqlalchemy engine to the experiment
+    we should convert it to a triage engine"""
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = sqlalchemy.create_engine(postgresql.url())
+        with TemporaryDirectory() as temp_dir:
+            with pytest.raises(ValueError):
+                MultiCoreExperiment(
+                    config=sample_config(),
+                    db_engine=db_engine,
+                    project_path=os.path.join(temp_dir, "inspections"),
+                )

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -484,12 +484,11 @@ def test_baselines_with_missing_features(experiment_class):
 
 
 def test_serializable_engine_check_sqlalchemy_fail():
-    """If we pass a vanilla sqlalchemy engine to the experiment
-    we should convert it to a triage engine"""
+    """If we pass a vanilla sqlalchemy engine to the experiment we should blow up"""
     with testing.postgresql.Postgresql() as postgresql:
         db_engine = sqlalchemy.create_engine(postgresql.url())
         with TemporaryDirectory() as temp_dir:
-            with pytest.raises(ValueError):
+            with pytest.raises(TypeError):
                 MultiCoreExperiment(
                     config=sample_config(),
                     db_engine=db_engine,

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 
 from descriptors import cachedproperty
 from timeout import timeout
-from sqlalchemy.engine import Engine
 
 from triage.component.architect.label_generators import (
     LabelGenerator,
@@ -47,7 +46,6 @@ from triage.experiments.validate import ExperimentValidator
 
 from triage.database_reflection import table_has_data
 from triage.util.conf import dt_from_str
-from triage.util.db import create_engine
 
 
 class ExperimentBase(ABC):
@@ -84,15 +82,6 @@ class ExperimentBase(ABC):
         self._check_config_version(config)
         self.config = config
 
-        if isinstance(db_engine, Engine):
-            logging.warning(
-                "Raw, unserializable SQLAlchemy engine passed. "
-                "URL will be used, other options may be lost in multi-process environments"
-            )
-            self.db_engine = create_engine(db_engine.url)
-        else:
-            self.db_engine = db_engine
-
         self.project_storage = ProjectStorage(project_path)
         self.model_storage_engine = ModelStorageEngine(self.project_storage)
         self.matrix_storage_engine = MatrixStorageEngine(
@@ -100,6 +89,7 @@ class ExperimentBase(ABC):
         )
         self.project_path = project_path
         self.replace = replace
+        self.db_engine = db_engine
         upgrade_db(db_engine=self.db_engine)
 
         self.features_schema_name = "features"

--- a/src/triage/experiments/multicore.py
+++ b/src/triage/experiments/multicore.py
@@ -2,6 +2,7 @@ import logging
 import traceback
 from functools import partial
 from pebble import ProcessPool
+from multiprocessing.reduction import ForkingPickler
 
 from triage.component.catwalk.utils import Batch
 
@@ -9,8 +10,17 @@ from triage.experiments import ExperimentBase
 
 
 class MultiCoreExperiment(ExperimentBase):
-    def __init__(self, n_processes=1, n_db_processes=1, *args, **kwargs):
-        super(MultiCoreExperiment, self).__init__(*args, **kwargs)
+    def __init__(self, db_engine, n_processes=1, n_db_processes=1, *args, **kwargs):
+        try:
+            ForkingPickler.dumps(db_engine)
+        except Exception as e:
+            raise ValueError(
+                "multiprocessing is unable to pickle passed SQLAlchemy engine."
+                "use triage.create_engine instead when running MultiCoreExperiment: "
+                "(e.g. from triage import create_engine)"
+            ) from e
+
+        super(MultiCoreExperiment, self).__init__(db_engine=db_engine, *args, **kwargs)
         if n_processes < 1:
             raise ValueError("n_processes must be 1 or greater")
         if n_db_processes < 1:

--- a/src/triage/experiments/multicore.py
+++ b/src/triage/experiments/multicore.py
@@ -10,17 +10,17 @@ from triage.experiments import ExperimentBase
 
 
 class MultiCoreExperiment(ExperimentBase):
-    def __init__(self, db_engine, n_processes=1, n_db_processes=1, *args, **kwargs):
+    def __init__(self, config, db_engine, *args, n_processes=1, n_db_processes=1, **kwargs):
         try:
             ForkingPickler.dumps(db_engine)
-        except Exception as e:
-            raise ValueError(
-                "multiprocessing is unable to pickle passed SQLAlchemy engine."
+        except Exception as exc:
+            raise TypeError(
+                "multiprocessing is unable to pickle passed SQLAlchemy engine. "
                 "use triage.create_engine instead when running MultiCoreExperiment: "
                 "(e.g. from triage import create_engine)"
-            ) from e
+            ) from exc
 
-        super(MultiCoreExperiment, self).__init__(db_engine=db_engine, *args, **kwargs)
+        super(MultiCoreExperiment, self).__init__(config, db_engine, *args, **kwargs)
         if n_processes < 1:
             raise ValueError("n_processes must be 1 or greater")
         if n_db_processes < 1:


### PR DESCRIPTION
The experiment checks whether or not the passed-in engine is a base sqlalchemy engine, and converts it into the serializable triage engine if so.

However, this check was broken. This PR fixes it to actually duck-type,
to see if the engine can be pickled to a memory file