### PR TITLE
Changing how we create subsets 

### DIFF
--- a/src/tests/architect_tests/test_entity_date_table_generators.py
+++ b/src/tests/architect_tests/test_entity_date_table_generators.py
@@ -4,7 +4,7 @@ import pytest
 import testing.postgresql
 from sqlalchemy.engine import create_engine
 
-from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator
+from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator, SubsetEntityDateTableGenerator
 
 from . import utils
 
@@ -243,3 +243,244 @@ def test_entity_date_table_generator_from_labels():
             )
         )
         assert results == expected_output
+
+
+def test_subset_evens_cohort():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 3, 1), True),
+        (3, datetime(2016, 1, 1), True),
+        (4, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 4, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, "events", input_data)
+
+        # create cohort table 
+        engine.execute(
+        """
+            create table cohort (
+                entity_id int,
+                as_of_date date,
+                active bool
+            )
+        """
+        )
+        for row in input_data:
+            engine.execute("insert into cohort values (%s, %s, %s)", row)
+        
+        as_of_dates = [
+
+            datetime(2016, 3, 1),
+            datetime(2016, 4, 1),
+        ]
+        ### test evens
+        subset_generator = SubsetEntityDateTableGenerator(
+            query="select distinct entity_id, outcome_date from events where entity_id %% 2 = 0 and outcome_date < '{as_of_date}'::date",
+            db_engine=engine,
+            entity_date_table_name="exp_hash_subset_entity_date",
+            replace=True,
+            cohort_table="cohort")
+        subset_generator.generate_entity_date_table(as_of_dates)
+        
+        expected_output = [
+            (2, datetime(2016, 3, 1), True),
+            (4, datetime(2016, 4, 1), True),
+        ]
+        results = list(
+            engine.execute(
+                f"""
+                select entity_id, as_of_date, active from {subset_generator.entity_date_table_name}
+                order by entity_id, as_of_date
+            """
+            )
+        )
+
+        assert results == expected_output 
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "entity_id")
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "as_of_date")
+        
+
+
+def test_subset_odds_cohort():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 3, 1), True),
+        (3, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 4, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+    
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, "events", input_data)
+
+        # create cohort table 
+        engine.execute(
+        """
+            create table cohort (
+                entity_id int,
+                as_of_date date,
+                active bool
+            )
+        """
+        )
+        for row in input_data:
+            engine.execute("insert into cohort values (%s, %s, %s)", row)
+        
+        as_of_dates = [
+            datetime(2016, 3, 1),
+            datetime(2016, 4, 1),
+        ]
+        ### test odds
+        subset_generator = SubsetEntityDateTableGenerator(
+            query="select distinct entity_id, outcome_date from events where entity_id %% 2 = 1 and outcome_date < '{as_of_date}'::date",
+            db_engine=engine,
+            entity_date_table_name="exp_hash_subset_entity_date",
+            replace=True,
+            cohort_table="cohort")
+        subset_generator.generate_entity_date_table(as_of_dates)
+        
+        expected_output = [
+            (1, datetime(2016, 3, 1), True),
+            (1, datetime(2016, 4, 1), True),
+            (3, datetime(2016, 4, 1), True),
+            (5, datetime(2016, 4, 1), True),
+        ]
+        results = list(
+            engine.execute(
+                f"""
+                select entity_id, as_of_date, active from {subset_generator.entity_date_table_name}
+                order by entity_id, as_of_date
+            """
+            )
+        )
+
+        assert results == expected_output 
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "entity_id")
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "as_of_date")
+
+
+def test_subset_empty():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 3, 1), True),
+        (3, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 4, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+    
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, "events", input_data)
+
+        # create cohort table 
+        engine.execute(
+        """
+            create table cohort (
+                entity_id int,
+                as_of_date date,
+                active bool
+            )
+        """
+        )
+        for row in input_data:
+            engine.execute("insert into cohort values (%s, %s, %s)", row)
+        
+        as_of_dates = [
+            datetime(2016, 1, 1),
+        ]
+        ### test evens
+        subset_generator = SubsetEntityDateTableGenerator(
+            query="select distinct entity_id, outcome_date from events where entity_id %% 2 = 1 and outcome_date < '{as_of_date}'::date",
+            db_engine=engine,
+            entity_date_table_name="exp_hash_subset_entity_date",
+            replace=True,
+            cohort_table="cohort")
+        subset_generator.generate_entity_date_table(as_of_dates)
+        
+        expected_output = []
+        results = list(
+            engine.execute(
+                f"""
+                select entity_id, as_of_date, active from {subset_generator.entity_date_table_name}
+                order by entity_id, as_of_date
+            """
+            )
+        )
+
+        assert results == expected_output 
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "entity_id")
+        utils.assert_index(engine, subset_generator.entity_date_table_name, "as_of_date")
+
+
+def test_subset_all_entities_in_cohort():
+    input_data = [
+        (1, datetime(2016, 1, 1), True),
+        (1, datetime(2016, 4, 1), False),
+        (1, datetime(2016, 3, 1), True),
+        (2, datetime(2016, 1, 1), False),
+        (2, datetime(2016, 3, 1), True),
+        (3, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 3, 1), True),
+        (4, datetime(2016, 4, 1), True),
+        (5, datetime(2016, 3, 1), True),
+        (5, datetime(2016, 4, 1), True),
+    ]
+    
+    with testing.postgresql.Postgresql() as postgresql:
+        engine = create_engine(postgresql.url())
+        utils.create_binary_outcome_events(engine, "events", input_data)
+
+        # create cohort table 
+        engine.execute(
+        """
+            create table cohort (
+                entity_id int,
+                as_of_date date,
+                active bool
+            )
+        """
+        )
+        for row in input_data:
+            engine.execute("insert into cohort values (%s, %s, %s)", row)
+        
+        as_of_dates = [
+            datetime(2016, 1, 1),
+        ]
+        ### test evens
+        subset_generator = SubsetEntityDateTableGenerator(
+            query="select distinct entity_id, outcome_date from events where entity_id %% 2 = 0 and outcome_date < '{as_of_date}'::date",
+            db_engine=engine,
+            entity_date_table_name="exp_hash_subset_entity_date",
+            replace=True,
+            cohort_table="cohort")
+        subset_generator.generate_entity_date_table(as_of_dates)
+        
+        expected_output = set([2, 4])
+        results = set(list(
+            engine.execute(
+                f"""
+                select distinct entity_id from {subset_generator.entity_date_table_name}
+            """
+            )
+        ))
+
+        assert results.issubset(expected_output) == True

