### PR TITLE
Bugfix for obtaining cohort from labels table

### DIFF
--- a/src/tests/test_defaults.py
+++ b/src/tests/test_defaults.py
@@ -7,26 +7,10 @@ from triage.component.catwalk.db import ensure_db
 from tests.utils import sample_config, populate_source_data
 from triage.experiments.defaults import (
     fill_timechop_config_missing,
-    fill_cohort_config_missing,
     fill_feature_group_definition,
     fill_model_grid_presets,
     model_grid_preset,
 )
-
-
-def test_fill_cohort_config_missing():
-    config = sample_config()
-    config.pop('cohort_config')
-    cohort_config = fill_cohort_config_missing(config)
-    assert cohort_config == {
-        'query': "select distinct entity_id from "
-                "((select entity_id, as_of_date as knowledge_date from "
-                "(select * from cat_complaints) as t)\n union \n(select entity_id, "
-                "as_of_date as knowledge_date from (select * from entity_zip_codes "
-                "join zip_code_events using (zip_code)) as t)) as e "
-                "where knowledge_date < '{as_of_date}'",
-        'name': 'all_entities'
-        }
 
 
 def test_fill_feature_group_definition():

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -142,8 +142,8 @@ class EntityDateTableGenerator:
                 select distinct as_of_date::DATE AS as_of_date FROM {self.entity_date_table_name}
             )
             select distinct l.as_of_date
-            from label_dates
-            join cohort_dates using(as_of_date)
+            from label_dates l
+            join cohort_dates c using(as_of_date)
             """
         ))
         if len(existing_dates) > 0:

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -130,7 +130,7 @@ class EntityDateTableGenerator:
             return
 
         self.db_engine.execute(f"""insert into {self.entity_date_table_name}
-            select distinct entity_id, as_of_date
+            select distinct entity_id, as_of_date, true
             from {self.labels_table_name}
             """)
 

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -156,16 +156,18 @@ class EntityDateTableGenerator:
                 select distinct as_of_date::DATE AS as_of_date FROM {self.entity_date_table_name}
             )
             insert into {self.entity_date_table_name}
-            select distinct entity_id, as_of_date, true
-            from {self.labels_table_name}
-            where as_of_date::DATE NOT IN (select as_of_date FROM cohort_dates)
+            select distinct l.entity_id, l.as_of_date, true
+            from {self.labels_table_name} as l
+            left join cohort_dates as c
+            on l.as_of_date::DATE = c.as_of_date::DATE
+            where c.as_of_date IS NULL
             """)
 
     def _empty_table_message(self, as_of_dates):
         return """Query does not return any rows for the given as_of_dates:
             {as_of_dates}
             '{query}'""".format(
-            query=self.query,
+            query=self.query or "labels table",
             as_of_dates=", ".join(
                 str(as_of_date)
                 for as_of_date in (

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -149,7 +149,7 @@ class EntityDateTableGenerator:
         if len(existing_dates) > 0:
             existing_dates = ', '.join(existing_dates)
             logger.notice(f'Existing entity_dates records found for the following dates, '
-                'so new records will not be inserted for these dates {existing_dates}')
+                f'so new records will not be inserted for these dates {existing_dates}')
 
         self.db_engine.execute(f"""
             with cohort_dates as (

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -78,7 +78,6 @@ from triage.tracking import (
 
 from triage.experiments.defaults import (
     fill_timechop_config_missing,
-    fill_cohort_config_missing,
     fill_feature_group_definition,
     fill_model_grid_presets,
 )
@@ -225,8 +224,6 @@ class ExperimentBase(ABC):
             self.config["temporal_config"] = fill_timechop_config_missing(
                 self.config, self.db_engine
             )
-            ## Defaults to all the entities found in the features_aggregation's from_obj
-            self.config["cohort_config"] = fill_cohort_config_missing(self.config)
             ## Defaults to all the feature_aggregation's prefixes
             self.config["feature_group_definition"] = fill_feature_group_definition(
                 self.config

--- a/src/triage/experiments/defaults.py
+++ b/src/triage/experiments/defaults.py
@@ -56,33 +56,6 @@ def fill_timechop_config_missing(config, db_engine):
     return default_config
 
 
-def fill_cohort_config_missing(config):
-    """
-    If none cohort_config section is provided, include all the entities by default
-
-    Args:
-        config (dict) a triage experiment configuration
-
-    Returns: (dict) a triage cohort config
-    """
-    from_query = "(select entity_id, {knowledge_date} as knowledge_date from (select * from {from_obj}) as t)"
-
-    feature_aggregations = config['feature_aggregations']
-
-    from_queries = [from_query.format(knowledge_date = agg['knowledge_date_column'], from_obj=agg['from_obj']) for agg in feature_aggregations]
-
-    unions = "\n union \n".join(from_queries)
-
-    query = f"select distinct entity_id from ({unions}) as e" +" where knowledge_date < '{as_of_date}'"
-
-    cohort_config = config.get('cohort_config', {})
-    default_config = {'query': query, 'name': 'all_entities'}
-
-    default_config.update(cohort_config)
-
-    return default_config
-
-
 def fill_feature_group_definition(config):
     """
     If feature_group_definition is not presents, this function sets it to all

--- a/src/triage/experiments/validate.py
+++ b/src/triage/experiments/validate.py
@@ -510,6 +510,9 @@ class LabelConfigValidator(Validator):
 class CohortConfigValidator(Validator):
     def _run(self, cohort_config):
         logger.spam("Validating of cohort configuration")
+        if not cohort_config:
+            logger.debug("No cohort config specified, label config will be used instead")
+            return
         if len(set(cohort_config.keys()).intersection({"query", "filepath"})) != 1:
             raise ValueError(
                 dedent(


### PR DESCRIPTION
Somewhat urgent bugfix -- currently, when omitting the `cohort_config` section of a `triage_config`, it gets filled in with a default query that selects all `entity_id` values from the feature table from objects. However, this default behavior no longer applies because this section of the config is now optional.

To fix this issue, this pull request does three things:
- Remove the `fill_cohort_config_missing` default function (and associated test)
- Allows for passing the `CohortConfigValidator` if the `cohort_config` section is omitted
- Avoids inserting cohort records for `as_of_date` values that already exist in the cohort table when defining the cohort based on the labels table (note directly related to the bugfix, but avoids potential inconsistencies by mimicking the existing behavior when inserting from a query with `replace=False`)