### PR TITLE
Fix upgrade_db to use filehandle [Resolves #572]

### DIFF
--- a/src/triage/component/results_schema/README.md
+++ b/src/triage/component/results_schema/README.md
@@ -10,12 +10,13 @@ Store results of modeling runs in a relational database
 2. You can do the initial schema and table creation a couple of different ways, with a couple of different options for passing database credentials.
 
 	- *Triage cli script*. Assuming you have triage installed from pip: `triage -d dbcredentials.yaml db upgrade`, or just `triage db upgrade` if you have a database credentials file at `database.yaml` (the default)
-	- *From Python code*. If you are in a Python console or notebook, you can call `upgrade_db` with either sqlalchemy engine pointing to your database, or a filename similar to what's used to launch the cli script.
+	- *From Python code*. If you are in a Python console or notebook, you can call `upgrade_db` with either sqlalchemy engine pointing to your database, or a filehandle to a credentials file.
 
 	```
 	>>> from triage.component.results_schema import upgrade_db
-	>>> upgrade_db(engine)
-	>>> upgrade_db('database.yaml')
+	>>> upgrade_db(db_engine=engine)
+	>>> with open ('database.yaml') as fh:
+            upgrade_db(db_config_filehandle=fh)
 	```
 
 This command will create a 'results' schema and the necessary tables.

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -55,13 +55,13 @@ def _base_alembic_args(db_config_filename=None):
     return base
 
 
-def upgrade_db(db_config_filename=None, db_engine=None):
-    if db_config_filename:
-        command.upgrade(alembic_config(db_config_filename=db_config_filename), "head")
+def upgrade_db(db_config_filehandle=None, db_engine=None):
+    if db_config_filehandle:
+        command.upgrade(alembic_config(db_config_filehandle=db_config_filehandle), "head")
     elif db_engine:
         command.upgrade(alembic_config(dburl=db_engine.url), "head")
     else:
-        raise ValueError("Must pass either a db_config_filename or a db_engine")
+        raise ValueError("Must pass either a db_config_filehandle or a db_engine")
 
 
 REVISION_MAPPING = {
@@ -74,22 +74,21 @@ REVISION_MAPPING = {
 }
 
 
-def stamp_db(revision, db_config_filename):
-    command.stamp(alembic_config(db_config_filename=db_config_filename), revision)
+def stamp_db(revision, db_config_filehandle):
+    command.stamp(alembic_config(db_config_filehandle=db_config_filehandle), revision)
 
 
-def alembic_config(db_config_filename=None, dburl=None):
-    if db_config_filename:
-        with open(db_config_filename) as f:
-            config = yaml.load(f)
-            dburl = URL(
-                "postgres",
-                host=config["host"],
-                username=config["user"],
-                database=config["db"],
-                password=config["pass"],
-                port=config["port"],
-            )
+def alembic_config(db_config_filehandle=None, dburl=None):
+    if db_config_filehandle:
+        config = yaml.load(db_config_filehandle)
+        dburl = URL(
+            "postgres",
+            host=config["host"],
+            username=config["user"],
+            database=config["db"],
+            password=config["pass"],
+            port=config["port"],
+        )
     path = os.path.abspath(__file__)
     dir_path = os.path.dirname(path)
     alembic_ini_path = os.path.join(dir_path, "alembic.ini")


### PR DESCRIPTION
- Modify upgrade_db and stamp_db filename option to be filehandle option to match
what the CLI passes in
- Update README examples