### PR TITLE
Small bugfixes for errors on test cleanup

### DIFF
--- a/src/tests/test_experiments.py
+++ b/src/tests/test_experiments.py
@@ -579,3 +579,4 @@ def test_experiment_metadata(finished_experiment):
     assert experiment_row.matrices_needed == experiment_row.time_splits * 2 * experiment_row.feature_group_combinations # x2 for train and test
     assert experiment_row.grid_size == 4
     assert experiment_row.models_needed == (experiment_row.matrices_needed/2) * experiment_row.grid_size # /2 because we only need models per train matrix
+    session.close()

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -124,7 +124,9 @@ def fake_trained_model(
     )
     session.add(db_model)
     session.commit()
-    return trained_model, db_model.model_id
+    model_id = db_model.model_id
+    session.close()
+    return trained_model, model_id
 
 
 def matrix_metadata_creator(**override_kwargs):


### PR DESCRIPTION
Fixes a small bug that was causing an exception on test cleanup on some systems by explicitly closing DB sessions when we're done with them.