### PR TITLE
Add feature_importance metric to SLR [solves #509]

### DIFF
--- a/src/triage/component/catwalk/feature_importances.py
+++ b/src/triage/component/catwalk/feature_importances.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 import sklearn.linear_model
 from sklearn.svm import SVC
+from triage.component.catwalk.estimators.classifiers import ScaledLogisticRegression
 
 
 def _ad_hoc_feature_importances(model):
@@ -22,7 +23,8 @@ def _ad_hoc_feature_importances(model):
     """
     feature_importances = None
 
-    if isinstance(model, (sklearn.linear_model.logistic.LogisticRegression)):
+    if (isinstance(model, (sklearn.linear_model.logistic.LogisticRegression)) or 
+        isinstance(model, (ScaledLogisticRegression))):
         coef_odds_ratio = np.exp(model.coef_)
         # intercept_odds_ratio = np.exp(model.intercept_[:,np.newaxis])
         # We are ignoring the intercept


### PR DESCRIPTION
This commit adds a small change into the catwalk component to calculate feature importances when the model object is a `catwalk.estimators.ScaledLogisticRegression`. Now, instead of not
calculating anything, triage will be able to push  to the `feature_importances` db table the importances using the marginal change of the coefficients (using the exponential function). This solves the old #509. 