### PR TITLE
Fix empty/columns check on HDFStore [Resolves #589]

### DIFF
--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -112,15 +112,6 @@ def test_MatrixStore_metadata():
         assert matrix_store.metadata == METADATA
 
 
-def test_MatrixStore_head_of_matrix():
-    for matrix_store in matrix_stores():
-        assert matrix_store.head_of_matrix.to_dict() == {
-            "k_feature": {1: 0.5},
-            "m_feature": {1: 0.4},
-            "label": {1: 0},
-        }
-
-
 def test_MatrixStore_columns():
     for matrix_store in matrix_stores():
         assert matrix_store.columns() == ["k_feature", "m_feature"]


### PR DESCRIPTION
Pandas' read_hdf does not implement a method for only loading the first
n rows that works reliably on different datasets, particularly with multi-indices.
This is problematic because head_of_matrix is how the MatrixStore
implements empty() and columns() methods.

Instead of implementing head_of_matrix, we implement
empty() and columns() on HDFStore directly, obviating the need for a
head_of_matrix method that only reads the first row.