### PR TITLE
Linear ranker and CLI fix

### DIFF
--- a/.github/workflows/build-mkdocs.yaml
+++ b/.github/workflows/build-mkdocs.yaml
@@ -23,10 +23,9 @@ jobs:
           python-version: 3.9
       
       - name: Install dependencies
-        run: | 
-          pip install --upgrade pip && pip install -r requirement/dev.txt
-          pip install git+https://github.com/dssg/triage.git@master
-          git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+        run: pip install --upgrade pip && pip install -r requirement/dev.txt
+        run: pip install git+https://github.com/dssg/triage.git@master
+        run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
       
       - name: Publish docs
         run: mkdocs gh-deploy -f "$(pwd)/docs/mkdocs.yml"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ML/Data Science Toolkit for Social Good and Public Policy Problems
 [![image](https://codecov.io/gh/dssg/triage/branch/master/graph/badge.svg)](https://codecov.io/gh/dssg/triage)
 [![image](https://codeclimate.com/github/dssg/triage.png)](https://codeclimate.com/github/dssg/triage)
 
-Building ML/Data Science systems requires answering many design questions, turning them into modeling choices, which in turn define and machine learning models. Questions such as cohort selection, unit of analysis determination, outcome determination, feature (explanatory variables or predictors) generation, model/classifier training, evaluation, selection, bias audits, interpretation, and list generation are often complicated and hard to make design choices around apriori. In addition, once these choices are made, they have to be combined in different ways throughout the course of a project.
+Building ML/Data Science systems requires answering many design questions, turning them into modeling choices, which in turn define and machine learning models. Questions such as cohort selection, unit of analysis determination, outcome determination, feature (explanatory variables or predictors) generation, model/classifier training, evaluation, selection, bias audits, interpretation, and list generation are often complicated and hard to make design choices around a priori. In addition, once these choices are made, they have to be combined in different ways throughout the course of a project.
 
 Triage is designed to:
 
@@ -17,7 +17,7 @@ Triage is designed to:
 ## Getting Started with Triage
 
 - Are you completely new to Triage? Run through a quick tutorial hosted on google colab (no setup necessary) to see what triage can do!  [Tutorial hosted on Google Colab](https://colab.research.google.com/github/dssg/triage/blob/master/example/colab/colab_triage.ipynb)
-- Runj it locally on an [example problem and data set from Donors Choose](https://github.com/dssg/donors-choose)
+- Run it locally on an [example problem and data set from Donors Choose](https://github.com/dssg/donors-choose)
 - [Dirty Duck Tutorial](https://dssg.github.io/triage/dirtyduck/) - Want a more in-depth walk through of triage's functionality and concepts? Go through the dirty duck tutorial that you can install on your local machine  with sample data
 - [QuickStart Guide](https://dssg.github.io/triage/quickstart/) - Try Triage out with your own project and data
 - [Triage Documentation Site](https://dssg.github.io/triage/) - Used Triage before and want more reference documentation?
@@ -34,11 +34,11 @@ To install Triage locally, you need:
   - **NOTE**: If your database is PostgreSQL 11+ you will get some
     speed improvements. We recommend updating to a recent
     version of PostgreSQL.
-- Ample space on an available disk, (or for example in Amazon Web
-  Services's S3), to store the matrices and models that will be created for your
+- Ample space on an available disk (or for example in Amazon Web
+  Services's S3) to store the matrices and models that will be created for your
   experiments
 
-We recommend starting with a new python virtual environment and pip installing triage there.
+We recommend starting with a new Python virtual environment and pip installing triage there.
 ```bash
 $ virtualenv triage-env
 $ . triage-env/bin/activate
@@ -90,7 +90,7 @@ There are a plethora of options available for experiment running, affecting thin
 
 ## Development
 
-Triag was initially developed at [University of Chicago's Center For Data Science and Public Policy](http://dsapp.uchicago.edu) and is now being maintained at Carnegie Mellon University.
+Triage was initially developed at [University of Chicago's Center For Data Science and Public Policy](http://dsapp.uchicago.edu) and is now being maintained at Carnegie Mellon University.
 
 To build this package (without installation), its dependencies may
 alternatively be installed from the terminal using `pip`:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,7 +59,6 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde
-  - pymdownx.superfences
 
 extra_javascript:
   - "js/mermaid.min.js"
@@ -69,15 +68,12 @@ extra_css:
   - "triage_docs.css"
 
 plugins: 
+  - search
   - mkdocstrings:
       default_handler: python
-      handlers:
+      handlers: 
         python:
-          rendering:
-            show_source: false
-      watch:
-        - src/triage
-
+          paths: [../src] 
 
 nav:
   - Home: index.md

--- a/docs/sources/api/audition/auditioner.md
+++ b/docs/sources/api/audition/auditioner.md
@@ -2,9 +2,10 @@ The `Auditioner` class is the main entry point for the Audition module. Users pa
 
 Other methods allow users to define more complex selection rules, list selected models, or plot results from the selection process.
 
-::: triage.component.audition.__init__
-    rendering:
-        show_root_toc_entry: False
-        group_by_category: True
-        show_category_heading: True
-        show_if_no_docstring: True
+::: triage.component.audition
+    options:
+        show_root_toc_entry: false
+        group_by_category: true
+        show_category_heading: true
+        show_if_no_docstring: true
+        

--- a/docs/sources/api/audition/selection_rules.md
+++ b/docs/sources/api/audition/selection_rules.md
@@ -9,9 +9,9 @@ A selection rule can be evaluated by calculating its *regret*, or the difference
 Triage supports 8 model selection rules. Each is represented internally by one of the following functions:
 
 ::: triage.component.audition.selection_rules
-    rendering:
+    options:
         heading_level: 3
-        show_root_toc_entry: False
+        show_root_toc_entry: false
     selection:
         filters: 
             - "!^BoundSelectionRule"
@@ -25,21 +25,21 @@ The arguments of each `add_rule_` method map to the arguments of the correspondi
 
 
 ::: triage.component.audition.rules_maker
-    rendering:
-        show_if_no_docstring: True
-        show_category_heading: False
-        show_root_heading: False
-        show_root_toc_entry: False
+    options:
+        show_if_no_docstring: true
+        show_category_heading: false
+        show_root_heading: false
+        show_root_toc_entry: false
         heading_level: 3
-    selection:
-        members:
-            - SimpleRuleMaker
-            - TwoMetricsRuleMaker
-            - RandomGroupRuleMaker
+        selection:
+            members:
+                - SimpleRuleMaker
+                - TwoMetricsRuleMaker
+                - RandomGroupRuleMaker
   
 ## Selection Grid
 
 ::: triage.component.audition.selection_rule_grid
-    rendering:
+    options:
         heading_level: 3
-        show_root_toc_entry: False
+        show_root_toc_entry: false

--- a/docs/sources/api/timechop/plotting.md
+++ b/docs/sources/api/timechop/plotting.md
@@ -1,5 +1,5 @@
 ::: triage.component.timechop.plotting.visualize_chops
-    rendering:
+    options:
         show_root_toc_entry: False
         group_by_category: True
         show_category_heading: True

--- a/docs/sources/api/timechop/timechop.md
+++ b/docs/sources/api/timechop/timechop.md
@@ -1,5 +1,5 @@
 ::: triage.component.timechop.timechop
-    rendering:
+    options:
         show_root_toc_entry: False
         group_by_category: True
         show_category_heading: True

--- a/docs/sources/dirtyduck/index.md
+++ b/docs/sources/dirtyduck/index.md
@@ -1,10 +1,10 @@
 This is a guide to `Triage`, a machine learning / data science tool initially developed at the [Center for Data Science and Public
-Policy](http://dsapp.uchicago.edu) (DSaPP) at the University of
+Policy](http://datasciencepublicpolicy.org) (DSaPP) at the University of
 Chicago and now being maintained at Carnegie Mellon University.
 
 
 `Triage` helps build ML systems for two [common
-problems](https://dssg.uchicago.edu/data-science-for-social-good-conference-2017/training-workshop-data-science-for-social-good-problem-templates/):
+problems](https://dssgfellowship.org/data-science-for-social-good-conference-2017/training-workshop-data-science-for-social-good-problem-templates/):
 (a) Early warning systems (**EWS** or **EIS**), (b) *resource
 prioritization* (a.k.a "an inspections problem"). These problems require careful thought and design and their formulation and
 implementation are often done incorrectly.

--- a/docs/sources/postmodeling/index.md
+++ b/docs/sources/postmodeling/index.md
@@ -1,6 +1,6 @@
 # Postmodeling
 
-The bulk of postmodeling is documented on its README. [Read it here](https://github.com/dssg/triage/tree/master/src/triage/component/postmodeling/contrast)
+The bulk of postmodeling is documented on its README. [Read it here](https://github.com/dssg/triage/tree/master/src/triage/component/postmodeling)
 
 ## Crosstabs
 

--- a/requirement/dev.txt
+++ b/requirement/dev.txt
@@ -1,8 +1,8 @@
 -r include/build.txt
-bump2version==1.0.1
-mkdocs==1.5.3
+bumpversion==0.6.0 
+mkdocs==1.6.1
 pymdown-extensions==10.8
 mkdocs-material==9.4.6
-mkdocstrings==0.24.0
-mkdocstrings-python==1.7.2
+mkdocstrings==0.29.1
+mkdocstrings-python==1.16.10
 black==22.3.0

--- a/requirement/main.txt
+++ b/requirement/main.txt
@@ -29,3 +29,4 @@ seaborn==0.11.2
 ohio==0.5.0
 aequitas==0.42.0
 plotly==6.0.1
+jupyter==1.0.0

--- a/src/triage/cli.py
+++ b/src/triage/cli.py
@@ -32,7 +32,7 @@ from triage.experiments import (
 )
 from triage.predictlist import predict_forward_with_existed_model, Retrainer
 from triage.component.postmodeling.crosstabs import CrosstabsConfigLoader, run_crosstabs
-from triage.component.postmodeling.utils.add_predictions import add_predictions
+from triage.component.postmodeling.add_predictions import add_predictions
 from triage.util.conf import load_query_if_needed
 from triage.util.db import create_engine
 


### PR DESCRIPTION
# New release (5.5.0)

## New functionality 
* Added `LinearRanker` to the available options for simple rankers. This ranker allows users to define weighted features, enabling the creation of baseline models that can mimic existing solutions

## Bug Fixes 
* Fixed the path for `add_predictions` script on CLI 
* Added `jupyter` package to requirements. The Experiment Summary Report task added in version 5.4.0 requires `ipykernel` and `nbconvert`, which come as part of the `jupyter` package
* Fixed display precision option in the experiment summary report template notebook

## Documentation 
* Updates in the Postmodeling section documentation on github pages 

Closes issues #960 #962 
