### PR TITLE
Lm predict forward no labels in matrix

### DIFF
--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -567,6 +567,7 @@ class MatrixBuilder(BuilderBase):
         
         # getting label series
         df_pl_aux = None
+        labels_series = None
         if self.includes_labels:
             labels_pl = df_pl.select(df_pl.columns[-1])
             # convert into pandas series 

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -312,6 +312,7 @@ class MatrixBuilder(BuilderBase):
         logger.debug(f"feature queries, number of queries: {len(feature_queries)}")
         
         # when predict forwarding we don't have labels
+        logger.info(f"Includes labels?: {self.includes_labels}")
         if self.includes_labels:
             label_query = self.label_load_query(
                 label_name,
@@ -495,6 +496,7 @@ class MatrixBuilder(BuilderBase):
 
         # label
         if self.includes_labels:
+            logger.info("CSV file for labels")
             copy_sql = f"COPY ({label_query}) TO STDOUT WITH CSV {header}"
             bio = io.BytesIO()
             cursor.copy_expert(copy_sql, bio)

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -566,6 +566,7 @@ class MatrixBuilder(BuilderBase):
         logger.debug(f"getting labels pandas series from polars data frame")
         
         # getting label series
+        df_pl_aux = None
         if self.includes_labels:
             labels_pl = df_pl.select(df_pl.columns[-1])
             # convert into pandas series 

--- a/src/triage/predictlist/__init__.py
+++ b/src/triage/predictlist/__init__.py
@@ -580,7 +580,6 @@ class Retrainer:
             "features_schema_name": "triage_production",
             "labels_schema_name": "public",
             "cohort_table_name": cohort_table_name,
-            "labels_table_name": self.label_name
         }
 
         matrix_builder = MatrixBuilder(


### PR DESCRIPTION
Modify the `builders.py` component to deal with the use case of not having labels on the matrix (predict forward). In case there are no labels, a CSV file is generated with 0s in it.  This change follows the logic on tag 5.2.3.  

It was tested with DoJo data using the `predictlist` logic: 

- Using only the `predict_forward_with_existed_model`
- Using the `Retrainer` object with `retrain` and `predict` methods
