### PR TITLE
Remove duplicate cohort section

### DIFF
--- a/example/config/experiment.yaml
+++ b/example/config/experiment.yaml
@@ -91,25 +91,6 @@ label_config:
     #name: 'inspections'
 
 
-# COHORT CONFIG
-# This block is completely optional. If you don't specify it, all distinct entities and dates from the labels table will be used.
-# This means that any entities that don't show up in your label query will not be in the matrix.
-# For many applications, this may be fine but in some cases (e.g. an inspections problem
-# where not all relevant entities have had recent inspections) it is easier to keep track of these concepts separately.
-#
-# Cohorts are configured by passing a query with placeholders for the 'as_of_date'.
-#
-# The 'query' key should have a query, parameterized with an '{as_of_date}', to select the entity_ids that should be included for a given date. The {as_of_date} will be replaced with each as_of_date that the experiment needs. The returned 'entity_id' must be an integer.
-#
-# You may enter a 'name' for your configuration.
-# This will be included in the metadata for each matrix and used to group models
-# If you don't pass one, the string 'default' will be used.
-cohort_config:
-    query: "select entity_id from events where outcome_date < '{as_of_date}'"
-    name: 'past_events'
-
-
-
 # FEATURE GENERATION
 # The aggregate features to generate for each train/test split
 #


### PR DESCRIPTION
The example experiment had two cohort sections. Only one is needed.