### PR TITLE
support 5 GB multipart upload threshold via S3Fs

### DIFF
--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -1,12 +1,11 @@
 import os
 import tempfile
 import unittest
-import yaml
 from collections import OrderedDict
 
 import pandas as pd
+import yaml
 from moto import mock_s3
-
 from numpy.testing import assert_almost_equal
 
 from triage.component.catwalk.storage import (


### PR DESCRIPTION
*I.e.* clean-up / speculation for issue #530 and pull request #534

S3Fs *appears* to support the boto3 configuration necessary to set the
multipart upload threshold, (from the [API documentation](https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem) and from a
manual test I've just done).

Moreover, S3Fs appears to provide us a slightly nicer interface, and more
options for performance optimizations, than we could easily get on our
own, with so few lines of code. (For that matter, even as is, this means
fewer lines of code, and more straight-forward code.)

But … am I right?

See also: [my original comment](https://github.com/dssg/triage/pull/534#issuecomment-444218744)