### PR TITLE
Faster train/test task generation

### DIFF
--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -398,11 +398,7 @@ class MatrixStore(object):
         """The raw metadata. Will load from storage into memory if not already loaded"""
         if self.__metadata is not None:
             return self.__metadata
-        metadata = self.load_metadata()
-        if self.should_cache:
-            self.__metadata = metadata
-        else:
-            return metadata
+        self.__metadata = self.load_metadata()
         return self.__metadata
 
     @metadata.setter
@@ -540,7 +536,6 @@ class MatrixStore(object):
 
     def clear_cache(self):
         self._matrix_label_tuple = None
-        self.metadata = None
 
     def __getstate__(self):
         """Remove object of a large size upon serialization.
@@ -549,7 +544,6 @@ class MatrixStore(object):
         """
         state = self.__dict__.copy()
         state['_matrix_label_tuple'] = None
-        state['__metadata'] = None
         return state
 
 


### PR DESCRIPTION
Generating train/test tasks can take hours. One culprit may be slow IO
of the matrices, which are loaded to decide if the job should be
processed. This commit makes the train-tester generate all of the tasks
withoug checking the matrices and skips processing the tasks if the
matrices are no good.