### PR TITLE
fix feature_importances bug with single-coefficient models

### DIFF
--- a/src/triage/component/catwalk/feature_importances.py
+++ b/src/triage/component/catwalk/feature_importances.py
@@ -63,4 +63,8 @@ def get_feature_importances(model):
 
         feature_importances = _ad_hoc_feature_importances(model)
 
+    # if we just ended up with a scalar (e.g., single feature logit), ensure we return an array
+    if isinstance(feature_importances, np.ndarray) and feature_importances.shape == ():
+        feature_importances = feature_importances.reshape((1,))
+
     return feature_importances

--- a/src/triage/component/catwalk/feature_importances.py
+++ b/src/triage/component/catwalk/feature_importances.py
@@ -32,6 +32,9 @@ def _ad_hoc_feature_importances(model):
         # NOTE: We need to squeeze this array so it has the correct dimensions
         feature_importances = coef_odds_ratio.squeeze()
 
+    elif isinstance(model, (SVC)) and (model.get_params()["kernel"] == "linear"):
+        feature_importances = model.coef_.squeeze()
+
     return feature_importances
 
 
@@ -49,9 +52,6 @@ def get_feature_importances(model):
 
     if hasattr(model, "feature_importances_"):
         feature_importances = model.feature_importances_
-
-    elif isinstance(model, (SVC)) and (model.get_params()["kernel"] == "linear"):
-        feature_importances = model.coef_.squeeze()
 
     else:
         warnings.warn(


### PR DESCRIPTION
Some models returning a single feature importance value (e.g., logistic regressions with one feature) were returning a scalar rather than an array, causing catwalk to fail when trying to write these models to the database and no predictions to be produced. This is in particular an issue with our new QuickStart Guide and Dirty Duckling Tutorial.

This PR simply checks the results for scalar values and reshapes them into an array with length of 1.