### PR TITLE
Disable individual importance in example experiment config

### DIFF
--- a/example/config/experiment.yaml
+++ b/example/config/experiment.yaml
@@ -353,5 +353,6 @@ scoring:
 # This entire section can be left blank,
 # in which case the defaults will be used.
 individual_importance:
-    methods: ['uniform']
+    methods: [] # empty list means don't calculate individual importances
+    # methods: ['uniform']
     n_ranks: 5


### PR DESCRIPTION
To optimize speed for new users who are copying from the example
experiment config, we disable individual importance as that can take
some time