### PR TITLE
remove project path from model hash

### DIFF
--- a/src/triage/component/catwalk/model_trainers.py
+++ b/src/triage/component/catwalk/model_trainers.py
@@ -86,6 +86,7 @@ class ModelTrainer:
         same attributes there would be no reason to keep the old one)
 
         Args:
+        matrix_metadata (dict): metadata associated with training matrix for this model
         class_path (string): a full class path for the classifier
         parameters (dict): all hyperparameters to be passed to the classifier
         random_seed (int) an integer suitable for seeding the random generator before training
@@ -96,7 +97,6 @@ class ModelTrainer:
         unique = {
             "className": class_path,
             "parameters": self.unique_parameters(parameters),
-            "project_path": self.model_storage_engine.project_storage.project_path,
             "training_metadata": matrix_metadata,
             "random_seed": random_seed,
         }


### PR DESCRIPTION
Looks like this should be all we have to do to remove the project path from the model hash, but we may want to bump the version when brining this in since the model hashes won't be backwards-compatible with runs from current versions of triage.