### PR TITLE
Listify feature names in ModelGrouper [Resolves #551]

### DIFF
--- a/src/tests/catwalk_tests/utils.py
+++ b/src/tests/catwalk_tests/utils.py
@@ -11,6 +11,7 @@ import yaml
 from triage.component.catwalk.storage import (
     ProjectStorage,
 )
+from triage.util.structs import FeatureNameList
 
 
 @contextmanager
@@ -53,7 +54,7 @@ def sample_metadata():
         "cohort_name": "default",
         "label_timespan": "1y",
         "metta-uuid": "1234",
-        "feature_names": ["ft1", "ft2"],
+        "feature_names": FeatureNameList(["ft1", "ft2"]),
         "feature_groups": ["all: True"],
         "indices": ["entity_id"],
     }

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -14,6 +14,7 @@ from triage.component.catwalk.storage import MatrixStore, ProjectStorage
 from triage.component.results_schema import Model, Matrix
 from triage.experiments import CONFIG_VERSION
 from tests.results_tests.factories import init_engine, session, MatrixFactory
+from triage.util.structs import FeatureNameList
 
 
 @contextmanager
@@ -139,7 +140,7 @@ def matrix_metadata_creator(**override_kwargs):
         "label_timespan": "1y",
         "metta-uuid": "1234",
         "matrix_type": "test",
-        "feature_names": ["ft1", "ft2"],
+        "feature_names": FeatureNameList(["ft1", "ft2"]),
         "feature_groups": ["all: True"],
         "indices": ["entity_id", "as_of_date"],
     }

--- a/src/triage/component/catwalk/model_grouping.py
+++ b/src/triage/component/catwalk/model_grouping.py
@@ -133,7 +133,7 @@ class ModelGrouper(object):
                 "            '{model_config}'::JSONB )".format(
                     class_path=model_group_args["class_path"],
                     parameters=json.dumps(model_group_args["parameters"]),
-                    feature_names=model_group_args["feature_names"],
+                    feature_names=list(model_group_args["feature_names"]),
                     model_config=json.dumps(
                         model_group_args["model_config"], sort_keys=True
                     ),


### PR DESCRIPTION
In ModelGrouper, listify feature names so that even with the new shortened
string representation from #547 it still works.

The matrix metadata factories are also updated to reflect this.