### PR TITLE
write 5+ GiB (matrices) to S3Store

### DIFF
--- a/src/tests/catwalk_tests/test_storage.py
+++ b/src/tests/catwalk_tests/test_storage.py
@@ -1,16 +1,16 @@
+import datetime
 import os
 import tempfile
 from collections import OrderedDict
 
+import boto3
 import pandas as pd
-import datetime
+import pytest
 import yaml
 from moto import mock_s3
-import boto3
 from numpy.testing import assert_almost_equal
 from pandas.testing import assert_frame_equal
 from unittest import mock
-import pytest
 
 from triage.component.catwalk.storage import (
     MatrixStore,
@@ -22,8 +22,11 @@ from triage.component.catwalk.storage import (
     ModelStorageEngine,
 )
 
+from tests.utils import CallSpy
+
 
 class SomeClass(object):
+
     def __init__(self, val):
         self.val = val
 
@@ -40,6 +43,70 @@ def test_S3Store():
         assert newVal.decode("utf-8") == "val"
         store.delete()
         assert not store.exists()
+
+
+@mock_s3
+def test_S3Store_large():
+    client = boto3.client('s3')
+    client.create_bucket(Bucket='test_bucket', ACL='public-read-write')
+
+    store = S3Store('s3://test_bucket/a_path')
+    assert not store.exists()
+
+    # NOTE: The issue under test (currently) arises when too large a "part"
+    # NOTE: is sent to S3 for upload -- greater than its 5 GiB limit on any
+    # NOTE: single upload request.
+    #
+    # NOTE: Though s3fs uploads file parts as soon as its buffer reaches
+    # NOTE: 5+ MiB, it does not ensure that its buffer -- and resulting
+    # NOTE: upload "parts" -- remain under this limit (as the result of a
+    # NOTE: single "write()").
+    #
+    # NOTE: Therefore, until s3fs adds handling to ensure it never attempts
+    # NOTE: to upload such large payloads, we'll handle this in S3Store,
+    # NOTE: by chunking out writes to s3fs.
+    #
+    # NOTE: This is all not only to explain the raison d'etre of this test,
+    # NOTE: but also as context for the following warning: The
+    # NOTE: payload we'll attempt to write, below, is far less than 5 GiB!!
+    # NOTE: (Attempting to provision a 5 GiB string in RAM just for this
+    # NOTE: test would be an ENORMOUS drag on test runs, and a conceivable
+    # NOTE: disruption, depending on the test environment's resources.)
+    #
+    # NOTE: As such, this test *may* fall out of sync with either the code
+    # NOTE: that it means to test or with the reality of the S3 API -- even
+    # NOTE: to the point of self-invalidation. (But, this should do the
+    # NOTE: trick; and, we can always increase the payload size here, or
+    # NOTE: otherwise tweak configuration, as necessary.)
+    one_mb = 2 ** 20
+    payload = b"0" * (10 * one_mb)  # 10MiB text of all zeros
+
+    with CallSpy('botocore.client.BaseClient._make_api_call') as spy:
+        store.write(payload)
+
+    call_args = [call[0] for call in spy.calls]
+    call_methods = [args[1] for args in call_args]
+
+    assert call_methods == [
+        'CreateMultipartUpload',
+        'UploadPart',
+        'UploadPart',
+        'CompleteMultipartUpload',
+    ]
+
+    upload_args = call_args[1]
+    upload_body = upload_args[2]['Body']
+
+    # NOTE: Why is this a BufferIO rather than the underlying buffer?!
+    # NOTE: (Would have expected the result of BufferIO.read() -- str.)
+    body_length = len(upload_body.getvalue())
+    assert body_length == 5 * one_mb
+
+    assert store.exists()
+    assert store.load() == payload
+
+    store.delete()
+    assert not store.exists()
 
 
 def test_FSStore():
@@ -210,7 +277,12 @@ def test_as_of_dates(project_storage):
         "entity_id": [1, 2, 1, 2],
         "feature_one": [0.5, 0.6, 0.5, 0.6],
         "feature_two": [0.5, 0.6, 0.5, 0.6],
-        "as_of_date": [pd.Timestamp(2016, 1, 1), pd.Timestamp(2016, 1, 1), pd.Timestamp(2017, 1, 1), pd.Timestamp(2017, 1, 1)],
+        "as_of_date": [
+            pd.Timestamp(2016, 1, 1),
+            pd.Timestamp(2016, 1, 1),
+            pd.Timestamp(2017, 1, 1),
+            pd.Timestamp(2017, 1, 1),
+        ],
         "label": [1, 0, 1, 0]
     }
     df = pd.DataFrame.from_dict(data)

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -1,23 +1,31 @@
 import datetime