--- a/src/tests/architect_tests/test_entity_date_table_generators.py
+++ b/src/tests/architect_tests/test_entity_date_table_generators.py
@@ -356,7 +356,6 @@ def test_subset_odds_cohort():
         expected_output = [
             (1, datetime(2016, 3, 1), True),
             (1, datetime(2016, 4, 1), True),
-            (3, datetime(2016, 4, 1), True),
             (5, datetime(2016, 4, 1), True),
         ]
         results = list(

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -242,7 +242,7 @@ class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
                     with subset as ({dated_query})
                     select 
                         c. entity_id
-                    subset s inner join {self.cohort_table} c
+                    from subset s inner join {self.cohort_table} c
                     on s.entity_id = c.entity_id
                     and c.as_of_date = '{formatted_date}'::date
                 ) q 

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -199,3 +199,49 @@ class CohortTableGeneratorNoOp(EntityDateTableGenerator):
     @property
     def entity_date_table_name(self):
         return None
+
+
+class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
+    def __init__(self, query, db_engine, entity_date_table_name, labels_table_name=None, replace=True, cohort_table=None):
+        super().__init__(query, db_engine, entity_date_table_name, labels_table_name, replace)
+
+        self.cohort_table = cohort_table
+        
+    def __create_and_populate_entity_date_table_from_query(self, as_of_dates):
+        """Create an entity_date table by sequentially running a
+            given date-parameterized query for all known dates.
+
+        Args:
+            as_of_dates (list of datetime.date): Dates to calculate entity states as of
+        """
+        self._maybe_create_entity_date_table()
+        logger.spam(f"Inserting rows into entity_date table {self.entity_date_table_name}")
+        
+        for as_of_date in as_of_dates:
+            formatted_date = f"{as_of_date.isoformat()}"
+            logger.spam(f"Looking for existing entity_date rows for as of date {as_of_date}")
+            any_existing = list(self.db_engine.execute(
+                f"""select 1 from {self.entity_date_table_name}
+                where as_of_date = '{formatted_date}'
+                limit 1
+                """
+            ))
+            if len(any_existing) == 1:
+                logger.notice(f"Since >0 entity_date rows found for date {as_of_date}, skipping")
+                continue
+            dated_query = self.query.format(as_of_date=formatted_date)
+            full_query = f"""insert into {self.entity_date_table_name}
+                select q.entity_id, '{formatted_date}'::timestamp, true
+                from (
+                    with subset as ({dated_query})
+                    select 
+                        c. entity_id
+                    subset s inner join {self.cohort_table} c
+                    on s.entity_id = c.entity_id
+                    and c.as_of_date = '{formatted_date}'::date
+                ) q 
+                group by 1, 2, 3
+            """
+            logger.spam(f"Running entity_date query for date: {as_of_date}, {full_query}")
+            self.db_engine.execute(full_query)
+    

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -97,8 +97,6 @@ class EntityDateTableGenerator:
         as_of_dates (list of datetime.date): Dates to calculate entity states as of
         """
         
-        print('Using the parent entity-table generator')
-        
         self._maybe_create_entity_date_table()
         logger.spam(f"Inserting rows into entity_date table {self.entity_date_table_name}")
         for as_of_date in as_of_dates:
@@ -218,8 +216,6 @@ class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
             as_of_dates (list of datetime.date): Dates to calculate entity states as of
         """
         
