### PR TITLE
Harden postmodeling against lack of predictions [Resolves #638]

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -82,6 +82,24 @@ def finished_experiment(shared_db_engine, shared_project_storage):
     return experiment
 
 
+@pytest.fixture(scope="module")
+def finished_experiment_without_predictions(shared_db_engine, shared_project_storage):
+    """A successfully-run experiment. Its database schemas and project storage can be queried.
+
+    Returns: (triage.experiments.SingleThreadedExperiment)
+    """
+    populate_source_data(shared_db_engine)
+    base_config = sample_config()
+    experiment = SingleThreadedExperiment(
+        base_config,
+        db_engine=shared_db_engine,
+        project_path=shared_project_storage.project_path,
+        save_predictions=False
+    )
+    experiment.run()
+    return experiment
+
+
 @pytest.fixture(scope='module')
 def crosstabs_config():
     """Example crosstabs config.

--- a/src/tests/postmodeling_tests/test_without_predictions.py
+++ b/src/tests/postmodeling_tests/test_without_predictions.py
@@ -1,0 +1,31 @@
+from triage.component.postmodeling.contrast.model_group_evaluator import ModelGroupEvaluator
+from triage.component.postmodeling.contrast.model_evaluator import ModelEvaluator
+import pytest
+
+
+@pytest.fixture(scope="module")
+def model_group_evaluator(finished_experiment_without_predictions):
+    return ModelGroupEvaluator((1, 1), finished_experiment_without_predictions.db_engine)
+
+
+@pytest.fixture(scope="module")
+def model_evaluator(finished_experiment_without_predictions):
+    return ModelEvaluator(1, 1, finished_experiment_without_predictions.db_engine)
+
+
+def test_ModelGroupEvaluator_metadata(model_group_evaluator):
+    assert all(value for metadata_row in model_group_evaluator.metadata for key, value in metadata_row.items() )
+
+
+def test_ModelGroupEvaluator_predictions(model_group_evaluator):
+    with pytest.raises(RuntimeError):
+        model_group_evaluator.predictions
+
+
+def test_ModelEvaluator_metadata(model_evaluator):
+    assert all(value for key, value in model_evaluator.metadata.items())
+
+
+def test_ModelEvaluator_predictions(model_evaluator):
+    with pytest.raises(RuntimeError):
+        model_evaluator.predictions


### PR DESCRIPTION
A quick fix to make the behavior in postmodeling more understandable if
it is run following an experiment without predictions.

- No longer use predictions to populate regular metadata
- When predictions are retrieved, throw an error if predictions are
empty
- Modify the repr to no longer use computed data from the database