### PR TITLE
Validate distinct feature group prefixes

### DIFF
--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -1,5 +1,6 @@
 import importlib
 import logging
+from itertools import permutations
 from datetime import datetime
 from textwrap import dedent
 

--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -344,23 +344,6 @@ class FeatureAggregationsValidator(Validator):
                     impute_rule = imp_dict.get(metric, imp_dict.get("all", {}))
                     self._validate_imputation_rule(agg_type, impute_rule)
 
-    def _validate_prefixes(self, feature_aggregation_config):
-        """
-        Ensure that no prefix starts with another prefix + _ to avoid
-        an error with feature group subsets when the group names overlap
-        """
-        all_prefixes = [f['prefix'] for f in feature_aggregation_config]
-        for prefix1, prefix2 in permutations(all_prefixes, 2):
-            if prefix2.startswith(prefix1+'_'):
-                raise ValueError(
-                    dedent(
-                        """
-                Section: feature_aggregations -
-                Feature group prefixes must be distinct: %s and %s"""
-                        % (prefix1, prefix2)
-                    )
-                )
-
     def _validate_aggregation(self, aggregation_config):
         logging.info("Validating aggregation config %s", aggregation_config)
         self._validate_keys(aggregation_config)
@@ -393,8 +376,6 @@ class FeatureAggregationsValidator(Validator):
             )
         for aggregation in feature_aggregation_config:
             self._validate_aggregation(aggregation)
-
-        self._validate_prefixes(feature_aggregation_config)
 
 
 class LabelConfigValidator(Validator):
@@ -519,6 +500,22 @@ class CohortConfigValidator(Validator):
 
 
 class FeatureGroupDefinitionValidator(Validator):
+    def _validate_prefixes(self, prefix_list):
+        """
+        Ensure that no prefix starts with another prefix + _ to avoid
+        an error with feature group subsets when the group names overlap
+        """
+        for prefix1, prefix2 in permutations(prefix_list, 2):
+            if prefix2.startswith(prefix1):
+                raise ValueError(
+                    dedent(
+                        """
+                Section: feature_group_definition -
+                Feature group prefixes must not overlap when using `prefix`: %s and %s"""
+                        % (prefix1, prefix2)
+                    )
+                )
+
     def _run(self, feature_group_definition, feature_aggregation_config):
         if not isinstance(feature_group_definition, dict):
             raise ValueError(
@@ -574,6 +571,7 @@ class FeatureGroupDefinitionValidator(Validator):
                         )
                     )
                 )
+            self._validate_prefixes(feature_group_definition["prefix"])
 
         if "tables" in feature_group_definition:
             available_tables = {


### PR DESCRIPTION
Adds a validation for feature group prefixes to ensure they're distinct, as we've noticed that overlapping prefixes (e.g., `mh` and `mh_dx`) cause problems with some subset strategies, such as leave-one-out. 

Note that we should be able to remove this validation when the underlying bug is fixed, but seemed like a useful stop-gap in the meantime.