### PR TITLE
Error on cohort or label duplicates

### DIFF
--- a/src/tests/architect_tests/test_database_reflection.py
+++ b/src/tests/architect_tests/test_database_reflection.py
@@ -40,6 +40,16 @@ class TestDatabaseReflection(TestCase):
         assert dbreflect.table_has_data("compliments", self.engine)
         assert not dbreflect.table_has_data("incidents", self.engine)
 
+    def test_table_has_duplicates(self):
+        self.engine.execute("create table events (col1 int, col2 int)")
+        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        self.engine.execute("insert into events values (1,2)")
+        self.engine.execute("insert into events values (1,3)")
+        assert dbreflect.table_has_duplicates("events", ['col1'], self.engine)
+        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        self.engine.execute("insert into events values (1,2)")
+        assert dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+
     def test_table_has_column(self):
         self.engine.execute("create table incidents (col1 varchar)")
         assert dbreflect.table_has_column("incidents", "col1", self.engine)

--- a/src/tests/architect_tests/test_database_reflection.py
+++ b/src/tests/architect_tests/test_database_reflection.py
@@ -5,6 +5,7 @@ from testing.postgresql import Postgresql
 from unittest import TestCase
 
 from triage.component.architect import database_reflection as dbreflect
+from triage.database_reflection import table_has_duplicates
 
 
 class TestDatabaseReflection(TestCase):
@@ -42,13 +43,13 @@ class TestDatabaseReflection(TestCase):
 
     def test_table_has_duplicates(self):
         self.engine.execute("create table events (col1 int, col2 int)")
-        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert not table_has_duplicates("events", ['col1', 'col2'], self.engine)
         self.engine.execute("insert into events values (1,2)")
         self.engine.execute("insert into events values (1,3)")
-        assert dbreflect.table_has_duplicates("events", ['col1'], self.engine)
-        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert table_has_duplicates("events", ['col1'], self.engine)
+        assert not table_has_duplicates("events", ['col1', 'col2'], self.engine)
         self.engine.execute("insert into events values (1,2)")
-        assert dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert table_has_duplicates("events", ['col1', 'col2'], self.engine)
 
     def test_table_has_column(self):
         self.engine.execute("create table incidents (col1 varchar)")

--- a/src/tests/architect_tests/test_label_generators.py
+++ b/src/tests/architect_tests/test_label_generators.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 import testing.postgresql
+import pytest
 from sqlalchemy import create_engine
 
 from triage.component.architect.label_generators import LabelGenerator

--- a/src/tests/postmodeling_tests/test_add_predictions.py
+++ b/src/tests/postmodeling_tests/test_add_predictions.py
@@ -1,7 +1,7 @@
 import pytest
 
 from triage.component.postmodeling.utils.add_predictions import add_predictions
