### PR TITLE
GitHub action test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,6 @@ jobs:
         pip install flake8 pytest
         pip install -r requirement/include/build.txt
         pip install -r requirement/include/test-management.txt
-    - name: Test with pytest
+    - name: Test with tox
       run: |
-        pytest
+        tox

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,12 +40,6 @@ jobs:
         pip install flake8 pytest
         pip install -r requirement/include/build.txt
         pip install -r requirement/include/test-management.txt
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-	services:
+    services:
       # Label used to access the service container
       postgres:
         # Docker Hub image
@@ -30,8 +30,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-	- name: Install system dependencies
-	  run: |
+    - name: Install system dependencies
+      run: |
         sudo apt-get update
         sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
     - name: Install dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,51 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+	services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+	- name: Install system dependencies
+	  run: |
+        sudo apt-get update
+        sudo apt-get install libblas-dev liblapack-dev libatlas-base-dev gfortran
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        pip install -r requirement/include/build.txt
+        pip install -r requirement/include/test-management.txt
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest


### PR DESCRIPTION
Travis doesn't appear to be working right now, so I got the test suite going with Github actions. This doesn't include PyPI upload or documentation site upload, but I think we can do those in a separate pull request. Now that we're doing a Triage sprint, having something automatically run our tests seems pretty high value, so I'd rather get this merged ASAP for the benefit of the sprint. 