### PR TITLE
fix imports in example postmodeling notebook

### DIFF
--- a/src/triage/component/postmodeling/contrast/postmodeling_tutorial.ipynb
+++ b/src/triage/component/postmodeling/contrast/postmodeling_tutorial.ipynb
@@ -38,11 +38,11 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "from collections import OrderedDict\n",
-    "from utils.aux_funcs import create_pgconn, get_models_ids\n",
+    "from triage.component.postmodeling.contrast.utils.aux_funcs import create_pgconn, get_models_ids\n",
     "from triage.component.catwalk.storage import ProjectStorage, ModelStorageEngine, MatrixStorageEngine\n",
-    "from parameters import PostmodelParameters\n",
-    "from model_evaluator import ModelEvaluator\n",
-    "from model_group_evaluator import ModelGroupEvaluator"
+    "from triage.component.postmodeling.contrast.parameters import PostmodelParameters\n",
+    "from triage.component.postmodeling.contrast.model_evaluator import ModelEvaluator\n",
+    "from triage.component.postmodeling.contrast.model_group_evaluator import ModelGroupEvaluator"
    ]
   },
   {


### PR DESCRIPTION
Import postmodeling utilities from installed `triage` rather than assuming notebook is being run in postmodeling code directory for example notebook.