### PR TITLE
WIP: Sort Default Feature Group Definition

### DIFF
--- a/src/triage/experiments/defaults.py
+++ b/src/triage/experiments/defaults.py
@@ -97,7 +97,7 @@ def fill_feature_group_definition(config):
     if not feature_group_definition:
         feature_aggregations = config['feature_aggregations']
 
-        feature_group_definition['prefix'] = list({agg['prefix'] for agg in feature_aggregations})
+        feature_group_definition['prefix'] = sorted(list({agg['prefix'] for agg in feature_aggregations}))
 
     return feature_group_definition
 


### PR DESCRIPTION
I believe this should fix the bug Evan identified in #832

However, one question before merging: is there any good reason for the default to not simply be:
```python
feature_group_definition['all'] = [True]
```

The `FeatureGroupCreator` already has an `all` subsetter that we could take advantage of rather than recreating the logic here. However, if we do that, I wonder if we want to explicitly sort the group names in creating the matrix metadata [here](https://github.com/dssg/triage/blob/2238b0fd864e6c39b9f0ae91a7245206e0cf310a/src/triage/component/architect/planner.py#L89) -- the main reason I didn't add that as well is because there might be an issue with backwards compatibility changing existing matrix hashses. That might not be a huge deal if we merge/tag at the same time as #830 however.