### PR TITLE
Add information about cohort, label, and bias to triage_runs

### DIFF
--- a/src/triage/component/results_schema/alembic/versions/3ce027594a5c_add_hashes_to_runs.py
+++ b/src/triage/component/results_schema/alembic/versions/3ce027594a5c_add_hashes_to_runs.py
@@ -1,0 +1,28 @@
+"""add hashes to runs
+
+Revision ID: 3ce027594a5c
+Revises: 5dd2ba8222b1
+Create Date: 2022-03-25 12:58:38.370271
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3ce027594a5c'
+down_revision = '5dd2ba8222b1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('triage_runs', sa.Column('cohort_table_name', sa.String(), nullable=True), schema='triage_metadata')
+    op.add_column('triage_runs', sa.Column('labels_table_name', sa.String(), nullable=True), schema='triage_metadata')
+    op.add_column('triage_runs', sa.Column('bias_hash', sa.String(), nullable=True), schema='triage_metadata')
+
+
+def downgrade():
+    op.drop_column('triage_runs', 'bias_hash', schema='triage_metadata')
+    op.drop_column('triage_runs', 'labels_table_name', schema='triage_metadata')
+    op.drop_column('triage_runs', 'cohort_table_name', schema='triage_metadata')

--- a/src/triage/component/results_schema/schema.py
+++ b/src/triage/component/results_schema/schema.py
@@ -126,6 +126,9 @@ class TriageRun(Base):
     current_status = Column(Enum(TriageRunStatus))
     stacktrace = Column(Text)
     random_seed = Column(Integer)
+    cohort_table_name = Column(String)
+    labels_table_name = Column(String)
+    bias_hash = Column(String)
         
 
 class Subset(Base):

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -67,6 +67,9 @@ from triage.experiments.validate import ExperimentValidator
 from triage.tracking import (
     initialize_tracking_and_get_run_id,
     experiment_entrypoint,
+    record_cohort_table_name,
+    record_labels_table_name,
+    record_bias_hash,
     record_matrix_building_started,
     record_model_building_started,
 )
@@ -287,6 +290,7 @@ class ExperimentBase(ABC):
                 "label_config missing or unrecognized. Without labels, "
                 "you will not be able to make matrices."
             )
+        record_labels_table_name(self.run_id, self.db_engine, self.labels_table_name)
 
         cohort_config = self.config.get("cohort_config", {})
         self.cohort_table_generator = None
@@ -317,6 +321,8 @@ class ExperimentBase(ABC):
                 replace=self.replace
             )
 
+        record_cohort_table_name(self.run_id, self.db_engine, self.cohort_table_name)
+
 
         if "bias_audit_config" in self.config:
             bias_config = self.config["bias_audit_config"]
@@ -331,6 +337,7 @@ class ExperimentBase(ABC):
                 protected_groups_table_name=self.protected_groups_table_name,
                 replace=self.replace
             )
+            record_bias_hash(self.run_id, self.db_engine, self.bias_hash)
         else:
             self.protected_groups_generator = ProtectedGroupsGeneratorNoOp()
             logger.notice(

--- a/src/triage/tracking.py
+++ b/src/triage/tracking.py
@@ -219,6 +219,42 @@ def record_matrix_building_started(run_id, db_engine):
         run_obj.matrix_building_started = datetime.datetime.now()
 
 
+def record_cohort_table_name(run_id, db_engine, cohort_table_name):
+    """Mark the current timestamp as the time at which matrix building started
+
+    Args:
+        run_id (int) The identifier/primary key of the run
+        db_engine (sqlalchemy.engine)
+        cohort_table_name (str) Name of the cohort table for this run
+    """
+    with get_run_for_update(db_engine, run_id) as run_obj:
+        run_obj.cohort_table_name = cohort_table_name
+
+
+def record_labels_table_name(run_id, db_engine, labels_table_name):
+    """Mark the current timestamp as the time at which matrix building started
+
+    Args:
+        run_id (int) The identifier/primary key of the run
+        db_engine (sqlalchemy.engine)
+        labels_table_name (str) Name of the labels table for this run
+    """
+    with get_run_for_update(db_engine, run_id) as run_obj:
+        run_obj.labels_table_name = labels_table_name
+
+
+def record_bias_hash(run_id, db_engine, bias_hash):
+    """Mark the current timestamp as the time at which matrix building started
+
+    Args:
+        run_id (int) The identifier/primary key of the run
+        db_engine (sqlalchemy.engine)
+        bias_hash (str) Identifier (hash) for bias audit for this run
+    """
+    with get_run_for_update(db_engine, run_id) as run_obj:
+        run_obj.bias_hash = bias_hash
+
+
 def record_model_building_started(run_id, db_engine):
     """Mark the current timestamp as the time at which model building started
 


### PR DESCRIPTION
Closes #859 

Currently, the relationship between a given run and the labels table/hash, cohort table/hash, and bias hash isn't stored anywhere (aside from the logs), which can make debugging and iterating on the experiment config a bit challenging. To address this, the current pull request adds tracking of these associations to the `triage_runs` table.