### PR TITLE
upgrade install-cli to better support non-GNU (MacOS)

### DIFF
--- a/develop
+++ b/develop
@@ -18,7 +18,7 @@
 
 # Update INSTALL_VERSION to require the version of install-cli this
 # script expects
-INSTALL_VERSION=0.0.5
+INSTALL_VERSION=0.0.6
 
 #
 # start bootstrap installation lib

--- a/develop
+++ b/develop
@@ -46,13 +46,28 @@ INSTALL_URL=https://raw.githubusercontent.com/dssg/install-cli/$INSTALL_VERSION/
 # pyenv
 
 pyenv_bin="${PYENV_ROOT:-$HOME/.pyenv}/bin"
+pyenv_homebrew_bin=/usr/local/bin
 
-exists_pyenv() {
+exists_pyenv_installer() {
   [ -d "$pyenv_bin" ]
 }
 
+exists_pyenv_homebrew() {
+  [ -x "${pyenv_homebrew_bin}/pyenv" ]
+}
+
+exists_pyenv() {
+  exists_pyenv_installer || exists_pyenv_homebrew
+}
+
 boostrap_pyenv() {
-  export PATH="$pyenv_bin:$PATH"
+  if exists_pyenv_installer
+  then
+    export PATH="$pyenv_bin:$PATH"
+  elif exists_pyenv_homebrew
+  then
+    export PATH="$pyenv_homebrew_bin:$PATH"
+  fi
 
   eval "$(pyenv init -)"
   eval "$(pyenv virtualenv-init -)"

--- a/develop
+++ b/develop
@@ -18,7 +18,7 @@
 
 # Update INSTALL_VERSION to require the version of install-cli this
 # script expects
-INSTALL_VERSION=0.0.4
+INSTALL_VERSION=0.0.5
 
 #
 # start bootstrap installation lib


### PR DESCRIPTION
The Bash library on which the `develop` script depends has been tweaked to better support non-GNU environments such as MacOS, (at least as far as I've been made aware that it needs to be).

…But, let me know how this works for you!

(If you check out this branch, you should be able to execute the script and … it should work.)

Resolves #532.