### PR TITLE
Updating predict forward with existing model

### DIFF
--- a/src/triage/predictlist/__init__.py
+++ b/src/triage/predictlist/__init__.py
@@ -43,6 +43,7 @@ from .utils import (
     save_retrain_and_get_hash,
     get_retrain_config_from_model_id,
     temporal_params_from_matrix_metadata,
+    cohort_config_from_label_config
 )
 
 
@@ -78,35 +79,17 @@ def predict_forward_with_existed_model(db_engine, project_path, model_id, as_of_
     experiment_config = experiment_config_from_model_id(db_engine, model_id)
  
     # 2. Generate cohort
-    cohort_config = experiment_config.get('cohort_config')
+    # cohort_config = experiment_config.get('cohort_config')
 
 
-    if cohort_config is None:
+    if experiment_config.get('cohort_config') is None:
         logger.info('Experiment config does not contain a cohort config. Using the label query')
-        label_query = experiment_config['label_config']['query']
+        experiment_config['cohort_config'] = cohort_config_from_label_config(experiment_config['label_config'])
 
-        # We need to remove the '{label_timespan} param' with some default
-        # It doesn't matter since we are not using the labels
-        # label_query = label_query.format(label_timespan='1week')
-        label_query = label_query.replace('{label_timespan}', '1week')
-
-        # Just selecting the entity id from the labels query
-        cohort_query = f"""
-            select 
-                entity_id
-            from ({label_query}) as lq
-        """
-        print(cohort_query)
-
-        cohort_config = dict()
-        cohort_config['query'] = cohort_query
-        cohort_config['name'] = 'default'
-
-
-    cohort_table_name = f"triage_production.cohort_{cohort_config['name']}"
+    cohort_table_name = f"triage_production.cohort_{experiment_config['cohort_config']['name']}"
     cohort_table_generator = EntityDateTableGenerator(
         db_engine=db_engine,
-        query=cohort_config['query'],
+        query=experiment_config['cohort_config']['query'],
         entity_date_table_name=cohort_table_name
     )
     cohort_table_generator.generate_entity_date_table(as_of_dates=[dt_from_str(as_of_date)])
@@ -176,7 +159,7 @@ def predict_forward_with_existed_model(db_engine, project_path, model_id, as_of_
     label_name = experiment_config['label_config']['name']
     label_type = 'binary'
     cohort_name = experiment_config['cohort_config']['name']
-    user_metadata = experiment_config['user_metadata']
+    user_metadata = experiment_config.get('user_metadata', {})
     
     # Use timechop to get the time definition for production
     temporal_config = experiment_config["temporal_config"]
@@ -259,6 +242,10 @@ class Retrainer:
         self.test_label_timespan = self.experiment_config['temporal_config']['test_label_timespans'][0]
         self.test_duration = self.experiment_config['temporal_config']['test_durations'][0]
         self.feature_start_time=self.experiment_config['temporal_config']['feature_start_time']
+
+        # Handling the case where a separate cohort_config is not defined
+        if self.experiment_config.get('cohort_config') is None:
+            self.experiment_config['cohort_config'] = cohort_config_from_label_config(self.experiment_config['label_config'])
 
         self.label_name = self.experiment_config['label_config']['name']
         self.cohort_name = self.experiment_config['cohort_config']['name']
@@ -387,9 +374,9 @@ class Retrainer:
         chops_train_matrix = chops[0]['train_matrix']
         as_of_date = datetime.strftime(chops_train_matrix['last_as_of_time'], "%Y-%m-%d")
         retrain_definition = {
-            'first_as_of_time': chops_train_matrix['first_as_of_time'],
-            'last_as_of_time': chops_train_matrix['last_as_of_time'],
-            'matrix_info_end_time': chops_train_matrix['matrix_info_end_time'],
+            'first_as_of_time': str(chops_train_matrix['first_as_of_time']),
+            'last_as_of_time': str(chops_train_matrix['last_as_of_time']),
+            'matrix_info_end_time': str(chops_train_matrix['matrix_info_end_time']),
             'as_of_times': [as_of_date],
             'training_label_timespan': chops_train_matrix['training_label_timespan'],
             'max_training_history': chops_train_matrix['max_training_history'],

--- a/src/triage/predictlist/__init__.py
+++ b/src/triage/predictlist/__init__.py
@@ -79,10 +79,8 @@ def predict_forward_with_existed_model(db_engine, project_path, model_id, as_of_
     experiment_config = experiment_config_from_model_id(db_engine, model_id)
  
     # 2. Generate cohort
-    # cohort_config = experiment_config.get('cohort_config')
-
-
     if experiment_config.get('cohort_config') is None:
+        # If a separate cohort_config is not defined in the config
         logger.info('Experiment config does not contain a cohort config. Using the label query')
         experiment_config['cohort_config'] = cohort_config_from_label_config(experiment_config['label_config'])
 
@@ -171,8 +169,16 @@ def predict_forward_with_existed_model(db_engine, project_path, model_id, as_of_
             test_label_timespan=temporal_config['test_label_timespans'][0]
     )
 
+    last_split_definition = prod_definitions[-1]
+
+    # formating the datetimes as strings to be saved as JSON
+    last_split_definition['first_as_of_time'] = str(last_split_definition['first_as_of_time'])
+    last_split_definition['last_as_of_time'] = str(last_split_definition['last_as_of_time'])
+    last_split_definition['matrix_info_end_time'] = str(last_split_definition['matrix_info_end_time'])
+    last_split_definition['as_of_times'] = [str(last_split_definition['as_of_times'][0])]
+
     matrix_metadata = Planner.make_metadata(
-            prod_definitions[-1],
+            last_split_definition,
             reconstructed_feature_dict,
             label_name,
             label_type,


### PR DESCRIPTION
The `predictlist` module needs to be updated to work with the current version of triage. This PR deals with the case of predicting with an existing model as it is a near-term priority, but will need to update the `Retrain` class as well:

Makes the following updates:
- handle the case where an explicit cohort is not defined by inferring the cohort from the label query
- handle the case where there's an overlap in feature group prefixes. e.g., when there are two feature groups `eviction` and `eviction_cases`, the features from the latter were included in the former leading to errors. 
- Fix the error with matrix metadata creation
- Handle the case with no `user_metadata` defined