+import functools
+import importlib
 import random
 import tempfile
 from contextlib import contextmanager
+from unittest import mock
 
+import matplotlib
 import numpy
 import pandas
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy import create_engine
 import testing.postgresql
+from descriptors import cachedproperty
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
 from triage.component.catwalk.db import ensure_db
-from triage.component.catwalk.utils import filename_friendly_hash
 from triage.component.catwalk.storage import MatrixStore, ProjectStorage
+from triage.component.catwalk.utils import filename_friendly_hash
 from triage.component.results_schema import Model, Matrix
 from triage.experiments import CONFIG_VERSION
-from tests.results_tests.factories import init_engine, session, MatrixFactory
 from triage.util.structs import FeatureNameList
-import matplotlib
+
+from tests.results_tests.factories import init_engine, session, MatrixFactory
+
 matplotlib.use("Agg")
-from matplotlib import pyplot as plt
+
+from matplotlib import pyplot as plt  # noqa
 
 
 def fake_labels(length):
@@ -77,11 +85,11 @@ class MockMatrixStore(MatrixStore):
         session = sessionmaker(db_engine)()
         session.add(Matrix(matrix_uuid=matrix_uuid))
         session.commit()
-    
+
     @property
     def as_of_dates(self):
         """The list of as-of-dates in the matrix"""
-        return self.init_as_of_dates or self.metadata["as_of_times"] 
+        return self.init_as_of_dates or self.metadata["as_of_times"]
 
     @property
     def labels(self):
@@ -179,7 +187,8 @@ def get_matrix_store(project_storage, matrix=None, metadata=None, write_to_db=Tr
         metadata = matrix_metadata_creator()
     matrix["as_of_date"] = matrix["as_of_date"].apply(pandas.Timestamp)
     matrix.set_index(MatrixStore.indices, inplace=True)
-    matrix_store = project_storage.matrix_storage_engine().get_store(filename_friendly_hash(metadata))
+    matrix_store = (project_storage.matrix_storage_engine()
+                    .get_store(filename_friendly_hash(metadata)))
     matrix_store.metadata = metadata
     new_matrix = matrix.copy()
     labels = new_matrix.pop(matrix_store.label_column_name)
@@ -378,7 +387,8 @@ def sample_config():
     ]
 
     cohort_config = {
-        "query": "select distinct(entity_id) from events where '{as_of_date}'::date >= outcome_date",
+        "query": "select distinct(entity_id) from events "
+                 "where '{as_of_date}'::date >= outcome_date",
         "name": "has_past_events",
     }
 
@@ -418,3 +428,89 @@ def assert_plot_figures_added():
     yield
     num_figures_after = plt.gcf().number
     assert num_figures_before < num_figures_after
