### PR TITLE
Add more user database management options to CLI [Resolves #697]

### DIFF
--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -383,12 +383,12 @@ class Crosstabs(Command):
 class Db(Command):
     """Manage experiment database"""
 
-    @cmdmethod("revision", help="database schema revision to upgrade to (see triage db history)")
+    @cmdmethod("-r", "--revision", default="head", help="database schema revision to upgrade to (see triage db history)")
     def upgrade(self, args):
         """Upgrade triage results database"""
         upgrade_db(revision=args.revision, dburl=self.root.db_url)
 
-    @cmdmethod("revision", help="database schema revision to downgrade to (see triage db history)")
+    @cmdmethod("-r", "--revision", default="-1", help="database schema revision to downgrade to (see triage db history)")
     def downgrade(self, args):
         """Downgrade triage results database"""
         downgrade_db(revision=args.revision, dburl=self.root.db_url)

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -13,7 +13,7 @@ from sqlalchemy.engine.url import URL
 from triage.component.architect.feature_generators import FeatureGenerator
 from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator
 from triage.component.audition import AuditionRunner
-from triage.component.results_schema import upgrade_db, stamp_db, REVISION_MAPPING
+from triage.component.results_schema import upgrade_db, stamp_db, db_history, downgrade_db
 from triage.component.timechop.plotting import visualize_chops
 from triage.component.catwalk.storage import CSVMatrixStore, Store, ProjectStorage
 from triage.experiments import (
@@ -383,29 +383,37 @@ class Crosstabs(Command):
 class Db(Command):
     """Manage experiment database"""
 
-    @cmdmethod
+    @cmdmethod("revision", help="database schema revision to upgrade to (see triage db history)")
     def upgrade(self, args):
         """Upgrade triage results database"""
-        upgrade_db(dburl=self.root.db_url)
+        upgrade_db(revision=args.revision, dburl=self.root.db_url)
 
-    @cmdmethod(
-        "configversion",
-        choices=REVISION_MAPPING.keys(),
-        help="config version of last experiment you ran",
-    )
+    @cmdmethod("revision", help="database schema revision to downgrade to (see triage db history)")
+    def downgrade(self, args):
+        """Downgrade triage results database"""
+        downgrade_db(revision=args.revision, dburl=self.root.db_url)
+
+    @cmdmethod("revision", help="database schema revision to stamp to (see triage db history)")
     def stamp(self, args):
-        """Instruct the triage results database to mark itself as updated to a
-        known version without doing any upgrading.
+        """Mark triage results database as updated to a known version without doing any upgrading.
 
-        Use this if the database was created without an 'alembic_version' table.
-        Uses the config version of your experiment to infer what database version is suitable.
+        The revision can be anything alembic recognizes, such as a specific revision or 'head' (the most recent revision in the current codebase)
+
+        This is most useful if the database was created without a 'results_schema_versions' table (i.e. old versions of triage that didn't enforce alembic use), but could also be useful after general database mangling.
+
+        If you don't know what the right revision is, here are some database revisions that old experiment configs are associated with:
+            - no config version: 8b3f167d0418
+            - v1 or v2: 72ac5cbdca05
+            - v3: 7d57d1cf3429
+            - v4: 89a8ce240bae
+            - v5: 2446a931de7a
         """
-        revision = REVISION_MAPPING[args.configversion]
-        print(
-            f"Based on config version {args.configversion} "
-            f"we think your results schema is version {revision} and are upgrading to it"
-        )
-        stamp_db(revision, dburl=self.root.db_url)
+        stamp_db(revision=args.revision, dburl=self.root.db_url)
+
+    @cmdmethod
+    def history(self, args):
+        """Show triage results database history"""
+        db_history(dburl=self.root.db_url)
 
 
 def execute():

--- a/src/triage/component/results_schema/__init__.py
+++ b/src/triage/component/results_schema/__init__.py
@@ -65,28 +65,30 @@ def _base_alembic_args(db_config_filename=None):
     return base
 
 
-def upgrade_db(db_engine=None, dburl=None):
+def upgrade_db(db_engine=None, dburl=None, revision="head"):
     if db_engine:
-        command.upgrade(alembic_config(dburl=db_engine.url), "head")
+        command.upgrade(alembic_config(dburl=db_engine.url), revision)
     elif dburl:
-        command.upgrade(alembic_config(dburl=dburl), "head")
+        command.upgrade(alembic_config(dburl=dburl), revision)
     else:
         raise ValueError("Must pass either a db_config_filehandle or a db_engine or a dburl")
 
 
-REVISION_MAPPING = {
-    "v1": "72ac5cbdca05",  # may add some logic to tag earlier ones if needed, could be 26 or 0d
-    "v2": "72ac5cbdca05",
-    "v3": "7d57d1cf3429",
-    "v4": "89a8ce240bae",
-    "v5": "2446a931de7a",
-    "pre-v1": "8b3f167d0418",
-}
+def downgrade_db(db_engine=None, dburl=None, revision="-1"):
+    if db_engine:
+        command.downgrade(alembic_config(dburl=db_engine.url), revision)
+    elif dburl:
+        command.downgrade(alembic_config(dburl=dburl), revision)
+    else:
+        raise ValueError("Must pass either a db_config_filehandle or a db_engine or a dburl")
 
 
 def stamp_db(revision, dburl):
     command.stamp(alembic_config(dburl=dburl), revision)
 
+
+def db_history(dburl):
+    command.history(alembic_config(dburl=dburl))
 
 def alembic_config(dburl):
     path = os.path.abspath(__file__)


### PR DESCRIPTION
In recent weeks/months, more operations on the results schema have
proven to be things that are useful to 'users' (people who use the
'triage' command), not just 'developers' (people who use the 'manage'
command). These include: stamping to a specific revision, downgrading,
upgrading to a specific revision, and even just viewing the revision history.
Here we allow the `triage db` command to interface with
alembic to do these things.

Furthermore, the old 'stamp' logic in `triage db` isn't terribly useful
now that we have been on alembic for a while, and pinning it to
experiment config versions wasn't very useful. Using the standard
alembic revisions for stamping I think makes more sense, but I copied
the dictionary from before into the help text for 'stamp' because it
could still be helpful.

- Modify old `triage db stamp` logic to use standard alembic revisions
- Enable `triage db upgrade` to take a revision (but default to HEAD)
- Add `triage db downgrade` that takes a revision
- Add `triage db history` to show revisions