### PR TITLE
check for default db config file before falling back to env var

### DIFF
--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -77,13 +77,12 @@ class Triage(RootCommand):
     def db_url(self):
         if self.args.dbfile:
             dbfile = self.args.dbfile
+        elif os.path.isfile(self.DATABASE_FILE_DEFAULT):
+            dbfile = open(self.DATABASE_FILE_DEFAULT)
         else:
             environ_url = os.getenv('DATABASE_URL')
             if environ_url:
                 return environ_url
-
-            if os.path.isfile(self.DATABASE_FILE_DEFAULT):
-                dbfile = open(self.DATABASE_FILE_DEFAULT)
             else:
                 raise EnvironmentError(
                     f"could not determine database connection information from "


### PR DESCRIPTION
The current CLI behavior falls back to the `DATABASE_URL` environment variable before checking for `database.yaml` in its default location. However, this doesn't quite line up with our documentation and could create unexpected behavior, especially for users with multiple triage projects or who have the environment variable set for other reasons.