### PR TITLE
Support Python 3.7 [Resolves #683]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - pip install -r requirement/include/build.txt -r requirement/include/test-management.txt
 env:
   matrix:
-  - BOTO_CONFIG=/tmp/nowhere
+    - BOTO_CONFIG=/tmp/nowhere
   global:
     secure: U00z8IVLCenhcgaf2k+orF2zrNuQDbuSZs7ob+HvUPUHbFf8nadGN7RQ1E/AeiDPuqqOB03gQnqEEM1/o6EzzTGICsjUuSwGkmXXVwkpk5DZeEv6zIlrXpIaPvD0ZRTDh9g2GohmL4AEc7v7cKxMCSW2zYfP9qhiHMmxD98yB3llc3Z/zBjCC1Wp9d6/2+MEiUWytqYg1pI4vamL+awHrgjpImrMYnC4guMpvwHqslL1t/HhvHzzrob1EjxIPZuDzzSmXAcRTDkrX56gFKn6+wPyGf7M8BbiyilqFThN93hhNc3XYXTV+ptQgi6Rn8EfKpKuL0qBW3wOw9e6SExtz8ESNB+DjSe7zTPNXGH1WbeyMUCrArdZj0+FVCjoT8dG9bDUMl+kgMn2J5VBS4umpmIVaJCJvmldojax4W+fuR4nrfnb3pIP+hDjemlgbpdmjBh39c+A3ZC7Zcv3fhpvGIyg8/2GBzNRaNc4wiVcd8An+VlToJLLwuBekA0J1NDWvKmuMX5Kew+Y4w1w1WgJAW8kWMEY51tlIwuWYdsdIRGLFgOucbtLMJpQXjtP8OxKHcWsCDiIEZJk49IMdcU3q6Wmss1TfElNwxpdpECrLEn8y1CDIhzb+PcUYdqHWPgW30TKOs4URags4m/XVmDJZrgv3JcwiQiYbUepZ8hPdTY=
 script: tox
@@ -19,21 +19,21 @@ notifications:
   email: false
 after_success: codecov
 deploy:
-    -
-      repo: dssg/triage
-      distributions: sdist bdist_wheel
-      password:
-          secure: o0JpnmjqbYgu75eUXfxX/FUw0ek6Pp1bdhqRH4x3VnINy3TdBZ1tdD35B0l8L5UaR+j8LawOwTt3md3EyQTNpJQypFChcF6LDTS2hF0ZxyFphgWWo+DWhx8abAT/xAECO7Z7pjynQcYy1OAC3U+V8E7gevlr/nWD1/Le0mC+BJocJQ6QBZCD84E4ennXdLUgMqQZlCUKvi6j7EXvV4NoXbuZPaZKhC77CZ0xpEu0aQG9IPPGgkmL3a5RQd5/Uu8rlBES5lzh9bysW3NvXSUaq5XXrQAx5Fba3/lDN8aVkFvseLwOfjZ1pdTnbcDH5ti24YYecBsRsF4qmOY5pVZQZWeQRZFZ+/wp0fa34M9XjIyN7rXKyPm2UX7A8IYyF95xvniKs0qUOBXGRq5IFse6OSUIuKLYl3XjN3IPUPRCXnxoCXyRFV3NNyvtfb47+eejrgfqav9SKE5auA/t5ioQh6FuVqBMCWK7FFiZCt4z1g6RmYAFlRcTuHeedKjOfzWU79AeUoTJA1tfz4FtNjIWfoZJyCNCUCQjYzD/yCJGuDCuY/42+QGaMo9oEVgw7ublC0Xzib+zyuogTvjxYQR+XGJnCgeDYEs7A/o8CHdJKSeIbxpnuZShPpkdBQgzWmnvlfgJTYICaa10oAf5+sDnBQQsumZBT3iuKJETXIkNxeo=
-      provider: pypi
-      user: dssg
-      on:
-           repo: dssg/triage
-           tags: true
+  -
+    repo: dssg/triage
+    distributions: sdist bdist_wheel
+    password:
+      secure: o0JpnmjqbYgu75eUXfxX/FUw0ek6Pp1bdhqRH4x3VnINy3TdBZ1tdD35B0l8L5UaR+j8LawOwTt3md3EyQTNpJQypFChcF6LDTS2hF0ZxyFphgWWo+DWhx8abAT/xAECO7Z7pjynQcYy1OAC3U+V8E7gevlr/nWD1/Le0mC+BJocJQ6QBZCD84E4ennXdLUgMqQZlCUKvi6j7EXvV4NoXbuZPaZKhC77CZ0xpEu0aQG9IPPGgkmL3a5RQd5/Uu8rlBES5lzh9bysW3NvXSUaq5XXrQAx5Fba3/lDN8aVkFvseLwOfjZ1pdTnbcDH5ti24YYecBsRsF4qmOY5pVZQZWeQRZFZ+/wp0fa34M9XjIyN7rXKyPm2UX7A8IYyF95xvniKs0qUOBXGRq5IFse6OSUIuKLYl3XjN3IPUPRCXnxoCXyRFV3NNyvtfb47+eejrgfqav9SKE5auA/t5ioQh6FuVqBMCWK7FFiZCt4z1g6RmYAFlRcTuHeedKjOfzWU79AeUoTJA1tfz4FtNjIWfoZJyCNCUCQjYzD/yCJGuDCuY/42+QGaMo9oEVgw7ublC0Xzib+zyuogTvjxYQR+XGJnCgeDYEs7A/o8CHdJKSeIbxpnuZShPpkdBQgzWmnvlfgJTYICaa10oAf5+sDnBQQsumZBT3iuKJETXIkNxeo=
+    provider: pypi
+    user: dssg
+    on:
+       repo: dssg/triage
+       tags: true
   -
     provider: pages
     skip_cleanup: true
     keep_history: true
     on:
-        tags: true
+      tags: true
     github_token:
-        secure: k9B6boJecrnckJaei63Ulyqq0Guj1D6hEGcnvChqlG0K7rbC8ItK9WAB+l349mPzFVflQqXvovcr+skB3FuVTiv8nD6y5ACKZTYy9IAC0OURHIBYEwnTyBFc7xuUKRlHsGok5DfQkUeQgiyUGTPLAExDkufjSAamnevATSGk3uCzpDzexRqSKm69Py1ZMEgSmTriH+Z90p/OET0lZPn0rkBXlgeReElJ2ffPjE8HaE9JovL22/9ZoNlBjnK85fAt4WEAWSdoL1f2Ye+XILlfIx2abFzbthU+0mPZf3U3bvzPWNwYzMs5fwnV635yHEMT2yRDA8Hrpbe+EFEk+/GfwITnVpSawmZutsuH4xjmh9owCTqMvI2IWNJ5cTVgs4NoRIlqU0Eiaxyn2Iv123WNO3SjoLKJ7i3CXK82V2rMkufbVBEzG010G24wJ087w+mZux7wxxQ5DQmgm1leNBLqGmkdGMYVBQubAyS5rKBW8akvBX+T3b8c/CUoamOnWXP6nTS3jGfSP0doBBqhe8C7qA75FfwS350ln/CJBfuU2mS7ya1PawS1sdZ9M8eYm1gl3ueLQjaXnG2BcbDqDGRNHrrXDGtNCdD7AeoQ+3jVUR1hoyHS+zxMxRUBb/Gpd7sKwyiF4kR5sQ2M3mLLo2YCk9+l8Y/nY9E3MuZggfq1d7c=
+      secure: k9B6boJecrnckJaei63Ulyqq0Guj1D6hEGcnvChqlG0K7rbC8ItK9WAB+l349mPzFVflQqXvovcr+skB3FuVTiv8nD6y5ACKZTYy9IAC0OURHIBYEwnTyBFc7xuUKRlHsGok5DfQkUeQgiyUGTPLAExDkufjSAamnevATSGk3uCzpDzexRqSKm69Py1ZMEgSmTriH+Z90p/OET0lZPn0rkBXlgeReElJ2ffPjE8HaE9JovL22/9ZoNlBjnK85fAt4WEAWSdoL1f2Ye+XILlfIx2abFzbthU+0mPZf3U3bvzPWNwYzMs5fwnV635yHEMT2yRDA8Hrpbe+EFEk+/GfwITnVpSawmZutsuH4xjmh9owCTqMvI2IWNJ5cTVgs4NoRIlqU0Eiaxyn2Iv123WNO3SjoLKJ7i3CXK82V2rMkufbVBEzG010G24wJ087w+mZux7wxxQ5DQmgm1leNBLqGmkdGMYVBQubAyS5rKBW8akvBX+T3b8c/CUoamOnWXP6nTS3jGfSP0doBBqhe8C7qA75FfwS350ln/CJBfuU2mS7ya1PawS1sdZ9M8eYm1gl3ueLQjaXnG2BcbDqDGRNHrrXDGtNCdD7AeoQ+3jVUR1hoyHS+zxMxRUBb/Gpd7sKwyiF4kR5sQ2M3mLLo2YCk9+l8Y/nY9E3MuZggfq1d7c=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 3.6
+python: ["3.6", "3.7"]
 addons:
   postgresql: '9.5'
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 python: ["3.6", "3.7"]
 addons:

--- a/docs/sources/dirtyduck/docs/eis.md
+++ b/docs/sources/dirtyduck/docs/eis.md
@@ -304,7 +304,7 @@ We need to specify the temporal configuration too
 
     ```sh
     # Remember to run this in bastion  NOT in your laptop shell!
-    triage experiment --matrix-format hdf experiments/eis_01.yaml --profile
+    triage experiment experiments/eis_01.yaml --profile
     ```
 
     This will take a **lot** amount of time (on my computer took 3h 42m), so, grab your coffee, chat with your coworkers, check your email, or read the [DSSG blog](https://dssg.uchicago.edu/blog). It's taking that long for several reasons:

--- a/docs/sources/dirtyduck/docs/inspections.md
+++ b/docs/sources/dirtyduck/docs/inspections.md
@@ -321,10 +321,10 @@ You can execute the experiment as<sup><a id="fnr.8" class="footref" href="#fn.8"
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_baseline.yaml --profile
+triage experiment experiments/inspections_baseline.yaml --profile
 ```
 
-This will print a lot of output, and if everything is correct it will create **6** matrices (3 for training, 3 for testing) in `triage/matrices` and every matrix will be represented by two files, one with the metadata of the matrix (a `yaml` file) and one with the actual matrix (the `h5` file).
+This will print a lot of output, and if everything is correct it will create **6** matrices (3 for training, 3 for testing) in `triage/matrices` and every matrix will be represented by two files, one with the metadata of the matrix (a `yaml` file) and one with the actual matrix (the `csv.gz` file).
 
 ```sh
 
@@ -686,7 +686,7 @@ You can execute the experiment like this:
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_dt.yaml  --profile
+triage experiment experiments/inspections_dt.yaml  --profile
 ```
 
 After the experiment finishes, you will get **6** new `model_groups` (1 per combination in `grid_config`)
@@ -914,7 +914,7 @@ You can execute the experiment with
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_label_failed_01.yaml  --profile
+triage experiment experiments/inspections_label_failed_01.yaml  --profile
 ```
 
 This will take a looooong time to run. The reason for that is easy to understand: We are computing a *lot* of models: 3 time splits, 4 model groups and 9 features sets (one for `all`, four for `leave_one_in` and four for `leave_one_out`), so \(3 \times 4 \times 9 = 108\) extra models.

--- a/docs/sources/dirtyduck/docs/triage_intro.md
+++ b/docs/sources/dirtyduck/docs/triage_intro.md
@@ -44,7 +44,7 @@ You can run that experiment with:
 
 ```shell
 # Remember to run this in bastion NOT in your laptop!
-triage experiment --matrix-format hdf experiments/simple_test_skeleton.yaml
+triage experiment experiments/simple_test_skeleton.yaml
 ```
 
 Every time you modify the configuration file and see the effects, you should execute the experiment again using the previous command.

--- a/docs/sources/dirtyduck/org/index.md
+++ b/docs/sources/dirtyduck/org/index.md
@@ -1187,7 +1187,7 @@ We will show you how to setup the experiment while explaining the inner workings
 You can run that experiment with:
 
     # Remember to run this in bastion NOT in your laptop!
-    triage experiment --matrix-format hdf experiments/simple_test_skeleton.yaml
+    triage experiment experiments/simple_test_skeleton.yaml
 
 Every time you modify the configuration file and see the effects, you should execute the experiment again using the previous command.
 
@@ -2875,10 +2875,10 @@ You can execute the experiment as<sup><a id="fnr.50" class="footref" href="#fn.5
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_baseline.yaml --profile
+triage experiment experiments/inspections_baseline.yaml --profile
 ```
 
-This will print a lot of output, and if everything is correct it will create **6** matrices (3 for training, 3 for testing) in `triage/matrices` and every matrix will be represented by two files, one with the metadata of the matrix (a `yaml` file) and one with the actual matrix (the `h5` file).
+This will print a lot of output, and if everything is correct it will create **6** matrices (3 for training, 3 for testing) in `triage/matrices` and every matrix will be represented by two files, one with the metadata of the matrix (a `yaml` file) and one with the actual matrix (the `csv.gz` file).
 
 ```sh
 
@@ -3240,7 +3240,7 @@ You can execute the experiment like this:
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_dt.yaml  --profile
+triage experiment experiments/inspections_dt.yaml  --profile
 ```
 
 After the experiment finishes, you will get **6** new `model_groups` (1 per combination in `grid_config`)
@@ -3468,7 +3468,7 @@ You can execute the experiment with
 
 ```sh
 # Remember to run this in bastion  NOT in your laptop shell!
-triage experiment --matrix-format hdf experiments/inspections_label_failed_01.yaml  --profile
+triage experiment experiments/inspections_label_failed_01.yaml  --profile
 ```
 
 This will take a looooong time to run. The reason for that is easy to understand: We are computing a *lot* of models: 3 time splits, 4 model groups and 9 features sets (one for `all`, four for `leave_one_in` and four for `leave_one_out`), so \(3 \times 4 \times 9 = 108\) extra models.
@@ -4224,7 +4224,7 @@ We need to specify the temporal configuration too
 
     ```sh
     # Remember to run this in bastion  NOT in your laptop shell!
-    triage experiment --matrix-format hdf experiments/eis_01.yaml --profile
+    triage experiment experiments/eis_01.yaml --profile
     ```
 
     This will take a **lot** amount of time (on my computer took 3h 42m), so, grab your coffee, chat with your coworkers, check your email, or read the [DSSG blog](https://dssg.uchicago.edu/blog). It's taking that long for several reasons:

--- a/docs/sources/experiments/running.md
+++ b/docs/sources/experiments/running.md
@@ -114,36 +114,6 @@ experiment.run()
 
 ```
 
-## Using HDF5 as a matrix storage format
-
-Triage by default uses CSV format to store matrices, but this can take up a lot of space. However, this is configurable.  Triage ships with an HDF5 storage module that you can use.
-
-### CLI
-
-On the command-line, this is configurable using the `--matrix-format` option, and supports `csv` and `hdf`.
-
-```bash
-triage experiment example/config/experiment.yaml --matrix-format hdf
-```
-
-### Python
-
-In Python, this is configurable using the `matrix_storage_class` keyword argument. To allow users to write their own storage modules, this is passed in the form of a class. The shipped modules are in `triage.component.catwalk.storage`. If you'd like to write your own storage module, you can use the [existing modules](https://github.com/dssg/triage/blob/master/src/triage/component/catwalk/storage.py) as a guide.
-
-```python
-from triage.experiments import SingleThreadedExperiment
-from triage.component.catwalk.storage import HDFMatrixStore
-
-experiment = SingleThreadedExperiment(
-    config=experiment_config
-    db_engine=create_engine(...),
-    matrix_storage_class=HDFMatrixStore,
-    project_path='/path/to/directory/to/save/data',
-)
-experiment.run()
-```
-
-Note: The HDF storage option is *not* compatible with S3.
 
 ## Validating an Experiment
 

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -5,7 +5,6 @@ psycopg2-binary==2.7.7
 python-dateutil==2.8.0
 scipy==1.2.1
 scikit-learn==0.20.3
-tables==3.3.0 # pyup: ignore
 matplotlib<2.2 # pyup: ignore
 pandas==0.24.2
 boto3==1.9.125

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     test_suite='tests',
     tests_require=REQUIREMENTS_TEST

--- a/src/tests/architect_tests/test_builders.py
+++ b/src/tests/architect_tests/test_builders.py
@@ -11,7 +11,7 @@ from triage.component.catwalk.utils import filename_friendly_hash
 from triage.component.architect.feature_group_creator import FeatureGroup
 from triage.component.architect.builders import MatrixBuilder
 from triage.component.catwalk.db import ensure_db
-from triage.component.catwalk.storage import ProjectStorage, HDFMatrixStore
+from triage.component.catwalk.storage import ProjectStorage
 from triage.component.results_schema.schema import Matrix
 
 from .utils import (
@@ -720,40 +720,6 @@ class TestBuildMatrix(TestCase):
             )
 
             with get_matrix_storage_engine() as matrix_storage_engine:
-                builder = MatrixBuilder(
-                    db_config=db_config,
-                    matrix_storage_engine=matrix_storage_engine,
-                    experiment_hash=experiment_hash,
-                    engine=engine,
-                )
-
-                uuid = filename_friendly_hash(self.good_metadata)
-                builder.build_matrix(
-                    as_of_times=self.good_dates,
-                    label_name="booking",
-                    label_type="binary",
-                    feature_dictionary=self.good_feature_dictionary,
-                    matrix_metadata=self.good_metadata,
-                    matrix_uuid=uuid,
-                    matrix_type="test",
-                )
-
-                assert len(matrix_storage_engine.get_store(uuid).design_matrix) == 5
-
-    def test_hdf_matrix(self):
-        with testing.postgresql.Postgresql() as postgresql:
-            # create an engine and generate a table with fake feature data
-            engine = create_engine(postgresql.url())
-            ensure_db(engine)
-            create_schemas(
-                engine=engine,
-                features_tables=features_tables,
-                labels=labels,
-                states=states,
-            )
-
-            with get_matrix_storage_engine() as matrix_storage_engine:
-                matrix_storage_engine.matrix_storage_class = HDFMatrixStore
                 builder = MatrixBuilder(
                     db_config=db_config,
                     matrix_storage_engine=matrix_storage_engine,

--- a/src/tests/architect_tests/utils.py
+++ b/src/tests/architect_tests/utils.py
@@ -138,30 +138,6 @@ def TemporaryDirectory():
         shutil.rmtree(name)
 
 
-@contextmanager
-def fake_metta(matrix_dict, metadata):
-    """Stores matrix and metadata in a metta-data-like form
-
-    Args:
-    matrix_dict (dict) of form { columns: values }.
-        Expects an entity_id to be present which it will use as the index
-    metadata (dict). Any metadata that should be set
-
-    Yields:
-        tuple of filenames for matrix and metadata
-    """
-    matrix = pd.DataFrame.from_dict(matrix_dict).set_index("entity_id")
-    with tempfile.NamedTemporaryFile() as matrix_file:
-        with tempfile.NamedTemporaryFile("w") as metadata_file:
-            hdf = pd.HDFStore(matrix_file.name)
-            hdf.put("title", matrix, data_columns=True)
-            matrix_file.seek(0)
-
-            yaml.dump(metadata, metadata_file)
-            metadata_file.seek(0)
-            yield (matrix_file.name, metadata_file.name)
-
-
 def fake_labels(length):
     return numpy.array([random.choice([True, False]) for i in range(0, length)])
 

--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -16,7 +16,6 @@ from triage.component.catwalk.storage import (
     MatrixStore,
     CSVMatrixStore,
     FSStore,
-    HDFMatrixStore,
     S3Store,
     ProjectStorage,
     ModelStorageEngine,
@@ -95,22 +94,16 @@ def matrix_stores():
         project_storage = ProjectStorage(tmpdir)
         tmpcsv = os.path.join(tmpdir, "df.csv.gz")
         tmpyaml = os.path.join(tmpdir, "df.yaml")
-        tmphdf = os.path.join(tmpdir, "df.h5")
         with open(tmpyaml, "w") as outfile:
             yaml.dump(METADATA, outfile, default_flow_style=False)
         df.to_csv(tmpcsv, compression="gzip")
-        df.to_hdf(tmphdf, "matrix")
         csv = CSVMatrixStore(project_storage, [], "df")
-        hdf = HDFMatrixStore(project_storage, [], "df")
-        assert csv.design_matrix.equals(hdf.design_matrix)
         # first test with caching
-        with csv.cache(), hdf.cache():
+        with csv.cache():
             yield csv
-            yield hdf
         # with the caching out of scope they will be nuked
-        # and these last two versions will not have any cache
+        # and this last version will not have any cache
         yield csv
-        yield hdf
 
 
 def test_MatrixStore_empty():

--- a/src/tests/catwalk_tests/utils.py
+++ b/src/tests/catwalk_tests/utils.py
@@ -14,30 +14,6 @@ from triage.component.catwalk.storage import (
 from triage.util.structs import FeatureNameList
 
 
-@contextmanager
-def fake_metta(matrix_dict, metadata):
-    """Stores matrix and metadata in a metta-data-like form
-
-    Args:
-    matrix_dict (dict) of form { columns: values }.
-        Expects an entity_id to be present which it will use as the index
-    metadata (dict). Any metadata that should be set
-
-    Yields:
-        tuple of filenames for matrix and metadata
-    """
-    matrix = pandas.DataFrame.from_dict(matrix_dict).set_index("entity_id")
-    with tempfile.NamedTemporaryFile() as matrix_file:
-        with tempfile.NamedTemporaryFile("w") as metadata_file:
-            hdf = pandas.HDFStore(matrix_file.name)
-            hdf.put("title", matrix, data_columns=True)
-            matrix_file.seek(0)
-
-            yaml.dump(metadata, metadata_file)
-            metadata_file.seek(0)
-            yield (matrix_file.name, metadata_file.name)
-
-
 def fake_labels(length):
     return numpy.array([random.choice([True, False]) for i in range(0, length)])
 

--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -13,7 +13,7 @@ import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 
 from tests.utils import sample_config, populate_source_data
-from triage.component.catwalk.storage import HDFMatrixStore, CSVMatrixStore
+from triage.component.catwalk.storage import CSVMatrixStore
 from triage.component.results_schema.schema import Experiment
 
 from triage.experiments import (
@@ -54,14 +54,9 @@ parametrize_experiment_classes = pytest.mark.parametrize(
     ],
 )
 
-parametrize_matrix_storage_classes = pytest.mark.parametrize(
-    ("matrix_storage_class",), [(HDFMatrixStore,), (CSVMatrixStore,)]
-)
-
 
 @parametrize_experiment_classes
-@parametrize_matrix_storage_classes
-def test_simple_experiment(experiment_class, matrix_storage_class):
+def test_simple_experiment(experiment_class):
     with testing.postgresql.Postgresql() as postgresql:
         db_engine = create_engine(postgresql.url())
         populate_source_data(db_engine)
@@ -70,7 +65,6 @@ def test_simple_experiment(experiment_class, matrix_storage_class):
                 config=sample_config(),
                 db_engine=db_engine,
                 project_path=os.path.join(temp_dir, "inspections"),
-                matrix_storage_class=matrix_storage_class,
                 cleanup=True,
             ).run()
 

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -15,7 +15,7 @@ from triage.component.architect.entity_date_table_generators import EntityDateTa
 from triage.component.audition import AuditionRunner
 from triage.component.results_schema import upgrade_db, stamp_db, REVISION_MAPPING
 from triage.component.timechop.plotting import visualize_chops
-from triage.component.catwalk.storage import CSVMatrixStore, HDFMatrixStore, Store, ProjectStorage
+from triage.component.catwalk.storage import CSVMatrixStore, Store, ProjectStorage
 from triage.experiments import (
     CONFIG_VERSION,
     MultiCoreExperiment,
@@ -157,7 +157,6 @@ class Experiment(Command):
 
     matrix_storage_map = {
         "csv": CSVMatrixStore,
-        "hdf": HDFMatrixStore,
     }
     matrix_storage_default = "csv"
 

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -10,7 +10,6 @@ import tempfile
 import sqlalchemy
 
 import pandas as pd
-import yaml
 import numpy
 from sqlalchemy.orm import sessionmaker
 
@@ -124,30 +123,6 @@ def TemporaryDirectory():
         yield name
     finally:
         shutil.rmtree(name)
-
-
-@contextmanager
-def fake_metta(matrix_dict, metadata):
-    """Stores matrix and metadata in a metta-data-like form
-
-    Args:
-    matrix_dict (dict) of form { columns: values }.
-        Expects an entity_id to be present which it will use as the index
-    metadata (dict). Any metadata that should be set
-
-    Yields:
-        tuple of filenames for matrix and metadata
-    """
-    matrix = pd.DataFrame.from_dict(matrix_dict).set_index("entity_id")
-    with tempfile.NamedTemporaryFile() as matrix_file:
-        with tempfile.NamedTemporaryFile("w") as metadata_file:
-            hdf = pd.HDFStore(matrix_file.name)
-            hdf.put("title", matrix, data_columns=True)
-            matrix_file.seek(0)
-
-            yaml.dump(metadata, metadata_file)
-            metadata_file.seek(0)
-            yield (matrix_file.name, metadata_file.name)
 
 
 def fake_labels(length):

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -315,7 +315,7 @@ class MatrixStorageEngine(object):
 class MatrixStore(object):
     """Base class for classes that allow access of a matrix and its metadata.
 
-    Subclasses should be scoped to a storage format (e.g. CSV, HDF)
+    Subclasses should be scoped to a storage format (e.g. CSV)
         and implement the _load, save, and head_of_matrix methods for that storage format
 
     Args:
@@ -550,62 +550,6 @@ class MatrixStore(object):
         state = self.__dict__.copy()
         state['_matrix_label_tuple'] = None
         return state
-
-
-class HDFMatrixStore(MatrixStore):
-    """Store and access matrices using HDF
-
-    Instead of overriding head_of_matrix, which cannot be easily and reliably done
-    using HDFStore without loading the whole matrix into memory,
-    we individually override 'empty' and 'columns'
-    to obviate the need for a performant 'head_of_matrix' operation.
-    """
-
-    suffix = "h5"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if isinstance(self.matrix_base_store, S3Store):
-            raise ValueError("HDFMatrixStore cannot be used with S3")
-
-    def columns(self, include_label=False):
-        """The matrix's column list"""
-        head_of_matrix = pd.read_hdf(self.matrix_base_store.path, start=0, stop=0)
-        columns = head_of_matrix.columns.tolist()
-        if include_label:
-            return columns
-        else:
-            return [col for col in columns if col != self.metadata["label_name"]]
-
-    @property
-    def empty(self):
-        """Whether or not the matrix has at least one row"""
-        if not self.matrix_base_store.exists():
-            return True
-        else:
-            try:
-                head_of_matrix = pd.read_hdf(self.matrix_base_store.path, start=0, stop=1)
-                return head_of_matrix.empty
-            except ValueError:
-                # There is no known way to make the start/stop operations work all the time
-                # , there is often a ValueError when trying to load just the first row
-                # However, if we do get a ValueError that means there is data so it can't be empty
-                return False
-
-    def _load(self):
-        return pd.read_hdf(self.matrix_base_store.path)
-
-    def save(self):
-        hdf = pd.HDFStore(
-            self.matrix_base_store.path,
-            mode="w",
-            complevel=4,
-            complib="zlib",
-        )
-        hdf.put(f"matrix_{self.matrix_uuid}", self.full_matrix_for_saving.apply(pd.to_numeric), data_columns=True)
-        hdf.close()
-        with self.metadata_base_store.open("wb") as fd:
-            yaml.dump(self.metadata, fd, encoding="utf-8")
 
 
 class CSVMatrixStore(MatrixStore):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = py36
+envlist = py3
 
-[testenv:py36]
+[testenv:py3]
 setenv = 
     AWS_ACCESS_KEY_ID=fake
     AWS_SECRET_ACCESS_KEY=fake


### PR DESCRIPTION
To support Python 3.7, remove the HDFMatrixStore (CSVs are compressed now, we get no real use out of HDF) and remove the ancient pytables dependency. Also update many documents and tests to remove HDF references.