### PR TITLE
Allow specifying both preset and user-specified model grids

### DIFF
--- a/docs/sources/triage_project_workflow.md
+++ b/docs/sources/triage_project_workflow.md
@@ -243,7 +243,7 @@ grid_config:
         min_samples_leaf: [0.01,0.05,0.10]
 ```
 
-Here, each top-level key is the modeling package (this needs to be a classification algorithm with a `scikit-learn`-style interface, but need not come from `scikit-learn` specifically), and the keys listed under it are hyperparameters of the algorithm with a list of values to test. `triage` will run the grid of all possible combinations of these hyperparameter values. Note that you can't specify both a `model_grid_preset` and `grid_config` at the same time.
+Here, each top-level key is the modeling package (this needs to be a classification algorithm with a `scikit-learn`-style interface, but need not come from `scikit-learn` specifically), and the keys listed under it are hyperparameters of the algorithm with a list of values to test. `triage` will run the grid of all possible combinations of these hyperparameter values. Note that if you specify both a `model_grid_preset` and `grid_config` at the same time, triage will combine the unique model specifications across the two sets (generally, this is most useful when adding project-specific commonsense baselines to the preset grid).
 
 Check out the [example config file](https://github.com/dssg/triage/blob/master/example/config/experiment.yaml) for more details on specifying your grid.
 

--- a/example/config/experiment.yaml
+++ b/example/config/experiment.yaml
@@ -432,7 +432,11 @@ individual_importance:
 # named: quickstart, small, medium, large
 # See the documentation for recommended uses cases for those.
 #
-# If you set this configuration section you SHOULD NOT include the grid_config section
+# If you set this configuration section you DO NOT NEED TO include the grid_config section.
+# However, you MAY optionally include both sections if you want to add additional model types
+# to the preset grid. Generally, this is most useful for including additional commonsense
+# baselines that are specific to your project.
+#
 # model_grid_presets: ['small']
 
 
@@ -448,7 +452,8 @@ individual_importance:
 # classifiers and hyperparameters are trained.
 #
 # NOTE: Triage now include a new parameter named 'model_grid_presets' (see above)
-# you can't have both at the same time. The experiment will fail if you forget this.
+# If you include both, triage will combine the unique model specifications across
+# the preset and user-specified grids.
 #
 grid_config:
     'sklearn.ensemble.ExtraTreesClassifier':

--- a/example/config/experiment.yaml
+++ b/example/config/experiment.yaml
@@ -437,7 +437,7 @@ individual_importance:
 # to the preset grid. Generally, this is most useful for including additional commonsense
 # baselines that are specific to your project.
 #
-# model_grid_presets: ['small']
+# model_grid_preset: 'small'
 
 
 # GRID CONFIGURATION
@@ -451,7 +451,7 @@ individual_importance:
 # each value is a list of potential values. All possible combinations of
 # classifiers and hyperparameters are trained.
 #
-# NOTE: Triage now include a new parameter named 'model_grid_presets' (see above)
+# NOTE: Triage now include a new parameter named 'model_grid_preset' (see above)
 # If you include both, triage will combine the unique model specifications across
 # the preset and user-specified grids.
 #

--- a/src/tests/test_defaults.py
+++ b/src/tests/test_defaults.py
@@ -121,5 +121,7 @@ def test_fill_model_grid_presets():
     # case 4: both
     config = sample_config()
     config['model_grid_preset'] = 'quickstart'
-    with pytest.raises(KeyError):
-        fill_grid = fill_model_grid_presets(config)
+    fill_grid = fill_model_grid_presets(config)
+    assert len(fill_grid) == 3
+    assert len(fill_grid.get('sklearn.tree.DecisionTreeClassifier', {}).get('max_depth', [])) == 3
+    assert len(fill_grid.get('sklearn.tree.DecisionTreeClassifier', {}).get('criterion', [])) == 1

--- a/src/triage/experiments/defaults.py
+++ b/src/triage/experiments/defaults.py
@@ -115,20 +115,20 @@ def fill_model_grid_presets(config):
     preset_type = config.get('model_grid_preset')
 
     if preset_type is not None:
-        if grid_config is not None:
-            # if you specified both grid_config and model_grid_preset, you're doing something wrong
-            raise KeyError("There can only be one (cannot specify both model_grid_preset and grid_config)")
-        grid_config = model_grid_preset(preset_type)
+        grid_config = model_grid_preset(preset_type, grid_config)
 
     return grid_config
 
 
-def model_grid_preset(grid_type):
+def model_grid_preset(grid_type, grid_config=None):
     """Load a preset model grid.
 
        Args:
             grid_type (string) The type of preset grid to load. May
                 by `quickstart`, `small`, `medium`, `large`, or `texas`
+            grid_config (dict) The user-specified model grid, allowing
+                users to extend a preset grid with other models, such
+                as common-sense baselines specific to their project
 
         Returns: (dict) a triage model grid config
     """
@@ -137,10 +137,11 @@ def model_grid_preset(grid_type):
     with open(presets_file, 'r') as f:
         model_grid_presets = yaml.full_load(f)
 
-    # output is a collector for the resulting grid, so initialize it with the parameters
-    # at the level of preset grid we want and find the next-lowest level to incorporate
-    output = model_grid_presets[grid_type]['grid'].copy()
-    prev_type = model_grid_presets[grid_type]['prev']
+    # output is a collector for the resulting grid, so initialize with the user-specified
+    # triage grid (if present), otherwise start with an empty dict. We initialize
+    # prev_type with the preset grid type to start crawling the presets at that point
+    output = (grid_config or {}).copy()
+    prev_type = grid_type
 
     # collapse the grid parameters down the levels until we reach one with no lower level
     while prev_type is not None:


### PR DESCRIPTION
Allow users to specify both `model_grid_preset` and `grid_config` sections of the experiment config, combining the unique model types and specifications across them. In general, I think this will be most useful when you want to add project-specific baselines on top of the preset grid.