### PR TITLE
Fix bug in check for collate groups key

### DIFF
--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -19,9 +19,10 @@ from triage.validation_primitives import string_is_tablesafe
 
 
 class Validator:
-    def __init__(self, db_engine=None, strict=True):
+    def __init__(self, db_engine=None, strict=True, entity_id_column="entity_id"):
         self.db_engine = db_engine
         self.strict = strict
+        self.entity_id_column = entity_id_column
 
     def run(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Quick PR to fix an error @rayidghani encountered on running with a `groups` key in the feature config -- this should now raise the intended deprecation warning rather than a cryptic error. We should also add a unit test for this behavior at some point (I created an issue to that effect), but I wanted to go ahead and merge this quickly to fix the bug.