### PR TITLE
Issue 864 py39

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -6,7 +6,7 @@ python-dateutil==2.8.1
 boto3==1.14.45
 click==7.1.2
 inflection==0.5.0
-numpy==1.19.0
+numpy==1.21.1
 sqlalchemy-postgres-copy==0.5.0
 retrying==1.3.3
 Dickens==1.0.1

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -14,7 +14,7 @@ signalled-timeout==1.0.0
 s3fs==0.4.2
 wrapt==1.12.1
 argcmdr==0.7.0
-sqlparse==0.3.1
+sqlparse==0.4.2
 pebble==4.5.3
 adjustText==0.7.3
 graphviz==0.14

--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -1,4 +1,3 @@
-from contextlib import contextmanager
 from triage.component.catwalk import ModelTrainTester, Predictor, ModelTrainer, ModelEvaluator, IndividualImportanceCalculator, ProtectedGroupsGenerator
 from triage.component.catwalk.utils import save_experiment_and_get_hash
 from triage.component.catwalk.model_trainers import flatten_grid_config

--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -13,7 +13,7 @@ from tests.utils import (
     matrix_metadata_creator,
 )
 
-from unittest.mock import patch, create_autospec, MagicMock
+from unittest.mock import patch, MagicMock
 
 
 def test_ModelTrainTester_generate_tasks(db_engine_with_results_schema, project_storage, sample_timechop_splits, sample_grid_config):
@@ -86,17 +86,17 @@ def setup_model_train_tester(project_storage, replace, additional_bigtrain_class
         'test_store': test_matrix_store
     }
 
-    predictor = MagicMock(spec_set=create_autospec(Predictor))
-    trainer = MagicMock(spec_set=create_autospec(ModelTrainer))
+    predictor = MagicMock(spec_set=Predictor)
+    trainer = MagicMock(spec_set=ModelTrainer)
 
     @contextmanager
     def noop():
         yield
 
     trainer.cache_models = noop
-    evaluator = MagicMock(spec_set=create_autospec(ModelEvaluator))
-    individual_importance_calculator = MagicMock(spec_set=create_autospec(IndividualImportanceCalculator))
-    protected_groups_generator = MagicMock(spec_set=create_autospec(ProtectedGroupsGenerator))
+    evaluator = MagicMock(spec_set=ModelEvaluator)
+    individual_importance_calculator = MagicMock(spec_set=IndividualImportanceCalculator)
+    protected_groups_generator = MagicMock(spec_set=ProtectedGroupsGenerator)
     train_tester = ModelTrainTester(
         matrix_storage_engine=matrix_storage_engine,
         model_trainer=trainer,

--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from triage.component.catwalk import ModelTrainTester, Predictor, ModelTrainer, ModelEvaluator, IndividualImportanceCalculator, ProtectedGroupsGenerator
 from triage.component.catwalk.utils import save_experiment_and_get_hash
 from triage.component.catwalk.model_trainers import flatten_grid_config
@@ -87,6 +88,12 @@ def setup_model_train_tester(project_storage, replace, additional_bigtrain_class
 
     predictor = MagicMock(spec_set=create_autospec(Predictor))
     trainer = MagicMock(spec_set=create_autospec(ModelTrainer))
+
+    @contextmanager
+    def noop():
+        yield
+
+    trainer.cache_models = noop
     evaluator = MagicMock(spec_set=create_autospec(ModelEvaluator))
     individual_importance_calculator = MagicMock(spec_set=create_autospec(IndividualImportanceCalculator))
     protected_groups_generator = MagicMock(spec_set=create_autospec(ProtectedGroupsGenerator))
@@ -102,6 +109,10 @@ def setup_model_train_tester(project_storage, replace, additional_bigtrain_class
         additional_bigtrain_classnames=additional_bigtrain_classnames
     )
     return train_tester, train_test_task
+
+
+def noop():
+    yield
 
 
 def test_ModelTrainTester_process_task_replace_False_needs_evaluations(project_storage):

--- a/src/tests/catwalk_tests/test_integration.py
+++ b/src/tests/catwalk_tests/test_integration.py
@@ -88,12 +88,6 @@ def setup_model_train_tester(project_storage, replace, additional_bigtrain_class
 
     predictor = MagicMock(spec_set=Predictor)
     trainer = MagicMock(spec_set=ModelTrainer)
-
-    @contextmanager
-    def noop():
-        yield
-
-    trainer.cache_models = noop
     evaluator = MagicMock(spec_set=ModelEvaluator)
     individual_importance_calculator = MagicMock(spec_set=IndividualImportanceCalculator)
     protected_groups_generator = MagicMock(spec_set=ProtectedGroupsGenerator)
@@ -109,10 +103,6 @@ def setup_model_train_tester(project_storage, replace, additional_bigtrain_class
         additional_bigtrain_classnames=additional_bigtrain_classnames
     )
     return train_tester, train_test_task
-
-
-def noop():
-    yield
 
 
 def test_ModelTrainTester_process_task_replace_False_needs_evaluations(project_storage):

--- a/src/triage/component/catwalk/__init__.py
+++ b/src/triage/component/catwalk/__init__.py
@@ -195,7 +195,7 @@ class ModelTrainTester:
 
             # Generate predictions for the testing data then training data
             for store in (test_store, train_store):
-                if self.replace or self.model_evaluator.needs_evaluations(store, model_id):
+                if self.replace or self.model_evaluator.needs_evaluations(store, model_id) is True:
                     logger.spam(
                         f"Generating new predictions for "
                         f"{store.matrix_type.string_name} matrix {store.uuid}, and model {model_id} to make evaluation",

--- a/src/triage/component/catwalk/__init__.py
+++ b/src/triage/component/catwalk/__init__.py
@@ -195,7 +195,7 @@ class ModelTrainTester:
 
             # Generate predictions for the testing data then training data
             for store in (test_store, train_store):
-                if self.replace or self.model_evaluator.needs_evaluations(store, model_id) is True:
+                if self.replace or self.model_evaluator.needs_evaluations(store, model_id):
                     logger.spam(
                         f"Generating new predictions for "
                         f"{store.matrix_type.string_name} matrix {store.uuid}, and model {model_id} to make evaluation",


### PR DESCRIPTION
Removes Python3.6 support and adds up to 3.9.
Changes needed:
- numpy upgrade
- Removes create_autospec function call from catwalk integration test; it appears that simply passing the class name to spec_set works now, and create_autospec used in conjunction with this now breaks it.