### PR TITLE
Don't auto-upgrade db for new Experiments [Resolves #695]

### DIFF
--- a/src/tests/results_tests/test_upgrade_if_clean.py
+++ b/src/tests/results_tests/test_upgrade_if_clean.py
@@ -5,7 +5,7 @@ import pytest
 
 def test_upgrade_if_clean_upgrades_if_clean(db_engine):
     results_schema.upgrade_if_clean(db_engine.url)
-    db_version = list(db_engine.execute("select version_num from results_schema_versions"))[0][0]
+    db_version = db_engine.execute("select version_num from results_schema_versions").scalar()
     alembic_cfg = results_schema.alembic_config(db_engine.url)
     assert db_version == script.ScriptDirectory.from_config(alembic_cfg).get_current_head()
 

--- a/src/tests/results_tests/test_upgrade_if_clean.py
+++ b/src/tests/results_tests/test_upgrade_if_clean.py
@@ -1,0 +1,17 @@
+from triage.component import results_schema
+from alembic import command, script
+import pytest
+
+
+def test_upgrade_if_clean_upgrades_if_clean(db_engine):
+    results_schema.upgrade_if_clean(db_engine.url)
+    db_version = list(db_engine.execute("select version_num from results_schema_versions"))[0][0]
+    alembic_cfg = results_schema.alembic_config(db_engine.url)
+    assert db_version == script.ScriptDirectory.from_config(alembic_cfg).get_current_head()
+
+
+def test_upgrade_if_clean_does_not_upgrade_if_not_clean(db_engine):
+    command.upgrade(results_schema.alembic_config(dburl=db_engine.url), "head")
+    command.downgrade(results_schema.alembic_config(dburl=db_engine.url), "-1")
+    with pytest.raises(ValueError):
+        results_schema.upgrade_if_clean(db_engine.url)

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -108,7 +108,7 @@ def upgrade_if_clean(dburl):
         logging.info("Database's results schema version is %s", current_revision)
         triage_head = script_.get_current_head()
         logging.info("Code's results schema version is %s", triage_head)
-        database_is_ahead = current_revision not in set(migration.revision for migration in script_.walk_revisions())
+        database_is_ahead = not any(migration.revision == current_revision for migration in script_.walk_revisions())
         if database_is_ahead:
             raise ValueError(
                 "Your database's results schema version, %s, is not a known revision to this"

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -99,7 +99,7 @@ def upgrade_if_clean(dburl):
     engine = create_engine(dburl)
     script_ = script.ScriptDirectory.from_config(alembic_cfg)
     if not table_exists('results_schema_versions', engine):
-        logging.info("No results_schema_versions table exists, which means that this installation"
+        logging.info("No results_schema_versions table exists, which means that this installation "
                      "is fresh. Upgrading db.")
         upgrade_db(dburl=dburl)
         return

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -104,7 +104,7 @@ def upgrade_if_clean(dburl):
         upgrade_db(dburl=dburl)
         return
     with engine.begin() as conn:
-        current_revision = list(conn.execute('select version_num from results_schema_versions limit 1'))[0][0]
+        current_revision = conn.execute('select version_num from results_schema_versions limit 1').scalar()
         logging.info("Database's results schema version is %s", current_revision)
         triage_head = script_.get_current_head()
         logging.info("Code's results schema version is %s", triage_head)

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -114,7 +114,7 @@ def upgrade_if_clean(dburl):
                 "Your database's results schema version, %s, is not a known revision to this"
                 "version of Triage knows about. Usually, this happens if you use a branch with a"
                 "new results schema version and upgrade the database to that version. To use this"
-                "version of Triage, you will likely need to check out that branch out"
+                "version of Triage, you will likely need to check out that branch out "
                 "and downgrade to %s",
                 current_revision,
                 triage_head

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -104,29 +104,33 @@ def upgrade_if_clean(dburl):
         upgrade_db(dburl=dburl)
         return
     with engine.begin() as conn:
-        current_revision = conn.execute('select version_num from results_schema_versions limit 1').scalar()
+        current_revision = conn.execute(
+            'select version_num from results_schema_versions limit 1'
+        ).scalar()
         logging.info("Database's results schema version is %s", current_revision)
         triage_head = script_.get_current_head()
         logging.info("Code's results schema version is %s", triage_head)
-        database_is_ahead = not any(migration.revision == current_revision for migration in script_.walk_revisions())
+        database_is_ahead = not any(
+            migration.revision == current_revision
+            for migration in script_.walk_revisions()
+        )
         if database_is_ahead:
             raise ValueError(
-                "Your database's results schema version, %s, is not a known revision to this"
-                "version of Triage knows about. Usually, this happens if you use a branch with a"
-                "new results schema version and upgrade the database to that version. To use this"
-                "version of Triage, you will likely need to check out that branch out "
-                "and downgrade to %s",
-                current_revision,
-                triage_head
+                f"Your database's results schema version, {current_revision}, is not a known "
+                "revision to this version of Triage. Usually, this happens if you use a branch "
+                "with a new results schema version and upgrade the database to that version. "
+                "To use this version of Triage, you will likely need to check out that branch "
+                f"and downgrade to {triage_head}",
             )
         elif current_revision != triage_head:
             raise ValueError(
-                "Your database's results schema revision, %s, does not equal the revision used"
-                "by this version of Triage. However, your database can be upgraded to this "
-                "revision. If you would like to upgrade the database, call "
-                "`triage db upgrade` if this is installed version of Triage, or "
-                "`manage alembic upgrade head` if this is a cloned Triage repository."
-                "The database changes may take a long time if this is a heavily populated database"
+                f"Your database's results schema revision, {current_revision}, is out of date "
+                "for this version of Triage. However, your database can be upgraded to this "
+                "revision. If you would like to upgrade your database from the console, and "
+                "you've installed Triage, you may execute `triage db upgrade`. "
+                "If the `triage` command is unavailable, (because you are running Triage directly "
+                " from a repository checkout), then `manage alembic upgrade head`. "
+                "The database changes may take a long time on a heavily populated database. "
                 "Otherwise, you can also downgrade your Triage version to match your database."
             )
 

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -127,7 +127,7 @@ class ExperimentBase(ABC):
         self.save_predictions = save_predictions
         self.skip_validation = skip_validation
         self.db_engine = db_engine
-        results_schema.upgrade_db(db_engine=self.db_engine)
+        results_schema.upgrade_if_clean(dburl=self.db_engine.url)
 
         self.features_schema_name = "features"
         self.materialize_subquery_fromobjs = materialize_subquery_fromobjs


### PR DESCRIPTION
To avoid the problem of time-consuming database upgrades happening when
we don't want them, the Experiment now:

1. Checks to see if the results_schema_versions table exists at all. if
it doesn't exist, upgrade. This is because means the results schema
should be clean in this case, and new users won't have to always run a
new thing when they first try Triage.
2. If it does exist, and the version number doesn't match what the
code's current HEAD revision is, throw an error. The error message is
customized to whether the database revision is a known revision to the
code (easy case, just upgrade if you have time) or not (you probably
upgraded on a different branch and need to go check out that branch to
downgrade).