### PR TITLE
Docs/bugfix

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -7,8 +7,8 @@ theme:
   font:
     text: 'Ubuntu'
     code: 'Ubuntu Mono'
-  logo:
-    icon: 'book'
+  icon:
+    logo: ./material/book
   favicon: 'assets/images/favicon.ico'
 
 docs_dir: sources
@@ -19,11 +19,11 @@ site_description: 'Documentation for Triage.'
 
 extra:
   social:
-    - type: 'github'
+    - icon: fontawesome/brands/github
       link: 'https://github.com/dssg/triage'
-    - type: 'twitter'
+    - icon: fontawesome/brands/twitter
       link: 'https://twitter.com/datascifellows'
-    - type: 'linkedin'
+    - icon: fontawesome/brands/linkedin
       link: 'https://linkedin.com/company/center-for-data-science-and-public-policy-university-of-chicago'
 
 

--- a/manage.py
+++ b/manage.py
@@ -33,5 +33,4 @@ class Docs(Local):
     """View Triage documentation through local server"""
     def prepare(self, args):
         yield plumlocal['python']['docs/update_docs.py']
-        with plumlocal.cwd(ROOT_PATH / 'docs'):
-            yield plumlocal['mkdocs']['serve']
+        yield plumlocal['mkdocs']['serve']['-f']['docs/mkdocs.yml']


### PR DESCRIPTION
- Fixes problem with mkdocstrings caused by running `mkdocs serve` outside of the triage root directory
- Updates `mkdocs.yml` for compatibility with `mkdocs-material` 5.0.0