### PR TITLE
 Experiment Profiling [Resolves #557]

### DIFF
--- a/docs/sources/experiments/running.md
+++ b/docs/sources/experiments/running.md
@@ -283,6 +283,9 @@ Here's an example query, which returns the top 10 model groups by precision at t
     limit 10
 ```
 
+
+
+
 ## Inspecting an Experiment before running
 
 Before you run an experiment, you can inspect properties of the Experiment object to ensure that it is configured in the way you want. Some examples:
@@ -292,6 +295,17 @@ Before you run an experiment, you can inspect properties of the Experiment objec
 - `experiment.matrix_build_tasks` will output a list representing each matrix that will be built.
 
 ## Optimizing Experiment Performance
+
+### Profiling an Experiment
+
+Experiment running slowly? Try the `profile` keyword argument, or `--profile` in the command line. This will output a cProfile file to the project path's `profiling_stats` directory.  This is a binary format but can be read with a variety of visualization programs.
+
+[snakeviz](https://jiffyclub.github.io/snakeviz/) - A browser based graphical viewer.
+[tuna](https://github.com/nschloe/tuna) - Another browser based graphical viewer
+[gprof2dot](https://github.com/jrfonseca/gprof2dot) - A command-line tool to convert files to graphviz format
+[pyprof2calltree](https://pypi.org/project/pyprof2calltree/) - A command-line tool to convert files to Valgrind log format, for viewing in established viewers like KCacheGrind
+
+Looking at the profile through a visualization program, you can see which portions of the experiment are taking up the most time. Based on this, you may be able to prioritize changes. For instance, if cohort/label/feature table generation are taking up the bulk of the time, you may add indexes to source tables, or increase the number of database processes. On the other hand, if model training is the culprit, you may temporarily try a smaller grid to get results more quickly.
 
 ### materialize_subquery_fromobjs
 By default, experiments will inspect the `from_obj` of every feature aggregation to see if it looks like a subquery, create a table out of it if so, index it on the `knowledge_date_column` and `entity_id`, and use that for running feature queries. This can make feature generation go a lot faster if the `from_obj` takes a decent amount of time to run and/or there are a lot of as-of-dates in the experiment. It won't do this for `from_objs` that are just tables, or simple joins (e.g. `entities join events using (entity_id)`) as the existing indexes you have on those tables should work just fine.

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 import pandas as pd
 import yaml
 from moto import mock_s3
+import boto3
 from numpy.testing import assert_almost_equal
 
 from triage.component.catwalk.storage import (
@@ -24,8 +25,6 @@ class SomeClass(object):
 
 def test_S3Store():
     with mock_s3():
-        import boto3
-
         client = boto3.client("s3")
         client.create_bucket(Bucket="test_bucket", ACL="public-read-write")
         store = S3Store(f"s3://test_bucket/a_path")
@@ -176,7 +175,6 @@ class MatrixStoreTest(unittest.TestCase):
 
     def test_s3_save(self):
         with mock_s3():
-            import boto3
 
             client = boto3.client("s3")
             client.create_bucket(Bucket="fake-matrix-bucket", ACL="public-read-write")

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -351,6 +351,19 @@ def test_custom_label_name(experiment_class):
             assert experiment.planner.label_names == ["custom_label_name"]
 
 
+def test_profiling(db_engine):
+    populate_source_data(db_engine)
+    with TemporaryDirectory() as temp_dir:
+        project_path = os.path.join(temp_dir, "inspections")
+        experiment = SingleThreadedExperiment(
+            config=sample_config(),
+            db_engine=db_engine,
+            project_path=project_path,
+            profile=True
+        ).run()
+        assert len(os.listdir(os.path.join(project_path, "profiling_stats"))) == 1
+
+
 @parametrize_experiment_classes
 def test_baselines_with_missing_features(experiment_class):
     with testing.postgresql.Postgresql() as postgresql:

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -200,6 +200,12 @@ class Experiment(Command):
             action="store_true",
             help="only validate the config file not running Experiment",
         )
+        parser.add_argument(
+            "--profile",
+            action="store_true",
+            dest="profile",
+            help="Record the time spent in various functions using cProfile"
+        )
 
         parser.add_argument(
             "--no-materialize-fromobjs",
@@ -223,6 +229,7 @@ class Experiment(Command):
             "replace": self.args.replace,
             "materialize_subquery_fromobjs": self.args.materialize_fromobjs,
             "matrix_storage_class": self.matrix_storage_map[self.args.matrix_format],
+            "profile": self.args.profile,
         }
         if self.args.n_db_processes > 1 or self.args.n_processes > 1:
             experiment = MultiCoreExperiment(


### PR DESCRIPTION
- Add cProfile bindings to experiment.run, write to profiling_stats
directory in project path.
- Add local_fs_path method to Storage classes so modules that need a
filename to write to (e.g. cProfile) can still use Project Storage.
- Add cli option for profiling
- Add section on profiling to docs