+
+
+class CallSpy:
+    """Callable-wrapper and -patcher to record invocations.
+
+    ``CallSpy``, (unlike ``Mock``), makes it easy to wrap callables for
+    the express purpose of recording how they're invoked – without
+    modifying functionality. And ``CallSpy``, (unlike ``Mock``),
+    reproduces the descriptor interface, such that methods can be
+    patched and proxied for this purpose, as easily as functions.
+
+    For example, as a context manager::
+
+        with CallSpy('my_module.MyClass.my_method') as spy:
+            ...
+
+        assert (('arg0',), {'param0': 0}) in spy.calls
+
+    """
+    def __init__(self, signature):
+        self.calls = []
+        self.signature = signature
+
+    @cachedproperty
+    def target_path(self):
+        return self.signature.split('.')
+
+    @cachedproperty
+    def target_name(self):
+        return self.target_path[-1]
+
+    @cachedproperty
+    def target_base(self):
+        # walk target path until can no longer import it as a module path
+        for index in range(len(self.target_path)):
+            path_parts = self.target_path[:(index + 1)]
+            import_path = '.'.join(path_parts)
+
+            try:
+                base = importlib.import_module(import_path)
+            except ImportError:
+                # we've imported all that we can import
+                # walk the remainder by attribute access
+                remainder = self.target_path[index:-1]
+                for part in remainder:
+                    base = getattr(base, part)
+
+                return base
+
+        raise ValueError(f"cannot patch signature {self.signature!r}")
+
+    @cachedproperty
+    def target_object(self):
+        return getattr(self.target_base, self.target_name)
+
+    @cachedproperty
+    def patch(self):
+        return mock.patch.object(self.target_base, self.target_name, new=self)
+
+    def start(self):
+        if not callable(self.target_object):
+            # 1. ensure target_object set before patching
+            # 2. check that it's sane (needn't be done here but reasonable)
+            raise TypeError(f"signature target not callable {self.target_object!r}")
+
+        self.patch.start()
+
+    def stop(self):
+        self.patch.stop()
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.target_object(*args, **kwargs)
+
+    def __get__(self, instance, cls=None):
+        if instance is None:
+            return self
+
+        return functools.partial(self, instance)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.stop()

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -1,12 +1,20 @@
 # coding: utf-8
 
-import os
-from os.path import dirname
-import pathlib
+import itertools
 import logging
+import os
+import pathlib
 from contextlib import contextmanager
-from sklearn.externals import joblib
+from os.path import dirname
 from urllib.parse import urlparse
