### PR TITLE
Colocate Testing with Training [Resolves #560]

### DIFF
--- a/src/tests/catwalk_tests/test_model_trainers.py
+++ b/src/tests/catwalk_tests/test_model_trainers.py
@@ -26,12 +26,12 @@ def grid_config():
 
 
 @pytest.fixture(scope="function")
-def default_model_trainer(db_engine, project_storage):
+def default_model_trainer(db_engine_with_results_schema, project_storage):
     model_storage_engine = project_storage.model_storage_engine()
     trainer = ModelTrainer(
         experiment_hash=None,
         model_storage_engine=model_storage_engine,
-        db_engine=db_engine,
+        db_engine=db_engine_with_results_schema,
         model_grouper=ModelGrouper(),
     )
     yield trainer
@@ -200,13 +200,13 @@ def test_baseline_exception_handling(default_model_trainer):
     assert model_ids == [1, None]
 
 
-def test_custom_groups(grid_config, db_engine, project_storage):
+def test_custom_groups(grid_config, db_engine_with_results_schema, project_storage):
     model_storage_engine = project_storage.model_storage_engine()
     trainer = ModelTrainer(
         experiment_hash=None,
         model_storage_engine=model_storage_engine,
         model_grouper=ModelGrouper(["class_path"]),
-        db_engine=db_engine,
+        db_engine=db_engine_with_results_schema,
     )
     # create training set
     model_ids = trainer.train_models(
@@ -217,7 +217,7 @@ def test_custom_groups(grid_config, db_engine, project_storage):
     # expect only one model group now
     records = [
         row[0]
-        for row in db_engine.execute(
+        for row in db_engine_with_results_schema.execute(
             "select distinct model_group_id from model_metadata.models"
         )
     ]

--- a/src/tests/catwalk_tests/test_model_trainers.py
+++ b/src/tests/catwalk_tests/test_model_trainers.py
@@ -25,205 +25,207 @@ def grid_config():
     }
 
 
-def test_model_trainer(grid_config):
-    with rig_engines() as (db_engine, project_storage):
-        # Creates a matrix entry in the matrices table with uuid from metadata above
-        model_storage_engine = project_storage.model_storage_engine()
-        trainer = ModelTrainer(
-            experiment_hash=None,
-            model_storage_engine=model_storage_engine,
-            model_grouper=ModelGrouper(),
-            db_engine=db_engine,
+@pytest.fixture(scope="function")
+def default_model_trainer(db_engine, project_storage):
+    model_storage_engine = project_storage.model_storage_engine()
+    trainer = ModelTrainer(
+        experiment_hash=None,
+        model_storage_engine=model_storage_engine,
+        db_engine=db_engine,
+        model_grouper=ModelGrouper(),
+    )
+    yield trainer
+
+
+def test_model_trainer(grid_config, default_model_trainer):
+    trainer = default_model_trainer
+    db_engine = trainer.db_engine
+    project_storage = trainer.model_storage_engine.project_storage
+    model_storage_engine = trainer.model_storage_engine
+
+    model_ids = trainer.train_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+
+    # assert
+    # 1. that the models and feature importances table entries are present
+    records = [
+        row
+        for row in db_engine.execute(
+            "select * from train_results.feature_importances"
         )
-        model_ids = trainer.train_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
+    ]
+    assert len(records) == 4 * 2  # maybe exclude entity_id? yes
+
+    records = [
+        row
+        for row in db_engine.execute("select model_hash from model_metadata.models")
+    ]
+    assert len(records) == 4
+    hashes = [row[0] for row in records]
+
+    # 2. that the model groups are distinct
+    records = [
+        row
+        for row in db_engine.execute(
+            "select distinct model_group_id from model_metadata.models"
         )
+    ]
+    assert len(records) == 4
 
-        # assert
-        # 1. that the models and feature importances table entries are present
-        records = [
-            row
-            for row in db_engine.execute(
-                "select * from train_results.feature_importances"
-            )
-        ]
-        assert len(records) == 4 * 2  # maybe exclude entity_id? yes
+    # 3. that the model sizes are saved in the table and all are < 1 kB
+    records = [
+        row
+        for row in db_engine.execute("select model_size from model_metadata.models")
+    ]
+    assert len(records) == 4
+    for i in records:
+        size = i[0]
+        assert size < 1
 
-        records = [
-            row
-            for row in db_engine.execute("select model_hash from model_metadata.models")
-        ]
-        assert len(records) == 4
-        hashes = [row[0] for row in records]
+    # 4. that all four models are cached
+    model_pickles = [model_storage_engine.load(model_hash) for model_hash in hashes]
+    assert len(model_pickles) == 4
+    assert len([x for x in model_pickles if x is not None]) == 4
 
-        # 2. that the model groups are distinct
-        records = [
-            row
-            for row in db_engine.execute(
-                "select distinct model_group_id from model_metadata.models"
-            )
-        ]
-        assert len(records) == 4
+    # 5. that their results can have predictions made on it
+    test_matrix = pandas.DataFrame.from_dict(
+        {"entity_id": [3, 4], "feature_one": [4, 4], "feature_two": [6, 5]}
+    ).set_index("entity_id")
 
-        # 3. that the model sizes are saved in the table and all are < 1 kB
-        records = [
-            row
-            for row in db_engine.execute("select model_size from model_metadata.models")
-        ]
-        assert len(records) == 4
-        for i in records:
-            size = i[0]
-            assert size < 1
+    for model_pickle in model_pickles:
+        predictions = model_pickle.predict(test_matrix)
+        assert len(predictions) == 2
 
-        # 4. that all four models are cached
-        model_pickles = [model_storage_engine.load(model_hash) for model_hash in hashes]
-        assert len(model_pickles) == 4
-        assert len([x for x in model_pickles if x is not None]) == 4
-
-        # 5. that their results can have predictions made on it
-        test_matrix = pandas.DataFrame.from_dict(
-            {"entity_id": [3, 4], "feature_one": [4, 4], "feature_two": [6, 5]}
-        ).set_index("entity_id")
-
-        for model_pickle in model_pickles:
-            predictions = model_pickle.predict(test_matrix)
-            assert len(predictions) == 2
-
-        # 6. when run again, same models are returned
-        new_model_ids = trainer.train_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
+    # 6. when run again, same models are returned
+    new_model_ids = trainer.train_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+    assert (
+        len(
+            [
+                row
+                for row in db_engine.execute(
+                    "select model_hash from model_metadata.models"
+                )
+            ]
         )
-        assert (
-            len(
-                [
-                    row
-                    for row in db_engine.execute(
-                        "select model_hash from model_metadata.models"
-                    )
-                ]
-            )
-            == 4
+        == 4
+    )
+    assert model_ids == new_model_ids
+
+    # 7. if replace is set, update non-unique attributes and feature importances
+    max_batch_run_time = [
+        row[0]
+        for row in db_engine.execute(
+            "select max(batch_run_time) from model_metadata.models"
         )
-        assert model_ids == new_model_ids
-
-        # 7. if replace is set, update non-unique attributes and feature importances
-        max_batch_run_time = [
-            row[0]
-            for row in db_engine.execute(
-                "select max(batch_run_time) from model_metadata.models"
-            )
-        ][0]
-        trainer = ModelTrainer(
-            experiment_hash=None,
-            model_storage_engine=model_storage_engine,
-            model_grouper=ModelGrouper(
-                model_group_keys=["label_name", "label_timespan"]
-            ),
-            db_engine=db_engine,
-            replace=True,
+    ][0]
+    trainer = ModelTrainer(
+        experiment_hash=None,
+        model_storage_engine=model_storage_engine,
+        model_grouper=ModelGrouper(
+            model_group_keys=["label_name", "label_timespan"]
+        ),
+        db_engine=db_engine,
+        replace=True,
+    )
+    new_model_ids = trainer.train_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+    assert model_ids == new_model_ids
+    assert [
+        row["model_id"]
+        for row in db_engine.execute(
+            "select model_id from model_metadata.models order by 1 asc"
         )
-        new_model_ids = trainer.train_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
+    ] == model_ids
+    new_max_batch_run_time = [
+        row[0]
+        for row in db_engine.execute(
+            "select max(batch_run_time) from model_metadata.models"
         )
-        assert model_ids == new_model_ids
-        assert [
-            row["model_id"]
-            for row in db_engine.execute(
-                "select model_id from model_metadata.models order by 1 asc"
-            )
-        ] == model_ids
-        new_max_batch_run_time = [
-            row[0]
-            for row in db_engine.execute(
-                "select max(batch_run_time) from model_metadata.models"
-            )
-        ][0]
-        assert new_max_batch_run_time > max_batch_run_time
+    ][0]
+    assert new_max_batch_run_time > max_batch_run_time
 
-        records = [
-            row
-            for row in db_engine.execute(
-                "select * from train_results.feature_importances"
-            )
-        ]
-        assert len(records) == 4 * 2  # maybe exclude entity_id? yes
-
-        # 8. if the cache is missing but the metadata is still there, reuse the metadata
-        for row in db_engine.execute("select model_hash from model_metadata.models"):
-            model_storage_engine.delete(row[0])
-        new_model_ids = trainer.train_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
+    records = [
+        row
+        for row in db_engine.execute(
+            "select * from train_results.feature_importances"
         )
-        assert model_ids == sorted(new_model_ids)
+    ]
+    assert len(records) == 4 * 2  # maybe exclude entity_id? yes
 
-        # 9. that the generator interface works the same way
-        new_model_ids = trainer.generate_trained_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
-        )
-        assert model_ids == sorted([model_id for model_id in new_model_ids])
+    # 8. if the cache is missing but the metadata is still there, reuse the metadata
+    for row in db_engine.execute("select model_hash from model_metadata.models"):
+        model_storage_engine.delete(row[0])
+    new_model_ids = trainer.train_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+    assert model_ids == sorted(new_model_ids)
+
+    # 9. that the generator interface works the same way
+    new_model_ids = trainer.generate_trained_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+    assert model_ids == sorted([model_id for model_id in new_model_ids])
 
 
-def test_baseline_exception_handling():
+def test_baseline_exception_handling(default_model_trainer):
     grid_config = {
         "triage.component.catwalk.baselines.rankers.PercentileRankOneFeature": {
             "feature": ["feature_one", "feature_three"]
         }
     }
-    with rig_engines() as (db_engine, project_storage):
-        trainer = ModelTrainer(
-            experiment_hash=None,
-            model_storage_engine=project_storage.model_storage_engine(),
-            db_engine=db_engine,
-            model_grouper=ModelGrouper(),
+    trainer = default_model_trainer
+    project_storage = trainer.model_storage_engine.project_storage
+
+    train_tasks = trainer.generate_train_tasks(
+        grid_config, dict(), get_matrix_store(project_storage)
+    )
+
+    model_ids = []
+    for train_task in train_tasks:
+        model_ids.append(trainer.process_train_task(**train_task))
+    assert model_ids == [1, None]
+
+
+def test_custom_groups(grid_config, db_engine, project_storage):
+    model_storage_engine = project_storage.model_storage_engine()
+    trainer = ModelTrainer(
+        experiment_hash=None,
+        model_storage_engine=model_storage_engine,
+        model_grouper=ModelGrouper(["class_path"]),
+        db_engine=db_engine,
+    )
+    # create training set
+    model_ids = trainer.train_models(
+        grid_config=grid_config,
+        misc_db_parameters=dict(),
+        matrix_store=get_matrix_store(project_storage),
+    )
+    # expect only one model group now
+    records = [
+        row[0]
+        for row in db_engine.execute(
+            "select distinct model_group_id from model_metadata.models"
         )
-
-        train_tasks = trainer.generate_train_tasks(
-            grid_config, dict(), get_matrix_store(project_storage)
-        )
-
-        model_ids = []
-        for train_task in train_tasks:
-            model_ids.append(trainer.process_train_task(**train_task))
-        assert model_ids == [1, None]
+    ]
+    assert len(records) == 1
+    assert records[0] == model_ids[0]
 
 
-def test_custom_groups(grid_config):
-    with rig_engines() as (db_engine, project_storage):
-        # create training set
-        model_storage_engine = project_storage.model_storage_engine()
-        trainer = ModelTrainer(
-            experiment_hash=None,
-            model_storage_engine=model_storage_engine,
-            model_grouper=ModelGrouper(["class_path"]),
-            db_engine=db_engine,
-        )
-        model_ids = trainer.train_models(
-            grid_config=grid_config,
-            misc_db_parameters=dict(),
-            matrix_store=get_matrix_store(project_storage),
-        )
-        # expect only one model group now
-        records = [
-            row[0]
-            for row in db_engine.execute(
-                "select distinct model_group_id from model_metadata.models"
-            )
-        ]
-        assert len(records) == 1
-        assert records[0] == model_ids[0]
-
-
-def test_n_jobs_not_new_model():
+def test_n_jobs_not_new_model(default_model_trainer):
     grid_config = {
         "sklearn.ensemble.AdaBoostClassifier": {"n_estimators": [10, 100, 1000]},
         "sklearn.ensemble.RandomForestClassifier": {
@@ -235,31 +237,33 @@ def test_n_jobs_not_new_model():
         },
     }
 
-    with rig_engines() as (db_engine, project_storage):
-        model_storage_engine = project_storage.model_storage_engine()
-        trainer = ModelTrainer(
-            experiment_hash=None,
-            model_storage_engine=model_storage_engine,
-            db_engine=db_engine,
-            model_grouper=ModelGrouper(),
-        )
+    trainer = default_model_trainer
+    project_storage = trainer.model_storage_engine.project_storage
+    db_engine = trainer.db_engine
 
-        train_tasks = trainer.generate_train_tasks(
-            grid_config, dict(), get_matrix_store(project_storage)
-        )
+    train_tasks = trainer.generate_train_tasks(
+        grid_config, dict(), get_matrix_store(project_storage)
+    )
 
-        assert len(train_tasks) == 35  # 32+3, would be (32*2)+3 if we didn't remove
-        assert (
-            len([task for task in train_tasks if "n_jobs" in task["parameters"]]) == 32
-        )
+    assert len(train_tasks) == 35  # 32+3, would be (32*2)+3 if we didn't remove
+    assert (
+        len([task for task in train_tasks if "n_jobs" in task["parameters"]]) == 32
+    )
 
-        for train_task in train_tasks:
-            trainer.process_train_task(**train_task)
+    for train_task in train_tasks:
+        trainer.process_train_task(**train_task)
 
-        for row in db_engine.execute(
-            "select hyperparameters from model_metadata.model_groups"
-        ):
-            assert "n_jobs" not in row[0]
+    for row in db_engine.execute(
+        "select hyperparameters from model_metadata.model_groups"
+    ):
+        assert "n_jobs" not in row[0]
+
+
+def test_cache_models(default_model_trainer):
+    assert not default_model_trainer.model_storage_engine.should_cache
+    with default_model_trainer.cache_models():
+        assert default_model_trainer.model_storage_engine.should_cache
+    assert not default_model_trainer.model_storage_engine.should_cache
 
 
 class RetryTest(unittest.TestCase):

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import unittest
 from collections import OrderedDict
 
 import pandas as pd
@@ -9,6 +8,7 @@ from moto import mock_s3
 import boto3
 from numpy.testing import assert_almost_equal
 from unittest import mock
+import pytest
 
 from triage.component.catwalk.storage import (
     CSVMatrixStore,
@@ -72,138 +72,151 @@ def test_ModelStorageEngine_caching(project_storage):
     assert 'myhash' not in mse.cache
 
 
-class MatrixStoreTest(unittest.TestCase):
-    data_dict = OrderedDict(
-        [
-            ("entity_id", [1, 2]),
-            ("k_feature", [0.5, 0.4]),
-            ("m_feature", [0.4, 0.5]),
-            ("label", [0, 1]),
-        ]
+DATA_DICT = OrderedDict(
+    [
+        ("entity_id", [1, 2]),
+        ("k_feature", [0.5, 0.4]),
+        ("m_feature", [0.4, 0.5]),
+        ("label", [0, 1]),
+    ]
+)
+
+METADATA = {"label_name": "label", "indices": ["entity_id"]}
+
+
+def matrix_stores():
+    df = pd.DataFrame.from_dict(DATA_DICT).set_index(["entity_id"])
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project_storage = ProjectStorage(tmpdir)
+        tmpcsv = os.path.join(tmpdir, "df.csv")
+        tmpyaml = os.path.join(tmpdir, "df.yaml")
+        tmphdf = os.path.join(tmpdir, "df.h5")
+        with open(tmpyaml, "w") as outfile:
+            yaml.dump(METADATA, outfile, default_flow_style=False)
+            df.to_csv(tmpcsv)
+            df.to_hdf(tmphdf, "matrix")
+            csv = CSVMatrixStore(project_storage, [], "df")
+            hdf = HDFMatrixStore(project_storage, [], "df")
+            assert csv.matrix.equals(hdf.matrix)
+            yield from [csv, hdf]
+
+
+def test_MatrixStore_empty():
+    for matrix_store in matrix_stores():
+        assert not matrix_store.empty
+
+
+def test_MatrixStore_metadata():
+    for matrix_store in matrix_stores():
+        assert matrix_store.metadata == METADATA
+
+
+def test_MatrixStore_head_of_matrix():
+    for matrix_store in matrix_stores():
+        assert matrix_store.head_of_matrix.to_dict() == {
+            "k_feature": {1: 0.5},
+            "m_feature": {1: 0.4},
+            "label": {1: 0},
+        }
+
+
+def test_MatrixStore_columns():
+    for matrix_store in matrix_stores():
+        assert matrix_store.columns() == ["k_feature", "m_feature"]
+
+
+def test_MatrixStore_resort_columns():
+    for matrix_store in matrix_stores():
+        result = matrix_store.matrix_with_sorted_columns(
+            ["m_feature", "k_feature"]
+        ).values.tolist()
+        expected = [[0.4, 0.5], [0.5, 0.4]]
+        assert_almost_equal(expected, result)
+
+
+def test_MatrixStore_already_sorted_columns():
+    for matrix_store in matrix_stores():
+        result = matrix_store.matrix_with_sorted_columns(
+            ["k_feature", "m_feature"]
+        ).values.tolist()
+        expected = [[0.5, 0.4], [0.4, 0.5]]
+        assert_almost_equal(expected, result)
+
+
+def test_MatrixStore_sorted_columns_subset():
+    with pytest.raises(ValueError):
+        for matrix_store in matrix_stores():
+            matrix_store.matrix_with_sorted_columns(["m_feature"]).values.tolist()
+
+
+def test_MatrixStore_sorted_columns_superset():
+    with pytest.raises(ValueError):
+        for matrix_store in matrix_stores():
+            matrix_store.matrix_with_sorted_columns(
+                ["k_feature", "l_feature", "m_feature"]
+            ).values.tolist()
+
+
+def test_MatrixStore_sorted_columns_mismatch():
+    with pytest.raises(ValueError):
+        for matrix_store in matrix_stores():
+            matrix_store.matrix_with_sorted_columns(
+                ["k_feature", "l_feature"]
+            ).values.tolist()
+
+
+def test_MatrixStore_save():
+    for matrix_store in matrix_stores():
+        original_dict = matrix_store.matrix.to_dict()
+        matrix_store.save()
+        # nuke the cache to force reload
+        matrix_store.matrix = None
+        assert matrix_store.matrix.to_dict() == original_dict
+
+
+def test_as_of_dates_entity_index(project_storage):
+    data = {
+        "entity_id": [1, 2],
+        "feature_one": [0.5, 0.6],
+        "feature_two": [0.5, 0.6],
+    }
+    matrix_store = CSVMatrixStore(project_storage, [], "test")
+    matrix_store.matrix = pd.DataFrame.from_dict(data)
+    matrix_store.metadata = {"end_time": "2016-01-01", "indices": ["entity_id"]}
+
+    assert matrix_store.as_of_dates == ["2016-01-01"]
+
+
+def test_as_of_dates_entity_date_index(project_storage):
+    data = {
+        "entity_id": [1, 2, 1, 2],
+        "feature_one": [0.5, 0.6, 0.5, 0.6],
+        "feature_two": [0.5, 0.6, 0.5, 0.6],
+        "as_of_date": ["2016-01-01", "2016-01-01", "2017-01-01", "2017-01-01"],
+    }
+    matrix_store = CSVMatrixStore(project_storage, [], "test")
+    matrix_store.matrix = pd.DataFrame.from_dict(data).set_index(
+        ["entity_id", "as_of_date"]
     )
+    matrix_store.metadata = {"indices": ["entity_id", "as_of_date"]}
 
-    metadata = {"label_name": "label", "indices": ["entity_id"]}
+    assert matrix_store.as_of_dates == ["2016-01-01", "2017-01-01"]
 
-    def matrix_stores(self):
-        df = pd.DataFrame.from_dict(self.data_dict).set_index(["entity_id"])
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            project_storage = ProjectStorage(tmpdir)
-            tmpcsv = os.path.join(tmpdir, "df.csv")
-            tmpyaml = os.path.join(tmpdir, "df.yaml")
-            tmphdf = os.path.join(tmpdir, "df.h5")
-            with open(tmpyaml, "w") as outfile:
-                yaml.dump(self.metadata, outfile, default_flow_style=False)
-                df.to_csv(tmpcsv)
-                df.to_hdf(tmphdf, "matrix")
-                csv = CSVMatrixStore(project_storage, [], "df")
-                hdf = HDFMatrixStore(project_storage, [], "df")
-                assert csv.matrix.equals(hdf.matrix)
-                yield from [csv, hdf]
+def test_s3_save():
+    with mock_s3():
 
-    def test_MatrixStore_empty(self):
-        for matrix_store in self.matrix_stores():
-            assert not matrix_store.empty
+        client = boto3.client("s3")
+        client.create_bucket(Bucket="fake-matrix-bucket", ACL="public-read-write")
+        example = next(matrix_stores())
+        project_storage = ProjectStorage("s3://fake-matrix-bucket")
 
-    def test_MatrixStore_metadata(self):
-        for matrix_store in self.matrix_stores():
-            assert matrix_store.metadata == self.metadata
+        tosave = CSVMatrixStore(project_storage, [], "test")
+        tosave.matrix = example.matrix
+        tosave.metadata = example.metadata
+        tosave.save()
 
-    def test_MatrixStore_head_of_matrix(self):
-        for matrix_store in self.matrix_stores():
-            assert matrix_store.head_of_matrix.to_dict() == {
-                "k_feature": {1: 0.5},
-                "m_feature": {1: 0.4},
-                "label": {1: 0},
-            }
-
-    def test_MatrixStore_columns(self):
-        for matrix_store in self.matrix_stores():
-            assert matrix_store.columns() == ["k_feature", "m_feature"]
-
-    def test_MatrixStore_resort_columns(self):
-        for matrix_store in self.matrix_stores():
-            result = matrix_store.matrix_with_sorted_columns(
-                ["m_feature", "k_feature"]
-            ).values.tolist()
-            expected = [[0.4, 0.5], [0.5, 0.4]]
-            assert_almost_equal(expected, result)
-
-    def test_MatrixStore_already_sorted_columns(self):
-        for matrix_store in self.matrix_stores():
-            result = matrix_store.matrix_with_sorted_columns(
-                ["k_feature", "m_feature"]
-            ).values.tolist()
-            expected = [[0.5, 0.4], [0.4, 0.5]]
-            assert_almost_equal(expected, result)
-
-    def test_MatrixStore_sorted_columns_subset(self):
-        with self.assertRaises(ValueError):
-            for matrix_store in self.matrix_stores():
-                matrix_store.matrix_with_sorted_columns(["m_feature"]).values.tolist()
-
-    def test_MatrixStore_sorted_columns_superset(self):
-        with self.assertRaises(ValueError):
-            for matrix_store in self.matrix_stores():
-                matrix_store.matrix_with_sorted_columns(
-                    ["k_feature", "l_feature", "m_feature"]
-                ).values.tolist()
-
-    def test_MatrixStore_sorted_columns_mismatch(self):
-        with self.assertRaises(ValueError):
-            for matrix_store in self.matrix_stores():
-                matrix_store.matrix_with_sorted_columns(
-                    ["k_feature", "l_feature"]
-                ).values.tolist()
-
-    def test_MatrixStore_save(self):
-        for matrix_store in self.matrix_stores():
-            original_dict = matrix_store.matrix.to_dict()
-            matrix_store.save()
-            # nuke the cache to force reload
-            matrix_store.matrix = None
-            assert matrix_store.matrix.to_dict() == original_dict
-
-    def test_as_of_dates_entity_index(self, project_storage):
-        data = {
-            "entity_id": [1, 2],
-            "feature_one": [0.5, 0.6],
-            "feature_two": [0.5, 0.6],
-        }
-        matrix_store = CSVMatrixStore(project_storage, [], "test")
-        matrix_store.matrix = pd.DataFrame.from_dict(data)
-        matrix_store.metadata = {"end_time": "2016-01-01", "indices": ["entity_id"]}
-
-        self.assertEqual(matrix_store.as_of_dates, ["2016-01-01"])
-
-    def test_as_of_dates_entity_date_index(self, project_storage):
-        data = {
-            "entity_id": [1, 2, 1, 2],
-            "feature_one": [0.5, 0.6, 0.5, 0.6],
-            "feature_two": [0.5, 0.6, 0.5, 0.6],
-            "as_of_date": ["2016-01-01", "2016-01-01", "2017-01-01", "2017-01-01"],
-        }
-        matrix_store = CSVMatrixStore(project_storage, [], "test")
-        matrix_store.matrix = pd.DataFrame.from_dict(data).set_index(
-            ["entity_id", "as_of_date"]
-        )
-        matrix_store.metadata = {"indices": ["entity_id", "as_of_date"]}
-
-        self.assertEqual(matrix_store.as_of_dates, ["2016-01-01", "2017-01-01"])
-
-    def test_s3_save(self):
-        with mock_s3():
-
-            client = boto3.client("s3")
-            client.create_bucket(Bucket="fake-matrix-bucket", ACL="public-read-write")
-            example = next(self.matrix_stores())
-            project_storage = ProjectStorage("s3://fake-matrix-bucket")
-
-            tosave = CSVMatrixStore(project_storage, [], "test")
-            tosave.matrix = example.matrix
-            tosave.metadata = example.metadata
-            tosave.save()
-
-            tocheck = CSVMatrixStore(project_storage, [], "test")
-            assert tocheck.metadata == example.metadata
-            assert tocheck.matrix.to_dict() == example.matrix.to_dict()
+        tocheck = CSVMatrixStore(project_storage, [], "test")
+        assert tocheck.metadata == example.metadata
+        assert tocheck.matrix.to_dict() == example.matrix.to_dict()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,6 +1,10 @@
 import pytest
 import testing.postgresql
+import tempfile
 from sqlalchemy import create_engine
+from triage.component.catwalk.storage import ProjectStorage
+from triage.component.catwalk.db import ensure_db
+from tests.results_tests.factories import init_engine
 
 
 @pytest.fixture(name='db_engine', scope='function')
@@ -12,5 +16,18 @@ def fixture_db_engine():
     """
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
+        ensure_db(engine)
+        init_engine(engine)
         yield engine
         engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def project_storage():
+    """Set up a temporary project storage engine
+
+    Yields (catwalk.storage.ProjectStorage)
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_storage = ProjectStorage(temp_dir)
+        yield project_storage

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -16,10 +16,15 @@ def fixture_db_engine():
     """
     with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
-        ensure_db(engine)
-        init_engine(engine)
         yield engine
         engine.dispose()
+
+
+@pytest.fixture(scope="function")
+def db_engine_with_results_schema(db_engine):
+    ensure_db(db_engine)
+    init_engine(db_engine)
+    yield db_engine
 
 
 @pytest.fixture(scope="function")

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -24,7 +24,7 @@ def fixture_db_engine():
 
 @pytest.fixture(scope="function")
 def project_storage():
-    """Set up a temporary project storage engine
+    """Set up a temporary project storage engine on the filesystem
 
     Yields (catwalk.storage.ProjectStorage)
     """

--- a/src/triage/component/catwalk/__init__.py
+++ b/src/triage/component/catwalk/__init__.py
@@ -2,5 +2,141 @@
 from .model_trainers import ModelTrainer
 from .predictors import Predictor
 from .evaluation import ModelEvaluator
+from .individual_importance import IndividualImportanceCalculator
+from .model_grouping import ModelGrouper
 
-__all__ = ("ModelTrainer", "Predictor", "ModelEvaluator")
+import logging
+
+
+class ModelTrainTester(object):
+    def __init__(
+        self,
+        matrix_storage_engine,
+        model_trainer,
+        model_evaluator,
+        individual_importance_calculator,
+        predictor
+    ):
+        self.matrix_storage_engine = matrix_storage_engine
+        self.model_trainer = model_trainer
+        self.model_evaluator = model_evaluator
+        self.individual_importance_calculator = individual_importance_calculator
+        self.predictor = predictor
+
+    def generate_tasks(self, split, grid_config, model_comment=None):
+        logging.info("Generating train/test tasks for split %s", split["train_uuid"])
+        train_store = self.matrix_storage_engine.get_store(split["train_uuid"])
+        if train_store.empty:
+            logging.warning(
+                """Train matrix for split %s was empty,
+            no point in training this model. Skipping
+            """,
+                split["train_uuid"],
+            )
+            return []
+        if len(train_store.labels().unique()) == 1:
+            logging.warning(
+                """Train Matrix for split %s had only one
+            unique value, no point in training this model. Skipping
+            """,
+                split["train_uuid"],
+            )
+            return []
+        train_tasks = self.model_trainer.generate_train_tasks(
+            grid_config=grid_config,
+            misc_db_parameters=dict(test=False, model_comment=model_comment),
+            matrix_store=train_store
+        )
+
+        train_test_tasks = []
+        for test_matrix_def, test_uuid in zip(
+            split["test_matrices"], split["test_uuids"]
+        ):
+            test_store = self.matrix_storage_engine.get_store(test_uuid)
+
+            if test_store.empty:
+                logging.warning(
+                    """Test matrix for uuid %s
+                was empty, no point in generating predictions. Not creating train/test task.
+                """,
+                    test_uuid,
+                )
+                continue
+            for train_task in train_tasks:
+                train_test_tasks.append(
+                    {
+                        "test_store": test_store,
+                        "train_store": train_store,
+                        "train_kwargs": train_task,
+                    }
+                )
+        return train_test_tasks
+
+    def process_all_tasks(self, tasks):
+        for task in tasks:
+            self.process_task(**task)
+
+    def process_task(self, test_store, train_store, train_kwargs):
+        logging.info("Beginning train task %s", train_kwargs)
+        model_id = self.model_trainer.process_train_task(**train_kwargs)
+        if not model_id:
+            logging.warning("No model id returned from ModelTrainer.process_train_task, "
+                            "training unsuccessful. Not attempting to test")
+            return
+        logging.info("Trained task %s and got model id %s", train_kwargs, model_id)
+        as_of_times = test_store.metadata["as_of_times"]
+        logging.info(
+            "Testing and scoring model id %s with test matrix %s. "
+            "as_of_times min: %s max: %s num: %s",
+            model_id,
+            test_store.uuid,
+            min(as_of_times),
+            max(as_of_times),
+            len(as_of_times),
+        )
+
+        self.individual_importance_calculator.calculate_and_save_all_methods_and_dates(
+            model_id, test_store
+        )
+
+        # Generate predictions for the testing data then training data
+        for store in (test_store, train_store):
+            if self.predictor.replace or self.model_evaluator.needs_evaluations(store, model_id):
+                logging.info(
+                    "The evaluations needed for matrix %s-%s and model %s"
+                    "are not all present in db, so predicting and evaluating",
+                    store.uuid,
+                    store.matrix_type,
+                    model_id
+                )
+                predictions_proba = self.predictor.predict(
+                    model_id,
+                    store,
+                    misc_db_parameters=dict(),
+                    train_matrix_columns=train_store.columns(),
+                )
+
+                self.model_evaluator.evaluate(
+                    predictions_proba=predictions_proba,
+                    matrix_store=store,
+                    model_id=model_id,
+                )
+            else:
+                logging.info(
+                    "The evaluations needed for matrix %s-%s and model %s are all present"
+                    "in db from a previous run (or none needed at all), so skipping!",
+                    store.uuid,
+                    store.matrix_type,
+                    model_id
+                )
+        self.model_trainer.uncache_model(model_id)
+
+
+__all__ = (
+    "IndividualImportanceCalculator",
+    "ModelEvaluator",
+    "ModelGrouper"
+    "ModelTrainer",
+    "Predictor",
+    "ModelTrainTester"
+)

--- a/src/triage/component/catwalk/individual_importance/__init__.py
+++ b/src/triage/component/catwalk/individual_importance/__init__.py
@@ -151,4 +151,5 @@ class IndividualImportanceCalculator(object):
                 importance_score=float(importance_record["score"]),
             )
             db_objects.append(db_object)
+        print(len(db_objects))
         save_db_objects(self.db_engine, db_objects)

--- a/src/triage/component/catwalk/individual_importance/__init__.py
+++ b/src/triage/component/catwalk/individual_importance/__init__.py
@@ -151,5 +151,4 @@ class IndividualImportanceCalculator(object):
                 importance_score=float(importance_record["score"]),
             )
             db_objects.append(db_object)
-        print(len(db_objects))
         save_db_objects(self.db_engine, db_objects)

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -17,6 +17,7 @@ from .feature_importances import get_feature_importances
 from .utils import (
     filename_friendly_hash,
     retrieve_model_id_from_hash,
+    retrieve_model_hash_from_id,
     db_retry,
     save_db_objects,
 )
@@ -420,3 +421,6 @@ class ModelTrainer(object):
             )
         logging.info("Found %s unique model training tasks", len(tasks))
         return tasks
+
+    def uncache_model(self, model_id):
+        self.model_storage_engine.uncache(retrieve_model_hash_from_id(self.db_engine, model_id))

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -280,6 +280,11 @@ class ModelTrainer(object):
 
     @contextmanager
     def cache_models(self):
+        """Caches each trained model in memory as it is written to storage.
+
+        Must be used as a context manager.
+        The cache is cleared when the context manager goes out of scope
+        """
         with self.model_storage_engine.cache_models():
             yield
 

--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -3,6 +3,7 @@ import datetime
 import importlib
 import logging
 import sys
+from contextlib import contextmanager
 
 import numpy as np
 import pandas
@@ -17,7 +18,6 @@ from .feature_importances import get_feature_importances
 from .utils import (
     filename_friendly_hash,
     retrieve_model_id_from_hash,
-    retrieve_model_hash_from_id,
     db_retry,
     save_db_objects,
 )
@@ -278,6 +278,11 @@ class ModelTrainer(object):
         logging.info("Wrote model to db: hash %s, got id %s", model_hash, model_id)
         return model_id
 
+    @contextmanager
+    def cache_models(self):
+        with self.model_storage_engine.cache_models():
+            yield
+
     def generate_trained_models(self, grid_config, misc_db_parameters, matrix_store):
         """Train and store configured models, yielding the ids one by one
 
@@ -421,6 +426,3 @@ class ModelTrainer(object):
             )
         logging.info("Found %s unique model training tasks", len(tasks))
         return tasks
-
-    def uncache_model(self, model_id):
-        self.model_storage_engine.uncache(retrieve_model_hash_from_id(self.db_engine, model_id))

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -218,6 +218,11 @@ class ModelStorageEngine(object):
 
     @contextmanager
     def cache_models(self):
+        """Caches each model in memory as it is written.
+
+        Must be used as a context manager.
+        The cache is cleared when the context manager goes out of scope
+        """
         self.should_cache = True
         try:
             yield

--- a/src/triage/component/catwalk/utils.py
+++ b/src/triage/component/catwalk/utils.py
@@ -171,6 +171,22 @@ def retrieve_model_id_from_hash(db_engine, model_hash):
 
 
 @db_retry
+def retrieve_model_hash_from_id(db_engine, model_id):
+    """Retrieves the model hash associated with a given model id
+
+    Args:
+        model_id (int) The id of a given model in the database
+
+    Returns: (str) the stored hash of the model
+    """
+    session = sessionmaker(bind=db_engine)()
+    try:
+        return session.query(Model).get(model_id).model_hash
+    finally:
+        session.close()
+
+
+@db_retry
 def save_db_objects(db_engine, db_objects):
     """Saves a collection of SQLAlchemy model objects to the database using a COPY command
 

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -27,9 +27,14 @@ from triage.component.architect.cohort_table_generators import (
 )
 from triage.component.timechop import Timechop
 from triage.component.results_schema import upgrade_db
-from triage.component.catwalk.model_grouping import ModelGrouper
-from triage.component.catwalk.model_trainers import ModelTrainer
-from triage.component.catwalk.model_testers import ModelTester
+from triage.component.catwalk import (
+    ModelTrainer,
+    ModelEvaluator,
+    Predictor,
+    IndividualImportanceCalculator,
+    ModelGrouper,
+    ModelTrainTester
+)
 from triage.component.catwalk.utils import (
     save_experiment_and_get_hash,
     associate_models_with_experiment,
@@ -231,14 +236,33 @@ class ExperimentBase(ABC):
             replace=self.replace,
         )
 
-        self.tester = ModelTester(
-            model_storage_engine=self.model_storage_engine,
-            matrix_storage_engine=self.matrix_storage_engine,
-            replace=self.replace,
+        self.predictor = Predictor(
             db_engine=self.db_engine,
-            individual_importance_config=self.config.get("individual_importance", {}),
-            evaluator_config=self.config.get("scoring", {}),
+            model_storage_engine=self.model_storage_engine,
             save_predictions=self.save_predictions,
+            replace=self.replace,
+        )
+
+        self.individual_importance_calculator = IndividualImportanceCalculator(
+            db_engine=self.db_engine,
+            n_ranks=self.config.get("individual_importance", {}).get("n_ranks", 5),
+            methods=self.config.get("individual_importance", {}).get("methods", ["uniform"]),
+            replace=self.replace,
+        )
+
+        self.evaluator = ModelEvaluator(
+            db_engine=self.db_engine,
+            sort_seed=self.config.get("scoring", {}).get("sort_seed", None),
+            testing_metric_groups=self.config.get("scoring", {}).get("testing_metric_groups", []),
+            training_metric_groups=self.config.get("scoring", {}).get("training_metric_groups", []),
+        )
+
+        self.model_train_tester = ModelTrainTester(
+            matrix_storage_engine=self.matrix_storage_engine,
+            model_evaluator=self.evaluator,
+            model_trainer=self.trainer,
+            individual_importance_calculator=self.individual_importance_calculator,
+            predictor=self.predictor
         )
 
     @cachedproperty
@@ -494,7 +518,7 @@ class ExperimentBase(ABC):
         )
 
     @abstractmethod
-    def process_train_tasks(self, train_tasks):
+    def process_train_test_tasks(self, train_tasks):
         pass
 
     @abstractmethod
@@ -541,67 +565,44 @@ class ExperimentBase(ABC):
         logging.info("Building all matrices")
         self.build_matrices()
 
-    def train_and_test_models(self):
+    def _all_train_test_tasks(self):
         if "grid_config" not in self.config:
             logging.warning(
                 "No grid_config was passed in the experiment config. No models will be trained"
             )
             return
 
+        train_test_tasks = []
         for split_num, split in enumerate(self.full_matrix_definitions):
             self.log_split(split_num, split)
-            train_store = self.matrix_storage_engine.get_store(split["train_uuid"])
-            if train_store.empty:
-                logging.warning(
-                    """Train matrix for split %s was empty,
-                no point in training this model. Skipping
-                """,
-                    split["train_uuid"],
-                )
-                continue
-            if len(train_store.labels().unique()) == 1:
-                logging.warning(
-                    """Train Matrix for split %s had only one
-                unique value, no point in training this model. Skipping
-                """,
-                    split["train_uuid"],
-                )
-                continue
+            for task in self.model_train_tester.generate_tasks(
+                split=split,
+                grid_config=self.config.get('grid_config'),
+                model_comment=self.config.get('model_comment', None)
+            ):
+                train_test_tasks.append(task)
+        return train_test_tasks
 
-            logging.info("Training models")
+    def train_and_test_models(self):
+        tasks = self._all_train_test_tasks()
+        if not tasks:
+            logging.warning("No train/test tasks found, so no training to do")
+            return
 
-            train_tasks = self.trainer.generate_train_tasks(
-                grid_config=self.config["grid_config"],
-                misc_db_parameters=dict(
-                    test=False, model_comment=self.config.get("model_comment", None)
-                ),
-                matrix_store=train_store,
-            )
-
-            associate_models_with_experiment(
-                self.experiment_hash,
-                [train_task['model_hash'] for train_task in train_tasks],
-                self.db_engine
-            )
-            model_ids = self.process_train_tasks(train_tasks)
-
-            logging.info("Done training models for split %s", split_num)
-
-            test_tasks = self.tester.generate_model_test_tasks(
-                split=split, train_store=train_store, model_ids=model_ids
-            )
-            logging.info(
-                "Found %s non-empty test matrices for split %s",
-                len(test_tasks),
-                split_num,
-            )
-
-            self.process_model_test_tasks(test_tasks)
+        logging.info("%s train/test tasks found. Beginning training.", len(tasks))
+        associate_models_with_experiment(
+            self.experiment_hash,
+            set(task['train_kwargs']['model_hash'] for task in tasks),
+            self.db_engine
+        )
+        self.process_train_test_tasks(tasks)
 
     def validate(self, strict=True):
         ExperimentValidator(self.db_engine, strict=strict).run(self.config)
 
     def _run(self):
+        cp = cProfile.Profile()
+        cp.enable()
         try:
             logging.info("Generating matrices")
             self.generate_matrices()
@@ -611,6 +612,12 @@ class ExperimentBase(ABC):
 
         self.train_and_test_models()
         logging.info("Experiment complete")
+        cp.disable()
+        store = self.project_storage.get_store(
+            ["profiling_stats"],
+            f"{int(time.time())}.profile"
+        )
+        cp.dump_stats(store.path)
         self._log_end_of_run_report()
 
     def _log_end_of_run_report(self):

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -601,8 +601,6 @@ class ExperimentBase(ABC):
         ExperimentValidator(self.db_engine, strict=strict).run(self.config)
 
     def _run(self):
-        cp = cProfile.Profile()
-        cp.enable()
         try:
             logging.info("Generating matrices")
             self.generate_matrices()
@@ -612,12 +610,6 @@ class ExperimentBase(ABC):
 
         self.train_and_test_models()
         logging.info("Experiment complete")
-        cp.disable()
-        store = self.project_storage.get_store(
-            ["profiling_stats"],
-            f"{int(time.time())}.profile"
-        )
-        cp.dump_stats(store.path)
         self._log_end_of_run_report()
 
     def _log_end_of_run_report(self):

--- a/src/triage/experiments/multicore.py
+++ b/src/triage/experiments/multicore.py
@@ -51,29 +51,13 @@ class MultiCoreExperiment(ExperimentBase):
                 except Exception:
                     logging.exception('Child failure')
 
-    def process_train_tasks(self, train_tasks):
-        partial_train_models = partial(
-            run_task_with_splatted_arguments, self.trainer.process_train_task
-        )
-        logging.info(
-            "Starting parallel training: %s tasks, %s processes",
-            len(train_tasks),
-            self.n_processes,
-        )
-        model_ids = []
-        for model_id in parallelize(
-            partial_train_models, train_tasks, self.n_processes
-        ):
-            model_ids.append(model_id)
-        return model_ids
-
-    def process_model_test_tasks(self, test_tasks):
+    def process_train_test_tasks(self, tasks):
         partial_test = partial(
-            run_task_with_splatted_arguments, self.tester.process_model_test_task
+            run_task_with_splatted_arguments, self.model_train_tester.process_task
         )
 
-        logging.info("Starting parallel testing with %s processes", self.n_db_processes)
-        parallelize(partial_test, test_tasks, self.n_db_processes)
+        logging.info("Starting parallel testing with %s processes", self.n_processes)
+        parallelize(partial_test, tasks, self.n_processes)
         logging.info("Cleaned up concurrent pool")
 
     def process_query_tasks(self, query_tasks):

--- a/src/triage/experiments/rq.py
+++ b/src/triage/experiments/rq.py
@@ -142,7 +142,7 @@ class RQExperiment(ExperimentBase):
         ]
         return self.wait_for(jobs)
 
-    def process_train_tasks(self, train_tasks):
+    def process_train_test_tasks(self, train_test_tasks):
         """Run train tasks using RQ
 
         Args:
@@ -152,32 +152,12 @@ class RQExperiment(ExperimentBase):
         """
         jobs = [
             self.queue.enqueue(
-                self.trainer.process_train_task,
+                self.model_train_tester.process_task,
                 timeout=DEFAULT_TIMEOUT,
                 result_ttl=DEFAULT_TIMEOUT,
                 ttl=DEFAULT_TIMEOUT,
-                **train_task
+                **task
             )
-            for train_task in train_tasks
-        ]
-        return self.wait_for(jobs)
-
-    def process_model_test_tasks(self, test_tasks):
-        """Run test tasks using RQ
-
-        Args:
-            test_tasks (list) of dictionaries, each representing kwargs suitable
-                for self.tester.process_model_test_task
-        Returns: (list) of job results for each given task
-        """
-        jobs = [
-            self.queue.enqueue(
-                self.tester.process_model_test_task,
-                timeout=DEFAULT_TIMEOUT,
-                result_ttl=DEFAULT_TIMEOUT,
-                ttl=DEFAULT_TIMEOUT,
-                **test_task
-            )
-            for test_task in test_tasks
+            for task in train_test_tasks
         ]
         return self.wait_for(jobs)

--- a/src/triage/experiments/singlethreaded.py
+++ b/src/triage/experiments/singlethreaded.py
@@ -8,12 +8,5 @@ class SingleThreadedExperiment(ExperimentBase):
     def process_matrix_build_tasks(self, matrix_build_tasks):
         self.matrix_builder.build_all_matrices(matrix_build_tasks)
 
-    def process_train_tasks(self, train_tasks):
-        return [
-            self.trainer.process_train_task(**train_task) for train_task in train_tasks
-        ]
-
-    def process_model_test_tasks(self, test_tasks):
-        return [
-            self.tester.process_model_test_task(**test_task) for test_task in test_tasks
-        ]
+    def process_train_test_tasks(self, tasks):
+        self.model_train_tester.process_all_tasks(tasks)


### PR DESCRIPTION
Converts the 'train task' into 'train/test task', so instead of training
a split all at once and then testing it all at once, each model is
trained and then immediately tested. Additionally, the tasks are
flattened instead of grouped by split.

A cache is added to the ModelStorageEngine so that the predictor can load the memory model if it's there. The ModelTrainTester manually uncaches the model once it's done testing. I think this should work but is worth some memory testing to make sure there's no terrible memory leaks. I didn't get time to test this part out before vacation so we should make sure to test that before merging.