### PR TITLE
Ensure attribute columns are strings in protected_df (closes #875)

### DIFF
--- a/src/triage/component/catwalk/protected_groups_generators.py
+++ b/src/triage/component/catwalk/protected_groups_generators.py
@@ -158,5 +158,6 @@ class ProtectedGroupsGenerator:
             parse_dates=["as_of_date"],
             index_col=MatrixStore.indices,
         )
+        protected_df[self.attribute_columns] = protected_df[self.attribute_columns].astype(str)
         del protected_df['cohort_hash']
         return protected_df


### PR DESCRIPTION
Closes #875 -- quick PR to ensure all attribute columns are read as strings rather than numeric datatypes when constructing the protected_df (numeric columns will cause downstream errors with the aequitas crosstabs).