### PR TITLE
Fix logging typos that only show up when splits are empty

### DIFF
--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -115,3 +115,16 @@ def test_ModelTrainTester_process_task_replace_True(project_storage):
     assert train_tester.model_evaluator.needs_evaluations.call_count == 0
     assert train_tester.predictor.predict.call_count == 2
     assert train_tester.model_evaluator.evaluate.call_count == 2
+
+
+def test_ModelTrainTester_process_task_empty_train(project_storage):
+    train_tester, train_test_task = setup_model_train_tester(project_storage, replace=True)
+    train_store = MagicMock()
+    train_store.empty = True
+    train_test_task['train_store'] = train_store
+    train_tester.process_task(**train_test_task)
+
+    assert train_tester.model_trainer.process_train_task.call_count == 0
+    assert train_tester.model_evaluator.needs_evaluations.call_count == 0
+    assert train_tester.predictor.predict.call_count == 0
+    assert train_tester.model_evaluator.evaluate.call_count == 0

--- a/src/triage/component/catwalk/__init__.py
+++ b/src/triage/component/catwalk/__init__.py
@@ -107,37 +107,38 @@ class ModelTrainTester(object):
     def process_task(self, test_store, train_store, train_kwargs):
         logging.info("Beginning train task %s", train_kwargs)
 
-        # If the train or test design matrix empty, or if the train store only
-        # has one label value, skip training the model.
-        if train_store.empty:
-            logging.warning(
-                """Train matrix for split %s was empty,
-            no point in training this model. Skipping
-            """,
-                split["train_uuid"],
-            )
-            return
-        if len(train_store.labels.unique()) == 1:
-            logging.warning(
-                """Train Matrix for split %s had only one
-            unique value, no point in training this model. Skipping
-            """,
-                split["train_uuid"],
-            )
-            return
-        if test_store.empty:
-            logging.warning(
-                """Test matrix for uuid %s
-            was empty, no point in generating predictions. Not processing train/test task.
-            """,
-                test_uuid,
-            )
-            return
-
         # If the matrices and train labels are OK, train and test the model!
         with self.model_trainer.cache_models(), test_store.cache(), train_store.cache():
             # will cache any trained models until it goes out of scope (at the end of the task)
             # this way we avoid loading the model pickle again for predictions
+
+            # If the train or test design matrix empty, or if the train store only
+            # has one label value, skip training the model.
+            if train_store.empty:
+                logging.warning(
+                    """Train matrix for split %s was empty,
+                no point in training this model. Skipping
+                """,
+                    train_store.uuid
+                )
+                return
+            if len(train_store.labels.unique()) == 1:
+                logging.warning(
+                    """Train Matrix for split %s had only one
+                unique value, no point in training this model. Skipping
+                """,
+                    train_store.uuid,
+                )
+                return
+            if test_store.empty:
+                logging.warning(
+                    """Test matrix for uuid %s
+                was empty, no point in generating predictions. Not processing train/test task.
+                """,
+                    test_store.uuid,
+                )
+                return
+
             model_id = self.model_trainer.process_train_task(**train_kwargs)
             if not model_id:
                 logging.warning("No model id returned from ModelTrainer.process_train_task, "


### PR DESCRIPTION
A bug was introduced when the train/test matrix checking switched from "create task" to "process task", in that the log messages were using variables that didn't actually exist. This snuck by because empty splits don't actually happen very often, but eventually we did run into it in production.

This fixes the bug, adds a test for it, and additionally moves those checks in the cache block to minimize unnecessary re-downloading of the matrix.