### PR TITLE
Update MANIFEST.in to include presets

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ recursive-include src alembic.ini
 recursive-include src model_group_stored_procedure.sql
 recursive-include src/tests *
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+recursive-include src *.yaml
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
WIth the new defaults schema, `model_grid_presets.yaml` should be included in the installation