### PR TITLE
Test with optional cohort, defaulting to label cohort

### DIFF
--- a/example/config/experiment.yaml
+++ b/example/config/experiment.yaml
@@ -57,13 +57,16 @@ temporal_config:
 #
 # The 'query' key should have a query, parameterized with an '{as_of_date}', to select the entity_ids that should be included for a given date. The {as_of_date} will be replaced with each as_of_date that the experiment needs. The returned 'entity_id' must be an integer.
 #
+# Optionally, this can also incldue a boolean label, in which case the label_config below is optional.
+#
 # You may enter a 'name' for your configuration.
 # This will be included in the metadata for each matrix and used to group models
 # If you don't pass one, the string 'default' will be used.
 #
-# This block is completely optional. If you don't specify it
-# it will default to all the entities in your event's tables  (from_obj in feature_aggregations).
-# The name by default in this case will be 'all_entities'
+# This block is completely optional. If you don't specify it, the labels will simply be used.
+# This means that any entities that don't show up in your label query will not be in the matrix.
+# For many applications, this may be fine but in some cases (e.g. an inspections problem
+# where not all relevant entities have had recent inspections) it is easier to keep track of these concepts separately.
 cohort_config:
     query: "select entity_id from events where outcome_date < '{as_of_date}'"
     name: 'past_events'

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -441,7 +441,7 @@ def sample_config():
         "model_comment": "test2-final-final",
         "model_group_keys": ["label_name", "label_type", "custom_key", "class_path", "parameters"],
         "feature_aggregations": feature_config,
-        "cohort_config": cohort_config,
+        #"cohort_config": cohort_config,
         "temporal_config": temporal_config,
         "grid_config": grid_config,
         "bias_audit_config": bias_audit_config,


### PR DESCRIPTION
Trying out the concept of making the cohort default to the label in order to give beginners an easy way to specify the cohort+label in one go instead of splitting. I know there is a question about whether this is the best way to message the concept to the user, but this is a very easy way to start testing. The implementation really just consists of setting the cohort table name (which is sent to everything downstream) to the label table name in these cases.

The opposite (optional label config, otherwise use the cohort as label) is possible but requires adding *and explaining* two pieces of optional items to the cohort config: the optional outcome column, but also the optional {label_timespan} parameter in the query itself. I started off doing this but had a very hard time explaining how this would work in the example config file. If people feel strongly that this is the better route we can go that route.

But here I'd like to explore starting with this as an implementation, seeing if it works, and maybe even consider changing the names of some of these config keys if it makes things more clear.

Not all the tests run yet but I did verify the basic experiment tests run without a cohort config here. 