### PR TITLE
fix link to database provisioner documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ . triage-env/bin/activate
 ## Data
 Triage needs data in a postgres database and a configuration file that has credentials for the database. The Triage CLI defaults database connection information to a file stored in 'database.yaml' (example in [example/database.yaml](https://github.com/dssg/triage/blob/master/example/database.yaml)).
 
-If you don't want to install Postgres yourself, try `triage db up` to create a vanilla Postgres 12 database using docker. For more details on this command, check out [Triage Database Provisioner](db.md)
+If you don't want to install Postgres yourself, try `triage db up` to create a vanilla Postgres 12 database using docker. For more details on this command, check out [Triage Database Provisioner](https://github.com/dssg/triage/blob/a994f3e42b3c8d4e50fce6afcf5e18ffb2c29a7a/docs/sources/db.md)
 
 ## Configure Triage for your project
 


### PR DESCRIPTION
the link in the readme was broken, but it looks like the docs site hasn't been updated in a while because the page isn't up there even though it is in mkdocs.yml