+
+import gzip
+import pandas as pd
+import s3fs
+import wrapt
+import yaml
+from sklearn.externals import joblib
+
 from triage.component.results_schema import (
     TestEvaluation,
     TrainEvaluation,
@@ -14,12 +22,6 @@ from triage.component.results_schema import (
     TrainPrediction,
 )
 from triage.util.pandas import downcast_matrix
-
-import pandas as pd
-import s3fs
-import yaml
-from boto3.s3.transfer import TransferConfig
-import gzip
 
 
 class Store(object):
@@ -72,9 +74,6 @@ class Store(object):
         raise NotImplementedError
 
 
-GB = 1024 ** 3
-
-
 class S3Store(Store):
     """Store an object in S3.
 
@@ -91,22 +90,29 @@ class S3Store(Store):
         **config: arguments to be passed to the S3Fs client constructor.
 
     """
-    transfer_multipart_threshold = 5 * GB
+    class S3FileWrapper(wrapt.ObjectProxy):
+
+        # don't allow wrapped object to take wrapper's place
+        # upon __enter__
+        def __enter__(self):
+            return self
+
+        def write(self, data, block_size=(5 * 2 ** 20)):
+            out = 0
+
+            for offset in itertools.count(0, block_size):
+                chunk = data[offset:(offset + block_size)]
+
+                if not chunk:
+                    return out
+
+                out += self.__wrapped__.write(chunk)
 
     def __init__(self, path_head, *path_parts, **config):
         self.path = str(
             pathlib.PurePosixPath(path_head.replace('s3://', ''),
                                   *path_parts)
         )
-
-        default_addl_kwargs = {
-            'Config': TransferConfig(
-                multipart_threshold=self.transfer_multipart_threshold,
-            ),
-        }
-        user_addl_kwargs = config.get('s3_additional_kwargs', {})
-        config['s3_additional_kwargs'] = dict(default_addl_kwargs, **user_addl_kwargs)
-
         self.config = config
 
     @property
@@ -120,7 +126,11 @@ class S3Store(Store):
         self.client.rm(self.path)
 
     def open(self, *args, **kwargs):
-        return self.client.open(self.path, *args, **kwargs)
+        # NOTE: remove S3FileWrapper as soon as s3fs properly
+        # NOTE: chunks out too-large writes
+        # NOTE: see also: tests.catwalk_tests.test_storage.test_S3Store_large
+        s3file = self.client.open(self.path, *args, **kwargs)
+        return self.S3FileWrapper(s3file)
 
 
 class FSStore(Store):


### PR DESCRIPTION
## Ensure ``S3Store`` does not attempt to write too-large chunks to S3 (5+ GiB)

### Changes

Underlying library ``s3fs`` automatically writes objects to S3 in "chunks"
or "parts" -- *i.e.* via multipart upload -- in line with S3's *minimum*
limit for multipart of 5 MiB.

This should, in general, avoid S3's *maximum* limit per (part) upload of
5 GiB. **However**, ``s3fs`` assumes that no *single* ``write()`` might
exceed the maximum, and as such fails to chunk out such too-large upload
requests prompted by singular writes of 5+ GiB.

This can and should be resolved in ``s3fs``. But first, it can, should
be and is resolved here in ``S3Store``.

resolves #530

### Testing

In addition to the included unit test, a functional test script was composed – currently uploaded to Gist as [test_store.py](https://gist.github.com/jesteria/079df79e0e591209aa6028053d720426).

In its default, incremental mode, the functional test found no issue – writing to ``s3fs`` in chunks under 5 GiB is no problem.

On the other hand, the following command to test a single 6 GiB write…

```sh
$ AWS_PROFILE=dsapp-ddj time nice -n 3 \
    python test_store.py --assert-type=S3Store --method=full -l 6GiB \
    s3://review.dssg.io/test.6GiB.full.dat
```

…resulted in:

    OSError: Write failed: review.dssg.io/test.6GiB.full.dat

…itself caused by:

    botocore.exceptions.ClientError: An error occurred (EntityTooLarge) when calling the PutObject operation: Your proposed upload exceeds the maximum allowed size

Only with the included changeset, the above command succeeded in [writing the object to S3](https://s3-us-west-2.amazonaws.com/review.dssg.io/test.6GiB.full.dat), with the timing output:

```sh
139.18user 55.41system 1:17:30elapsed 4%CPU (0avgtext+0avgdata 6845376maxresident)k
0inputs+48outputs (0major+7931521minor)pagefaults 0swaps
```

(It certainly wasn't quick, but it was memory-stable. In the error case, RAM use exploded and threatened system stability – perhaps due to the payload being passed around and even copied by error handlers.)

### Further consideration

It is important to cover this edge case and ensure that we can write 5+ GiB strings as necessary. However, it would be best (at least for memory stability) that we not attempt to, as possible.

A cursory look over the codebase brought this back to the fore, in [`triage.component.catwalk.storage.CSVMatrixStore.save`](https://github.com/dssg/triage/blob/11ee0444546137e21cd53d99b2601a1afe1c1a9b/src/triage/component/catwalk/storage.py#L578):

```python
self.matrix_base_store.write(gzip.compress(self.full_matrix_for_saving.to_csv(None).encode("utf-8")))
```

I remember that it _was_ attempted to write the above without storing entire payloads at once in memory, (_e.g._ to pass the file object to `gzip` such that it could write to it iteratively according to standard buffering); however, this option was put aside, (likely for good reason).

That said, we should seriously consider ways to maintain such standard buffering interactions, in lieu of working entirely in RAM, where possible, (at least to better avoid such edge cases and limitations).