-        print('Using the overridden entity-table generator')
-        
         self._maybe_create_entity_date_table()
         logger.spam(f"Inserting rows into entity_date table {self.entity_date_table_name}")
         
@@ -259,3 +255,13 @@ class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
         else:
             logger.warning('Query not working, subset table not created!')
     
+        if table_has_duplicates(
+            self.entity_date_table_name,
+            ['entity_id', 'as_of_date'],
+            self.db_engine
+            ):
+            raise ValueError(f"Duplicates found in {self.entity_date_table_name}!")
+
+        logger.debug(f"Entity-date table generated at {self.entity_date_table_name}")
+        logger.spam(f"Generating stats on {self.entity_date_table_name}")
+        logger.spam(f"Row count of {self.entity_date_table_name}: {table_row_count(self.entity_date_table_name, self.db_engine)}")

--- a/src/triage/component/architect/entity_date_table_generators.py
+++ b/src/triage/component/architect/entity_date_table_generators.py
@@ -96,6 +96,9 @@ class EntityDateTableGenerator:
         Args:
         as_of_dates (list of datetime.date): Dates to calculate entity states as of
         """
+        
+        print('Using the parent entity-table generator')
+        
         self._maybe_create_entity_date_table()
         logger.spam(f"Inserting rows into entity_date table {self.entity_date_table_name}")
         for as_of_date in as_of_dates:
@@ -204,16 +207,19 @@ class CohortTableGeneratorNoOp(EntityDateTableGenerator):
 class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
     def __init__(self, query, db_engine, entity_date_table_name, labels_table_name=None, replace=True, cohort_table=None):
         super().__init__(query, db_engine, entity_date_table_name, labels_table_name, replace)
-
+        print('Initializing the new child class Subset entity date generator')
         self.cohort_table = cohort_table
         
-    def __create_and_populate_entity_date_table_from_query(self, as_of_dates):
+    def create_and_populate_entity_date_table_from_query(self, as_of_dates):
         """Create an entity_date table by sequentially running a
             given date-parameterized query for all known dates.
 
         Args:
             as_of_dates (list of datetime.date): Dates to calculate entity states as of
         """
+        
+        print('Using the overridden entity-table generator')
+        
         self._maybe_create_entity_date_table()
         logger.spam(f"Inserting rows into entity_date table {self.entity_date_table_name}")
         
@@ -244,4 +250,12 @@ class SubsetEntityDateTableGenerator(EntityDateTableGenerator):
             """
             logger.spam(f"Running entity_date query for date: {as_of_date}, {full_query}")
             self.db_engine.execute(full_query)
