### PR TITLE
Dependency updates

### DIFF
--- a/requirement/dev.txt
+++ b/requirement/dev.txt
@@ -2,6 +2,6 @@
 bumpversion==0.6.0
 mkdocs==1.1.2
 pymdown-extensions==7.1
-mkdocs-material==5.4.0
+mkdocs-material==7.0.6
 mkdocstrings==0.12.0
 black==19.10b0

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -1,6 +1,6 @@
 alembic==1.4.2
 SQLAlchemy==1.3.18
-PyYAML==5.3.1
+PyYAML==5.4.1
 psycopg2-binary==2.8.5
 python-dateutil==2.8.1
 boto3==1.14.45

--- a/src/tests/architect_tests/test_integration.py
+++ b/src/tests/architect_tests/test_integration.py
@@ -327,7 +327,7 @@ def basic_integration_test(
             feature_group_name_lists = []
             for metadata_path in metadatas:
                 with open(os.path.join(matrix_directory, metadata_path)) as f:
-                    metadata = yaml.full_load(f)
+                    metadata = yaml.load(f, Loader=yaml.Loader)
                     feature_group_name_lists.append(metadata["feature_groups"])
 
             for matrix_uuid, num_observations, matrix_type in matrices_records:

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -549,7 +549,7 @@ class MatrixStore:
     def load_metadata(self):
         """Load metadata from storage"""
         with self.metadata_base_store.open("rb") as fd:
-            return yaml.full_load(fd)
+            return yaml.load(fd, Loader=yaml.Loader)
 
     def save(self):
         raise NotImplementedError


### PR DESCRIPTION
Updates PyYAML and mkdocs-material to satisfy safety-ci

However, note that for loading matrix metadata I'm switching from `yaml.full_load(fd)` to `yaml.load(fd, Loader=yaml.Loader)` which isn't ideal. Based on the errors I was getting, it seems that in order to stick with `full_load`, we would need to define representers and constructors specifically for the `AsOfTimeList` and `FeatureNameList` (see the [example here](https://pyyaml.org/wiki/PyYAMLDocumentation)). Note that doing so would lose the ability to load matrix metadata from previous versions of triage (though a utility to upgrade old metadata files probably wouldn't be too difficult to write).

@thcrock -- would appreciate your thoughts here.