### PR TITLE
use >=, not <=

### DIFF
--- a/example/label/events.sql
+++ b/example/label/events.sql
@@ -1,7 +1,7 @@
 select
-    events.entity_id,
+    entity_id,
     bool_or(outcome::bool)::integer as outcome
 from events
-where '{as_of_date}' <= outcome_date
+where outcome_date >= '{as_of_date}'
     and outcome_date < '{as_of_date}'::timestamp + interval '{label_timespan}'
 group by entity_id


### PR DESCRIPTION
In general, we try to use `>=` and `<` rather than `<=` or `>` for time inequalities in our examples to be consistent with the fact that triage internally uses closed-left-ends and open-right-ends for time intervals. This makes mentally translating examples into triage behavior easier. This commit fixes an example where we used `<=` for label creation.