+            
+            
+    def generate_entity_date_table(self, as_of_dates):
+        if self.query:
+            logger.spam(f"Query is present, so running query on as_of_dates: {as_of_dates}")
+            self.create_and_populate_entity_date_table_from_query(as_of_dates)
+        else:
+            logger.warning('Query not working, subset table not created!')
     

--- a/src/triage/component/catwalk/subsetters.py
+++ b/src/triage/component/catwalk/subsetters.py
@@ -3,7 +3,7 @@ logger = verboselogs.VerboseLogger(__name__)
 
 from sqlalchemy.orm import sessionmaker
 
-from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator
+from triage.component.architect.entity_date_table_generators import EntityDateTableGenerator, SubsetEntityDateTableGenerator
 from triage.component.catwalk.utils import (filename_friendly_hash, get_subset_table_name)
 from triage.component.results_schema import Subset
 
@@ -37,10 +37,12 @@ class Subsetter:
         db_engine,
         replace,
         as_of_times,
+        cohort_table_name
     ):
         self.db_engine = db_engine
         self.replace = replace
         self.as_of_times = as_of_times
+        self.cohort_table_name = cohort_table_name
 
     def generate_tasks(self, subset_configs):
         logger.debug("Generating subset table creation tasks")
@@ -48,11 +50,18 @@ class Subsetter:
         for subset_config in subset_configs:
             if subset_config:
                 subset_hash = filename_friendly_hash(subset_config)
-                subset_table_generator = EntityDateTableGenerator(
+                # subset_table_generator = EntityDateTableGenerator(
+                #     entity_date_table_name=get_subset_table_name(subset_config),
+                #     db_engine=self.db_engine,
+                #     query=subset_config["query"],
+                #     replace=self.replace
+                # )
+                subset_table_generator = SubsetEntityDateTableGenerator(
                     entity_date_table_name=get_subset_table_name(subset_config),
                     db_engine=self.db_engine,
                     query=subset_config["query"],
-                    replace=self.replace
+                    replace=self.replace,
+                    cohort_table=self.cohort_table_name
                 )
                 subset_tasks.append(
                     {

--- a/src/triage/component/catwalk/subsetters.py
+++ b/src/triage/component/catwalk/subsetters.py
@@ -49,13 +49,10 @@ class Subsetter:
         subset_tasks = []
         for subset_config in subset_configs:
             if subset_config:
+                # adding the cohort_table name to the subset_config so the hash reflects the config table name
+                subset_config['cohort_table_name'] = self.cohort_table_name
                 subset_hash = filename_friendly_hash(subset_config)
-                # subset_table_generator = EntityDateTableGenerator(
-                #     entity_date_table_name=get_subset_table_name(subset_config),
-                #     db_engine=self.db_engine,
-                #     query=subset_config["query"],
-                #     replace=self.replace
-                # )
+
                 subset_table_generator = SubsetEntityDateTableGenerator(
                     entity_date_table_name=get_subset_table_name(subset_config),
                     db_engine=self.db_engine,

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -427,6 +427,7 @@ class ExperimentBase(ABC):
                 db_engine=self.db_engine,
                 replace=self.replace,
                 as_of_times=self.all_as_of_times,
+                cohort_table_name=self.cohort_table_name
             )
         else:
             self.subsetter = SubsetterNoOp()


### PR DESCRIPTION
In the current version of triage, we view `subsets` as subsets of entities independent from cohorts we create (unless we add the cohort query to the subset query). As a result, the subset tables tend to have duplicates of the same entity_id for many as of dates (even if those entities are not a part of the cohort for those as of dates) and tends to create very large tables. 

This is more acute when we have a large universe of entities. To counter this, either we could include the cohort query in every subset query we write on the experiment config (e.g., as a CTE), or we could modify it under the hood to only include entities from the respective cohorts into the subset (treating subsets as a subset of a cohort rather than a subset of all entities). This PR is attempting to do the latter.

Merging this PR will:
- Create an extended class of the `EntityDateTableGenerator` to handle subset tables called `SubsetEntityDateTableGenerator`. The extended class adds an automatic inner join with the cohort table to make sure the subset table only includes entities that belong to the cohort of the respective date.
- Add the `cohort_table_name` to the `subset_config`, so that we can track the cohort table that the subset belong to and the `subset_hash` reflects the cohort table 
