### PR TITLE
Cohort inspector

### DIFF
--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -27,6 +27,7 @@ matplotlib==3.3.4
 pandas==1.0.5
 seaborn==0.10.1
 ohio==0.5.0
+pydantic==1.9.0
 
 
 aequitas==0.42.0

--- a/src/tests/architect_tests/test_plotting.py
+++ b/src/tests/architect_tests/test_plotting.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+import testing.postgresql
+from sqlalchemy.engine import create_engine
+
+from . import utils
+
+from triage.component.architect.plotting import inspect_cohort_query_on_date, CohortInspectionResults
+
+def test_inspect_cohort_query_on_date():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 1, 1), True),
+        (3, datetime(2016, 1, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, "events", input_data)
+        results = inspect_cohort_query_on_date(
+            db_engine=engine,
+            query="select entity_id from events where outcome_date < '{as_of_date}'::date",
+            as_of_date=datetime(2016, 2, 1)
+        )
+
+        expected_output = CohortInspectionResults(
+            ran_successfully=True,
+            num_rows=3,
+            distinct_entity_ids=3,
+            examples=[1, 2, 3]
+        )
+            
+        assert results == expected_output

--- a/src/tests/architect_tests/test_plotting.py
+++ b/src/tests/architect_tests/test_plotting.py
@@ -29,8 +29,26 @@ def test_inspect_cohort_query_on_date():
         expected_output = CohortInspectionResults(
             ran_successfully=True,
             num_rows=3,
-            distinct_entity_ids=3,
+            num_distinct_entity_ids=3,
             examples=[1, 2, 3]
+        )
+            
+        assert results == expected_output
+
+def test_inspect_cohort_query_on_date_unsuccessful():
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        results = inspect_cohort_query_on_date(
+            db_engine=engine,
+            query="select entity_id from events2 where outcome_date < '{as_of_date}'::date",
+            as_of_date=datetime(2016, 2, 1)
+        )
+
+        expected_output = CohortInspectionResults(
+            ran_successfully=False,
+            num_rows=0,
+            num_distinct_entity_ids=0,
+            examples=[]
         )
             
         assert results == expected_output

--- a/src/triage/component/architect/plotting.py
+++ b/src/triage/component/architect/plotting.py
@@ -13,7 +13,7 @@ class CohortInspectionResults(pydantic.BaseModel):
     distinct_entity_ids: int
     examples: List[str]
 
-def inspect_cohort_query_on_date(query: str, db_engine, as_of_date: datetime.date):
+def inspect_cohort_query_on_date(query: str, db_engine, as_of_date: datetime.date) -> CohortInspectionResults:
     cohort_table_name = 'temp_inspect_cohort'
     generator = EntityDateTableGenerator(
         query=query,

--- a/src/triage/component/architect/plotting.py
+++ b/src/triage/component/architect/plotting.py
@@ -10,7 +10,7 @@ import pydantic
 class CohortInspectionResults(pydantic.BaseModel):
     ran_successfully: bool
     num_rows: int
-    distinct_entity_ids: int
+    num_distinct_entity_ids: int
     examples: List[str]
 
 def inspect_cohort_query_on_date(query: str, db_engine, as_of_date: datetime.date) -> CohortInspectionResults:
@@ -23,13 +23,21 @@ def inspect_cohort_query_on_date(query: str, db_engine, as_of_date: datetime.dat
     )
     results = {}
     logger.info('Inspecting cohort query at %s', query)
-    generator.generate_entity_date_table([as_of_date])
-    logger.info('Cohort query successfully ran')
-    results['ran_successfully'] = True
+    try:
+        generator.generate_entity_date_table([as_of_date])
+        results['ran_successfully'] = True
+    except:
+        return CohortInspectionResults(
+            ran_successfully=False,
+            num_rows=0,
+            num_distinct_entity_ids=0,
+            examples=[]
+        )
+
     results['num_rows'] = list(db_engine.execute(
         f'select count(*) from {cohort_table_name} where as_of_date = %s',
         as_of_date))[0][0]
-    results['distinct_entity_ids'] = list(db_engine.execute(
+    results['num_distinct_entity_ids'] = list(db_engine.execute(
         f'select count(distinct(entity_id)) from {cohort_table_name} where as_of_date = %s',
         as_of_date))[0][0]
 

--- a/src/triage/component/architect/plotting.py
+++ b/src/triage/component/architect/plotting.py
@@ -1,0 +1,52 @@
+import datetime
+import verboselogs
+from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator
+from typing import List, Optional
+
+logger = verboselogs.VerboseLogger(__name__)
+
+import pydantic
+
+class CohortInspectionResults(pydantic.BaseModel):
+    ran_successfully: Optional[bool]
+    num_rows: int
+    distinct_entity_ids: int
+    examples: List[str]
+
+def inspect_cohort_query_on_date(query: str, db_engine, as_of_date: datetime.date):
+    temp_table_name = 'temp_inspect_cohort'
+    generator = EntityDateTableGenerator(
+        query=query,
+        db_engine=db_engine,
+        entity_date_table_name=temp_table_name,
+        replace=True
+    )
+    results = {}
+    logger.info('Inspecting cohort query at %s', query)
+    generator.generate_entity_date_table([as_of_date])
+    logger.info('Cohort query successfully ran')
+    results['ran_successfully'] = True
+    results.update(inspect_cohort_on_date(temp_table_name, as_of_date, db_engine))
+    return CohortInspectionResults(**results)
+
+
+def inspect_cohort_on_date(cohort_table_name, as_of_date, db_engine):
+    """Inspects a finished cohort
+
+    expects the table at cohort_table_name to be populated
+    """
+    results = {}
+    results['num_rows'] = list(db_engine.execute(
+        f'select count(*) from {cohort_table_name} where as_of_date = %s',
+        as_of_date))[0][0]
+    results['distinct_entity_ids'] = list(db_engine.execute(
+        f'select count(distinct(entity_id)) from {cohort_table_name} where as_of_date = %s',
+        as_of_date))[0][0]
+
+    results['examples'] = sorted([
+        row[0]
+        for row in db_engine.execute(f'select entity_id from {cohort_table_name} ORDER BY random() limit 5')
+    ])
+    
+
+    return results


### PR DESCRIPTION
Just putting something together quick for inspecting cohorts. 

I added pydantic here as a prototype for using it elsewhere in Triage. I think when we specify specific dict structure as arguments (which we do all over the place) or return values (which we usually don't, but this PR certainly does), we should be more specific about what that dict is supposed to contain. Pydantic makes it pretty easy to do this.

Anyway, this is just the single-date version. I wanted a check-in to see if we should keep going this direction, and maybe decide what else the interface should be. Logging all of these values maybe?