### PR TITLE
Add linear ranker to Triage

### DIFF
--- a/src/tests/catwalk_tests/test_baselines.py
+++ b/src/tests/catwalk_tests/test_baselines.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_array_equal
 
 from triage.component.catwalk.baselines.rankers import PercentileRankOneFeature
 from triage.component.catwalk.baselines.rankers import BaselineRankMultiFeature
+from triage.component.catwalk.baselines.rankers import LinearRanker
 from triage.component.catwalk.baselines.thresholders import SimpleThresholder
 from triage.component.catwalk.baselines.thresholders import get_operator_method
 from triage.component.catwalk.baselines.thresholders import OPERATOR_METHODS
@@ -49,6 +50,15 @@ def data(request):
 @pytest.fixture(scope="class")
 def rules(request):
     request.cls.rules = ["x1 > 0", "x2 <= 1"]
+
+@pytest.fixture(scope="class")
+def features(request):
+    request.cls.features = ['x1', 'x2', 'x3', 'x4', 'x6', 'x7']
+
+@pytest.fixture(scope="class")
+def weights(request):
+    request.cls.weights = [0.6, 0.5, 0.4, 0.7, 0.6, 0.3]
+
 
 def predict_proba_deprecated(ranker, x):
         """ Generate the rank scores and return these.
@@ -285,3 +295,37 @@ class TestSimpleThresholder(TestCase):
                     [[1, 1, 1, 1, 1, 1, 0, 1], [1, 1, 1, 1, 1, 1, 0, 1]]
                 ).transpose()
             np.testing.assert_array_equal(results, expected_results)
+
+
+@pytest.mark.usefixtures("data", "features", "weights")
+class TestLinearRanker(TestCase):
+    def test_fit(self):
+        ranker = LinearRanker(
+            self.features,
+            self.weights
+        )
+        assert ranker.feature_importances_ is None
+        ranker.fit(x=self.data["X_train"], y=self.data["y_train"])
+        np.testing.assert_array_equal(
+            ranker.feature_importances_, np.array([0.19354839, 0.16129032, 
+                                                   0.12903226, 0.22580645, 
+                                                   0.19354839, 0.09677419])
+        )
+
+    def test_predict_proba(self):
+        features = self.features,
+        weights = self.weights
+        ranker = LinearRanker(features, weights)
+        ranker.fit(x=self.data["X_train"], y=self.data["y_train"])
+        results = ranker.predict_proba(self.data["X_test"])
+
+        expected_results = np.array([[0.75411428, 0.24588572],
+                                     [0.69980399, 0.30019601],
+                                     [0.79451361, 0.20548639],
+                                     [0.27090783, 0.72909217],
+                                     [0.39821089, 0.60178911],
+                                     [0.67697988, 0.32302012],
+                                     [0.51544567, 0.48455433],
+                                     [0.63648246, 0.36351754]])
+
+        np.testing.assert_array_equal(results, expected_results)

--- a/src/tests/catwalk_tests/test_baselines.py
+++ b/src/tests/catwalk_tests/test_baselines.py
@@ -306,19 +306,22 @@ class TestLinearRanker(TestCase):
         )
         assert ranker.feature_importances_ is None
         ranker.fit(x=self.data["X_train"], y=self.data["y_train"])
-        np.testing.assert_array_equal(
-            ranker.feature_importances_, np.array([0.19354839, 0.16129032, 
-                                                   0.12903226, 0.22580645, 
-                                                   0.19354839, 0.09677419])
+        np.testing.assert_almost_equal(
+            ranker.feature_importances_, 
+            np.array([0.19354839, 0.16129032, 
+                      0.12903226, 0.22580645, 
+                      0.19354839, 0.09677419]),
+            decimal=4
         )
 
     def test_predict_proba(self):
-        features = self.features,
-        weights = self.weights
-        ranker = LinearRanker(features, weights)
+        ranker = LinearRanker(self.features, 
+                              self.weights)
         ranker.fit(x=self.data["X_train"], y=self.data["y_train"])
         results = ranker.predict_proba(self.data["X_test"])
-
+        
+        assert results.shape == (8, 2)
+        
         expected_results = np.array([[0.75411428, 0.24588572],
                                      [0.69980399, 0.30019601],
                                      [0.79451361, 0.20548639],
@@ -328,4 +331,7 @@ class TestLinearRanker(TestCase):
                                      [0.51544567, 0.48455433],
                                      [0.63648246, 0.36351754]])
 
-        np.testing.assert_array_equal(results, expected_results)
+        np.testing.assert_almost_equal(results, 
+                                       expected_results, 
+                                       decimal=4)
+        

--- a/src/triage/component/catwalk/baselines/rankers.py
+++ b/src/triage/component/catwalk/baselines/rankers.py
@@ -265,6 +265,6 @@ class LinearRanker:
 
         # Compute the score as a linear combination 
         score = np.array((self.weights * x[self.features]).sum(axis=1))
-        rv = np.array([np.empty(len(score)), score]).T
+        rv = np.array([1-score, score]).T
 
         return rv

--- a/src/triage/component/catwalk/baselines/rankers.py
+++ b/src/triage/component/catwalk/baselines/rankers.py
@@ -1,8 +1,10 @@
 import verboselogs, logging
 logger = verboselogs.VerboseLogger(__name__)
-from scipy import stats
 import numpy as np
 import pandas as pd
+
+from scipy import stats
+from collections import defaultdict
 from triage.component.catwalk.exceptions import BaselineFeatureNotInMatrix
 
 REQUIRED_KEYS = frozenset(["feature", "low_value_high_score"])
@@ -190,3 +192,84 @@ class BaselineRankMultiFeature:
         scores_0 = np.array([1-s for s in scores_1])
 
         return np.array([scores_0, scores_1]).transpose()
+
+
+class LinearRanker:
+    """This baseline objects ranks importance based on a linear combination
+    given by self.weights * self.features.
+    For example, if self.weights=[0.20, 0.80] and self.features=['A', 'B'] then this
+    baseline creates a score based on the linear combination and ranks people accordingly
+
+    Attributes
+    ----------
+    features: list of features to rank on. features[0] and features[-1] are the
+        most and least important features
+    weights: list of weights to use in the linear combination
+    feature_importances_: vector in [0,1]^len(features) where a greater value
+        indicates the greater importance of the corresponding feature
+
+    Methods
+    ----------
+    fit: fill in feature_importances_ and perform sanity checks
+    predict_proba: output scores
+    """
+    def __init__(self, features, weights, random_state=42):
+        self.features = features
+        self.weights = np.array(weights) / sum(np.array(weights))
+        #self.__name__ = 'LinearRanker'
+        self.feature_importances_ = None
+        self.random_state = random_state
+    
+    def _set_feature_importance(self, x):
+        """ Assigns feature importances based on the weights provided.
+        """
+        diff_features = set(self.features).difference(set(x.columns.tolist()))
+        if len(diff_features) > 0:
+            for feature in list(diff_features): 
+                logger.error(f"LinearRanker refers to feature {feature} not included in the training matrix!")
+                raise Exception(f"LinearRanker refers to feature {feature} not included in the training matrix!")
+        
+        # feature importance 
+        df = pd.DataFrame({'feature': self.features, 'weight': self.weights})
+        # normalize weights 
+        df.weight = df.weight / df.weight.sum()
+        self.feature_importances_ = np.array(df.weight) 
+       
+
+    def fit(self, x, y):
+        """Run sanity checks and populate self.feature_importances_
+        """
+        # Ensure all the features requested are real features
+        self._set_feature_importance(x) 
+
+        return self
+
+    def predict_proba(self, x):
+        """Returns an n by 2 matrix. The first col is 0 and the second one is
+        the linear combination of self.weights and self.features.
+
+        Args:
+        x: dataframe with multiindex=(joid, as_of_date) and n rows i.e., joid-date pairs
+
+        Returns:
+        np.array of shape (n, 2) where n is the number of rows in X.
+
+        This output has this structure to mimic the behavior of sklearn.model.predic_proba()
+        """ 
+
+        # Change scale of each column from 0 to 1
+        def index_build(feat):
+            perc_99 = x[feat].quantile(0.99)
+            x.loc[x[feat] > perc_99, feat] = perc_99
+            # Apply function to non-zero percentile columns
+            if perc_99 != 0:
+                x[feat] = x[feat]/perc_99
+        
+        for feature in self.features:
+            index_build(feature)
+
+        # Compute the score as a linear combination 
+        score = np.array((self.weights * x[self.features]).sum(axis=1))
+        rv = np.array([np.empty(len(score)), score]).T
+
+        return rv

--- a/src/triage/component/catwalk/baselines/rankers.py
+++ b/src/triage/component/catwalk/baselines/rankers.py
@@ -200,18 +200,13 @@ class LinearRanker:
     For example, if self.weights=[0.20, 0.80] and self.features=['A', 'B'] then this
     baseline creates a score based on the linear combination and ranks people accordingly
 
-    Attributes
-    ----------
-    features: list of features to rank on. features[0] and features[-1] are the
-        most and least important features
-    weights: list of weights to use in the linear combination
-    feature_importances_: vector in [0,1]^len(features) where a greater value
-        indicates the greater importance of the corresponding feature
+    Args:
+        features (list): list of features to rank on. features[0] and features[-1] are the
+           most and least important features
+        weights (list): list of weights to use in the linear combination
 
-    Methods
-    ----------
-    fit: fill in feature_importances_ and perform sanity checks
-    predict_proba: output scores
+    Returns:
+        scores (array): Numpy array of shape (n, 2) where n is the number of rows in X. 
     """
     def __init__(self, features, weights, random_state=42):
         self.features = features

--- a/src/triage/component/catwalk/baselines/rankers.py
+++ b/src/triage/component/catwalk/baselines/rankers.py
@@ -226,8 +226,6 @@ class LinearRanker:
         
         # feature importance 
         df = pd.DataFrame({'feature': self.features, 'weight': self.weights})
-        # normalize weights 
-        df.weight = df.weight / df.weight.sum()
         self.feature_importances_ = np.array(df.weight) 
        
 


### PR DESCRIPTION
Adding a Linear Ranker to the menu of options of simple baselines Triage offers. 

The Capstone 2023 team developed this linear ranker as a way to emulate a heuristic generated by one of our partners in the DoJo project. It uses a list of features and corresponding weights to generate a weighted sum of features.

Unit tests were also generated (and tested).

Closes issue #961 