### PR TITLE
Deleting matrices (csv.gz) from /tmp when using S3 as storage

### DIFF
--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -556,7 +556,7 @@ class MatrixBuilder(BuilderBase):
         matrix_store.save_tmp_csv(output_, path_, matrix_uuid, "_label.csv")
 
         # add label file to filenames
-        filenames.append(path_ + "/" + matrix_uuid + "_label.csv")
+        filenames.append(f"{path_}/{matrix_uuid}_label.csv")
         
         # check if the number of rows among all features and label -if any- files are the same
         try: 
@@ -598,7 +598,7 @@ class MatrixBuilder(BuilderBase):
         logger.debug(f"about to load csvmatrix with uuid {matrix_uuid} as polars df")
         start = time.time()
         # load as DF with polars
-        filename_ = path_ + '/' + matrix_uuid + '.csv'
+        filename_ = f'{path_}/{matrix_uuid}.csv'
         #df = pd.read_csv(filename_, parse_dates=["as_of_date"])
         df_pl = pl.read_csv(filename_, infer_schema_length=0).with_columns(pl.all().exclude(
             ['entity_id', 'as_of_date']).cast(pl.Float32, strict=False))

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -640,8 +640,7 @@ class MatrixBuilder(BuilderBase):
         df.set_index(["entity_id", "as_of_date"], inplace=True)
         logger.debug(f"df data types: {df.dtypes}")
         logger.debug(f"Pandas DF memory usage: {df.memory_usage(deep=True).sum()/1000000} MB")
-
-        logger.debug(f"Generating gzip from full matrix csv")
+        # generating gzip file from csv
         generate_gzip(path_, matrix_uuid)
 
         # if matrix store is S3 

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -338,7 +338,7 @@ def generate_gzip(path, matrix_uuid):
     """
     filename_ = f"{path}/{matrix_uuid}.csv"
 
-    logger.debug(f"About to generate gzip for {matrix_uuid}.csv")
+    logger.debug(f"About to generate gzip for {matrix_uuid}.csv in {filename_}")
     try:
         with open(filename_, 'rb') as f_in:
             with gzip.open(f"{filename_}.gz", 'wb') as f_out:

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -337,8 +337,8 @@ def generate_gzip(path, matrix_uuid):
         matrix_uuid (string): _description_
     """
     filename_ = f"{path}/{matrix_uuid}.csv"
-
-    logger.debug(f"About to generate gzip for {matrix_uuid}.csv in {"/".join(filename_.split("/")[:-1])}")
+    filepath_ = "/".join(filename_.split("/")[:-1])
+    logger.debug(f"About to generate gzip for {matrix_uuid}.csv in {filepath_}")
     try:
         with open(filename_, 'rb') as f_in:
             with gzip.open(f"{filename_}.gz", 'wb') as f_out:

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -338,12 +338,12 @@ def generate_gzip(path, matrix_uuid):
     """
     filename_ = f"{path}/{matrix_uuid}.csv"
 
-    logger.debug(f"About to generate gzip for {matrix_uuid}.csv in {filename_}")
+    logger.debug(f"About to generate gzip for {matrix_uuid}.csv in {"/".join(filename_.split("/")[:-1])}")
     try:
         with open(filename_, 'rb') as f_in:
             with gzip.open(f"{filename_}.gz", 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)
-                logger.debug(f"gzip file {matrix_uuid}.csv.gz generated")
+                logger.debug(f"gzip file {filename_}.gz generated")
     except FileNotFoundError as e:
         logger.error(f"File {filename_} not found: {e}")
     except Exception as e:

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -615,7 +615,7 @@ class CSVMatrixStore(MatrixStore):
         # if it is a S3 storage type
         else:
             user_id = os.getenv('USER')
-            path_ = Path(f"/tmp/{user_id}/")
+            path_ = Path(f"/tmp/{user_id}")
             # create directory if it doesn't exist
             os.makedirs(path_, exist_ok=True)
         

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -614,8 +614,9 @@ class CSVMatrixStore(MatrixStore):
             path_ = Path("/" + "/".join(parts_path))
         # if it is a S3 storage type
         else:
-            # path_ = Path("/tmp/triage_output/matrices")
-            path_ = Path("/tmp")
+            user_id = os.getenv('USER')
+            # path_ = Path("/tmp/$user/")
+            path_ = Path(f"/tmp/{user_id}")
             os.makedirs(path_, exist_ok=True)
         
         logger.debug(f"get storage directory path: {path_}")

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -615,8 +615,8 @@ class CSVMatrixStore(MatrixStore):
         # if it is a S3 storage type
         else:
             user_id = os.getenv('USER')
-            # path_ = Path("/tmp/$user/")
-            path_ = Path(f"/tmp/{user_id}")
+            path_ = Path(f"/tmp/{user_id}/")
+            # create directory if it doesn't exist
             os.makedirs(path_, exist_ok=True)
         
         logger.debug(f"get storage directory path: {path_}")

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -703,7 +703,7 @@ class CSVMatrixStore(MatrixStore):
 
     def save_tmp_csv(self, output, path_, matrix_uuid, suffix):
         logger.debug(f"saving temporal csv for matrix {matrix_uuid + suffix} ")
-        with open(path_ + "/" + matrix_uuid + suffix, "wb") as fd:  
+        with open(f"{path_}/{matrix_uuid}{suffix}", "wb") as fd:  
             return fd.write(output)
 
 

--- a/src/triage/component/catwalk/storage.py
+++ b/src/triage/component/catwalk/storage.py
@@ -152,8 +152,11 @@ class S3Store(Store):
         return self.S3FileWrapper(s3file)
     
     def download(self, *args, **kwargs):
-        self.client.download(self.path, "/tmp/")
-        logger.debug(f"File {self.path} downloaded from S3 to /tmp/")
+        """Download the file from S3 to the local filesystem.""" 
+        user_id = os.getenv('USER')
+        filepath_ = f"/tmp/{user_id}"
+        self.client.download(self.path, filepath_)
+        logger.debug(f"File {self.path} downloaded from S3 to {filepath_}")
 
 
 class FSStore(Store):


### PR DESCRIPTION
Closes Issue #957 

### What it does
When the project's storage is S3, we use the `/tmp` folder to store temporary files needed to build feature matrices and to download the matrices stored in S3 when training models. `csv.gz` files weren't being deleted, causing problems when more than 1 person is working on the same project. Now we use the `/tmp/{user}` folder to store files generated by Triage, making sure we are deleting them after feature matrices creation **and** after we upload the matrices in memory for training models.  

### Modifications 
* `catwalk.storage`: Using `/tmp/{user}` to store temporary CSV files, matrices generated (`csv.gz`), and matrices downloaded from S3 used for training.
* `architect.builders`: 
      * Eliminated `generate_gzip` and `remove_unnecessary_files` functions from the MatrixBuild class and moved them to `architect.utils`  
      * Modify/eliminate ambiguous debug logging messages to be clearer ("about to...", instead of "doing...") 
      * Improve code on how we are creating and eliminating files for creating matrices (`subprocess` with check and sending list to eliminate `shell=True`)

### Testing 
Tested in the following scenarios with Donors choose project
* Single thread experiment in S3 storage 
* Single thread experiment in File System storage 
* Multi thread experiment in S3 storage 
* Multi thread experiment in File System storage 
