### PR TITLE
Shorten log lines [Resolves #528]

### DIFF
--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -156,7 +156,7 @@ class BuilderBase(object):
             table_name=table_name,
             index_query=indices_query,
         )
-        logging.info(
+        logging.debug(
             "Creating matrix-specific entity-date table for matrix " "%s with query %s",
             matrix_uuid,
             query,

--- a/src/triage/component/architect/feature_dictionary_creator.py
+++ b/src/triage/component/architect/feature_dictionary_creator.py
@@ -1,5 +1,6 @@
 import logging
 from triage.component.architect.utils import str_in_sql
+from triage.util.structs import FeatureNameList
 
 
 class FeatureDictionaryCreator(object):
@@ -33,12 +34,8 @@ class FeatureDictionaryCreator(object):
                     )
                 )
             ]
-            logging.info(
-                "Feature names found for table %s: %s",
-                feature_table_name,
-                feature_names,
-            )
-            feature_dictionary[feature_table_name] = feature_names
+            feature_dictionary[feature_table_name] = FeatureNameList(feature_names)
+        logging.info("Feature dictionary built: %s", feature_dictionary)
         return feature_dictionary
 
     def _build_feature_names_query(self, table_name, index_columns):

--- a/src/triage/component/architect/feature_generators.py
+++ b/src/triage/component/architect/feature_generators.py
@@ -264,9 +264,9 @@ class FeatureGenerator(object):
 
     def _aggregation(self, aggregation_config, feature_dates, state_table):
         logging.info(
-            "Building collate.SpacetimeAggregation for config %s and as_of_dates %s",
+            "Building collate.SpacetimeAggregation for config %s and %s as_of_dates",
             aggregation_config,
-            feature_dates,
+            len(feature_dates),
         )
 
         # read top-level imputation rules from the aggregation config; we'll allow

--- a/src/triage/component/architect/feature_group_mixer.py
+++ b/src/triage/component/architect/feature_group_mixer.py
@@ -66,9 +66,9 @@ class FeatureGroupMixer(object):
         """Apply all strategies to the list of feature groups
 
         Args:
-            feature_groups (list) A list of feature dicts,
+            feature_groups (list) A list of feature dictionarys,
                 each representing a group
-        Returns: (list) of feature dicts
+        Returns: (list) of feature dictionaries
         """
         final_results = []
         for strategy in self.strategies:

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -15,6 +15,7 @@ import numpy
 from sqlalchemy.orm import sessionmaker
 
 from triage.component.results_schema import Model
+from triage.util.structs import FeatureNameList
 
 
 def str_in_sql(values):
@@ -29,13 +30,13 @@ def feature_list(feature_dictionary):
     Returns: sorted list of feature names
     """
     if not feature_dictionary:
-        return []
-    return sorted(
+        return FeatureNameList()
+    return FeatureNameList(sorted(
         functools.reduce(
             operator.concat,
             (feature_dictionary[key] for key in feature_dictionary.keys()),
         )
-    )
+    ))
 
 
 def convert_string_column_to_date(column):

--- a/src/triage/component/catwalk/evaluation.py
+++ b/src/triage/component/catwalk/evaluation.py
@@ -226,8 +226,9 @@ class ModelEvaluator(object):
                 )
 
                 logging.info(
-                    "Evaluations for %s%s, labeled examples %s "
+                    "%s for %s%s, labeled examples %s "
                     "above threshold %s, positive labels %s, value %s",
+                    evaluation_table_obj,
                     metric,
                     parameter_string,
                     num_labeled_examples,

--- a/src/triage/component/catwalk/predictors.py
+++ b/src/triage/component/catwalk/predictors.py
@@ -146,7 +146,6 @@ class Predictor(object):
             session.close()
         db_objects = []
         test_label_timespan = matrix_store.metadata["label_timespan"]
-        logging.warning(test_label_timespan)
 
         if "as_of_date" in matrix_store.matrix.index.names:
             logging.info(

--- a/src/triage/util/structs.py
+++ b/src/triage/util/structs.py
@@ -1,0 +1,16 @@
+"""Classes representing simple but deep data structures that we reuse throughout
+Triage code and want to display more intelligently in log files
+"""
+
+
+class TruncatedRepresentationList(list):
+    def __repr__(self):
+        return f"[{self[0]} ... {self[-1]} (Total: {len(self)})]"
+
+
+class AsOfTimeList(TruncatedRepresentationList):
+    pass
+
+
+class FeatureNameList(TruncatedRepresentationList):
+    pass


### PR DESCRIPTION
Long log lines are generally introduced by long lists of features or
as-of-times. Here we introduce structs to hold those lists but override
their __repr__ to be much shorter.

Some other minor logging issues are taken care of here, such as:
- one info->debug change
- change some from format-strings to logging arguments
- remove this one vestigial warning that had no purpose