### PR TITLE
Enable dburl env var in results_schema CLI [Resolves #636]

### DIFF
--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -389,7 +389,7 @@ class Db(Command):
     @cmdmethod
     def upgrade(self, args):
         """Upgrade triage results database"""
-        upgrade_db(args.dbfile)
+        upgrade_db(dburl=self.root.db_url)
 
     @cmdmethod(
         "configversion",
@@ -408,7 +408,7 @@ class Db(Command):
             f"Based on config version {args.configversion} "
             f"we think your results schema is version {revision} and are upgrading to it"
         )
-        stamp_db(revision, args.dbfile)
+        stamp_db(revision, dburl=self.root.db_url)
 
 
 def execute():

--- a/src/triage/component/results_schema/README.md
+++ b/src/triage/component/results_schema/README.md
@@ -9,14 +9,13 @@ Store results of modeling runs in a relational database
 
 2. You can do the initial schema and table creation a couple of different ways, with a couple of different options for passing database credentials.
 
-	- *Triage cli script*. Assuming you have triage installed from pip: `triage -d dbcredentials.yaml db upgrade`, or just `triage db upgrade` if you have a database credentials file at `database.yaml` (the default)
-	- *From Python code*. If you are in a Python console or notebook, you can call `upgrade_db` with either sqlalchemy engine pointing to your database, or a filehandle to a credentials file.
+	- *Triage cli script*. Assuming you have triage installed from pip: `triage -d dbcredentials.yaml db upgrade`, or just `triage db upgrade` if you have a database credentials file at `database.yaml` (the default). As with other Triage cli endpoints, the DATABASE_URL environment variable can be used as well.
+	- *From Python code*. If you are in a Python console or notebook, you can call `upgrade_db` with either sqlalchemy engine pointing to your database, or a database URL.
 
 	```
 	>>> from triage.component.results_schema import upgrade_db
 	>>> upgrade_db(db_engine=engine)
-	>>> with open ('database.yaml') as fh:
-            upgrade_db(db_config_filehandle=fh)
+	>>> upgrade_db(dburl='postgresql://....')
 	```
 
 This command will create a 'results' schema and the necessary tables.

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -57,13 +57,13 @@ def _base_alembic_args(db_config_filename=None):
     return base
 
 
-def upgrade_db(db_config_filehandle=None, db_engine=None):
-    if db_config_filehandle:
-        command.upgrade(alembic_config(db_config_filehandle=db_config_filehandle), "head")
-    elif db_engine:
+def upgrade_db(db_engine=None, dburl=None):
+    if db_engine:
         command.upgrade(alembic_config(dburl=db_engine.url), "head")
+    elif dburl:
+        command.upgrade(alembic_config(dburl=dburl), "head")
     else:
-        raise ValueError("Must pass either a db_config_filehandle or a db_engine")
+        raise ValueError("Must pass either a db_config_filehandle or a db_engine or a dburl")
 
 
 REVISION_MAPPING = {
@@ -76,21 +76,11 @@ REVISION_MAPPING = {
 }
 
 
-def stamp_db(revision, db_config_filehandle):
-    command.stamp(alembic_config(db_config_filehandle=db_config_filehandle), revision)
+def stamp_db(revision, dburl):
+    command.stamp(alembic_config(dburl=dburl), revision)
 
 
-def alembic_config(db_config_filehandle=None, dburl=None):
-    if db_config_filehandle:
-        config = yaml.load(db_config_filehandle)
-        dburl = URL(
-            "postgres",
-            host=config["host"],
-            username=config["user"],
-            database=config["db"],
-            password=config["pass"],
-            port=config["port"],
-        )
+def alembic_config(dburl):
     path = os.path.abspath(__file__)
     dir_path = os.path.dirname(path)
     alembic_ini_path = os.path.join(dir_path, "alembic.ini")


### PR DESCRIPTION
- Replace db_config_filehandle support in results_schema utilities with
dburl and pass dburl from standard Triage CLI parsing options