### PR TITLE
Update model_group_performance.py

### DIFF
--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -84,7 +84,7 @@ class ModelGroupPerformancePlotter(object):
                 metric,
                 parameter,
                 train_end_time,
-                best_case,
+                best_case as raw_value,
                 'best case' as model_type
             from {dist_table}
             where metric || parameter = '{metric}{parameter}'

--- a/src/triage/component/audition/model_group_performance.py
+++ b/src/triage/component/audition/model_group_performance.py
@@ -74,22 +74,22 @@ class ModelGroupPerformancePlotter(object):
                 parameter,
                 train_end_time,
                 raw_value,
-                mg.model_type
-            from {dist_table} dist
+                mg.model_type as model_type
+            from {dist_table} as dist
             join model_metadata.model_groups mg using (model_group_id)
             where model_group_id in ({model_group_ids})
             union
             select
-                0 model_group_id,
+                0 as model_group_id,
                 metric,
                 parameter,
                 train_end_time,
                 best_case,
-                'best case' model_type
+                'best case' as model_type
             from {dist_table}
             where metric || parameter = '{metric}{parameter}'
             and train_end_time in ({train_end_times})
-            group by model_group_id, metric, parameter, train_end_time, raw_value, mg.model_type
+            group by model_group_id, metric, parameter, train_end_time, raw_value, model_type
             order by model_group_id asc, train_end_time asc
             """.format(
                 metric=metric,

--- a/src/triage/component/audition/plotting.py
+++ b/src/triage/component/audition/plotting.py
@@ -64,7 +64,7 @@ def _plot_lines(frame, x_col, y_col, ax, grp_col, colordict, cat_col, styledict)
         df = frame.loc[frame[grp_col] == grp_val]
         cat = df.iloc[0][cat_col]
         df.plot(
-            x_col, y_col, ax=ax, c=colordict[cat], style=styledict[cat], legend=False
+            x_col, y_col, ax=ax, c=colordict[cat], style=styledict[cat], legend=False, alpha=0.4
         )
 
 


### PR DESCRIPTION
`df.plot` _always_ assumes that all the points are connected, and uses the order of the data frame's index.

See the following screenshots (using the same example dataset from the issue #648 )

![Selección_006](https://user-images.githubusercontent.com/494528/54947560-9e8ec480-4f08-11e9-9e9d-16a26e0b1486.png)

and if you sort the dates:

![Selección_007](https://user-images.githubusercontent.com/494528/54947568-a189b500-4f08-11e9-8270-6d2693ab86ae.png)

Also removed the subsetting in pandas (it is not needed, it is done in SQL now)