-from triage.component.architect.database_reflection import table_has_data
+from triage.database_reflection import table_has_data
 
 
 MODEL_IDS_QUERY = """

--- a/src/tests/test_database_reflection.py
+++ b/src/tests/test_database_reflection.py
@@ -4,8 +4,7 @@ from sqlalchemy.types import VARCHAR
 from testing.postgresql import Postgresql
 from unittest import TestCase
 
-from triage.component.architect import database_reflection as dbreflect
-from triage.database_reflection import table_has_duplicates
+import triage.database_reflection as dbreflect
 
 
 class TestDatabaseReflection(TestCase):
@@ -43,13 +42,13 @@ class TestDatabaseReflection(TestCase):
 
     def test_table_has_duplicates(self):
         self.engine.execute("create table events (col1 int, col2 int)")
-        assert not table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
         self.engine.execute("insert into events values (1,2)")
         self.engine.execute("insert into events values (1,3)")
-        assert table_has_duplicates("events", ['col1'], self.engine)
-        assert not table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert dbreflect.table_has_duplicates("events", ['col1'], self.engine)
+        assert not dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
         self.engine.execute("insert into events values (1,2)")
-        assert table_has_duplicates("events", ['col1', 'col2'], self.engine)
+        assert dbreflect.table_has_duplicates("events", ['col1', 'col2'], self.engine)
 
     def test_table_has_column(self):
         self.engine.execute("create table incidents (col1 varchar)")

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -1,7 +1,7 @@
 import verboselogs
 
 from triage.component.architect.database_reflection import table_has_data
-from triage.database_reflection import table_row_count, table_exists
+from triage.database_reflection import table_row_count, table_exists, table_has_duplicates
 
 
 logger = verboselogs.VerboseLogger(__name__)
@@ -54,6 +54,13 @@ class EntityDateTableGenerator:
 
         if not table_has_data(self.entity_date_table_name, self.db_engine):
             raise ValueError(self._empty_table_message(as_of_dates))
+
+        if table_has_duplicates(
+            self.entity_date_table_name,
+            ['entity_id', 'as_of_date'],
+            self.db_engine
+            ):
+            raise ValueError(f"Duplicates found in {self.entity_date_table_name}!")
 
         logger.debug(f"Entity-date table generated at {self.entity_date_table_name}")
         logger.spam(f"Generating stats on {self.entity_date_table_name}")

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -1,7 +1,6 @@
 import verboselogs
 
-from triage.component.architect.database_reflection import table_has_data
-from triage.database_reflection import table_row_count, table_exists, table_has_duplicates
+from triage.database_reflection import table_has_data, table_row_count, table_exists, table_has_duplicates
 
 
 logger = verboselogs.VerboseLogger(__name__)

--- a/src/triage/component/architect/validations.py
+++ b/src/triage/component/architect/validations.py
@@ -1,5 +1,5 @@
 """Functions for validating input, mostly around database schema and state"""
-from triage.component.architect.database_reflection import (
+from triage.database_reflection import (
     table_exists,
     table_has_column,
     column_type,

--- a/src/triage/database_reflection.py
+++ b/src/triage/database_reflection.py
@@ -76,11 +76,11 @@ def table_has_data(table_name, db_engine):
     """
     if not table_exists(table_name, db_engine):
         return False
-    result = [
-        row for row in db_engine.execute("select 1 from {} limit 1".format(table_name))
+    results = [
+        row for row in db_engine.execute("select * from {} limit 1".format(table_name))
     ]
 
-    return any(result)
+    return len(results) > 0
 
 
 def table_row_count(table_name, db_engine):

--- a/src/triage/database_reflection.py
+++ b/src/triage/database_reflection.py
@@ -99,6 +99,35 @@ def table_row_count(table_name, db_engine):
     )
 
 
+def table_has_duplicates(table_name, column_list, db_engine):
+    """Check whether the table has duplicate rows on the set of columns.
+
+    The table is expected to exist and contain the columns in column_list.
+
+    Args:
+        table_name (string) A table name (with schema)
+        column_list (list) A list of column names
+        db_engine (sqlalchemy.engine)
+
+    Returns: (boolean) Whether or not duplicates are found
+    """
+    if not table_has_data(table_name, db_engine):
+        return False
+
+    cols = ','.join(['"%s"' % c for c in column_list])
+    sql = f"""
+    WITH counts AS (
+        SELECT {cols}
+        , COUNT(*) AS num_records
+        FROM {table_name}
+        GROUP BY {cols}
+    )
+    SELECT MAX(num_records) FROM counts
+    """
+    result = next(db_engine.execute(sql))
+    return result > 1
+
+
 def table_has_column(table_name, column, db_engine):
     """Check whether the table contains a column of the given name
 

--- a/src/triage/database_reflection.py
+++ b/src/triage/database_reflection.py
@@ -124,7 +124,7 @@ def table_has_duplicates(table_name, column_list, db_engine):
     )
     SELECT MAX(num_records) FROM counts
     """
-    result = next(db_engine.execute(sql))
+    result = next(db_engine.execute(sql))[0]
     return result > 1
 
 


### PR DESCRIPTION
Closes #872 

Adds a check for duplicates in the labels or cohort table in order to error earlier and with a more helpful message when this occurs (currently, this tends to cause a duplicate primary key error far downstream when saving predictions, which can be difficult to debug).

Note that I actually haven't added a unit test for catching duplicates in the cohort because two routes (via query or labels) for generating these already do a `distinct` or `group by` so these shouldn't actually occur. We could consider removing this logic and putting the burden on user (which might enforce better understanding of what triage is doing/expecting), but I'm not sure that's too worthwhile.

@thcrock -- is the fact that there are two (essentially identical) `database_reflection.py` files (one in `src/triage/` and the other in `src/triage/component/architect/`) an artifact of the merge to a single repo? I'd like to consolidate -- thoughts/preferences on which is a better place for this it to live?