### PR TITLE
Triage database provisioner

### DIFF
--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -13,7 +13,7 @@ Dickens==1.0.1
 signalled-timeout==1.0.0
 s3fs==0.4.2
 wrapt==1.12.1
-argcmdr==0.6.0
+argcmdr==0.7.0
 sqlparse==0.3.1
 pebble==4.5.3
 adjustText==0.7.3


### PR DESCRIPTION
Not quite ready for merge (I would add some documentation around this and maybe clean up the code a bit), but I wanted to get thoughts on this interface for a local Dockerized database provisioner. The idea is Triage users could use this to easily set up a database outside of a Dirtyduck context but without having to do Postgres on their own. With just docker as a dependency, they can:
1. Bring up the thing from scratch; build the image, run Postgres through the image, and write a database.yaml file using the credentials created by the script.
2. Start the container if if stopped
3. Rebuild the container if it was removed

All using the command 'triage db up'.

Note: I don't know what's going on with the Crosstabs CLI but I couldn't get this to run while using those imports. Did that crosstab code get removed? It's obviously unrelated to this PR but if I can't run the CLI with those lines in there I had to take them out.