### PR TITLE
Upgrade ohio

### DIFF
--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -24,5 +24,5 @@ pebble==4.3.10
 seaborn==0.9.0
 adjustText==0.7.3
 graphviz==0.10.1
-ohio==0.1.2
+ohio==0.4.0
 requests==2.21.0


### PR DESCRIPTION
Ohio has had some speed upgrades since we've started using it, and 0.1.2 is ancient in ohio terms, so this PR upgrades it.