### PR TITLE
Fix bug with logging existing cohort dates

### DIFF
--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -147,7 +147,7 @@ class EntityDateTableGenerator:
             """
         ))
         if len(existing_dates) > 0:
-            existing_dates = ', '.join([rec[0] for rec in existing_dates])
+            existing_dates = ', '.join([rec[0].isoformat() for rec in existing_dates])
             logger.notice(f'Existing entity_dates records found for the following dates, '
                 f'so new records will not be inserted for these dates {existing_dates}')
 

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -147,7 +147,7 @@ class EntityDateTableGenerator:
             """
         ))
         if len(existing_dates) > 0:
-            existing_dates = ', '.join(existing_dates)
+            existing_dates = ', '.join([rec[0] for rec in existing_dates])
             logger.notice(f'Existing entity_dates records found for the following dates, '
                 f'so new records will not be inserted for these dates {existing_dates}')
 


### PR DESCRIPTION
Need to unpack the results list for the log message when encountering existing as_of_dates in the cohort table and building from the labels query while using `replace=False`