### PR TITLE
Use compressed CSVs [Resolves #498]

### DIFF
--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -90,12 +90,12 @@ def matrix_stores():
 
     with tempfile.TemporaryDirectory() as tmpdir:
         project_storage = ProjectStorage(tmpdir)
-        tmpcsv = os.path.join(tmpdir, "df.csv")
+        tmpcsv = os.path.join(tmpdir, "df.csv.gz")
         tmpyaml = os.path.join(tmpdir, "df.yaml")
         tmphdf = os.path.join(tmpdir, "df.h5")
         with open(tmpyaml, "w") as outfile:
             yaml.dump(METADATA, outfile, default_flow_style=False)
-        df.to_csv(tmpcsv)
+        df.to_csv(tmpcsv, compression="gzip")
         df.to_hdf(tmphdf, "matrix")
         csv = CSVMatrixStore(project_storage, [], "df")
         hdf = HDFMatrixStore(project_storage, [], "df")

--- a/src/tests/test_partial_experiments.py
+++ b/src/tests/test_partial_experiments.py
@@ -181,7 +181,7 @@ class Matrices(TestCase):
             matrices = experiment.matrix_build_tasks
             assert len(matrices) > 0
             for matrix in matrices:
-                assert "{}.csv".format(matrix) in matrices_and_metadata
+                assert "{}.csv.gz".format(matrix) in matrices_and_metadata
                 assert "{}.yaml".format(matrix) in matrices_and_metadata
 
     def test_validate_nonstrict(self):


### PR DESCRIPTION
- Make the CSVMatrixStore use compression and rename files to csv.gz