### PR TITLE
Crosstabs from a matrix

### DIFF
--- a/requirement/test.txt
+++ b/requirement/test.txt
@@ -1,7 +1,7 @@
 -r include/lint.txt
 -r include/test-management.txt
 parsedatetime==2.6
-csvkit==1.0.7
+#csvkit==1.0.7
 factory_boy==3.2.1
 testing.postgresql==1.3.0
 pytest==6.2.5 #<4.0.0 # pyup: ignore

--- a/src/tests/postmodeling_tests/test_crosstabs.py
+++ b/src/tests/postmodeling_tests/test_crosstabs.py
@@ -1,4 +1,6 @@
-import pytest 
+
+
+import pandas as pd
 
 from triage.component.postmodeling.crosstabs import run_crosstabs, run_crosstabs_from_matrix
 from triage.database_reflection import table_has_data
@@ -9,14 +11,12 @@ def test_run_crosstabs(finished_experiment, crosstabs_config):
     expected_table_name = (
         crosstabs_config.output["schema"] + "." + crosstabs_config.output["table"]
     )
-    table_has_data(expected_table_name, finished_experiment.db_engine)
+    assert table_has_data(expected_table_name, finished_experiment.db_engine)
 
-
+    
 def test_run_crosstabs_from_matrix(finished_experiment):
     """assert that crosstabs table is populated for all threshold types"""
-    project_path = finished_experiment.project_storage.project_path
-    engine=finished_experiment.db_engine
-    model_id = 1
+    
     thresholds = {
         'rank_abs_no_ties': 50,
         'rank_abs_with_ties': 50, 
@@ -26,17 +26,32 @@ def test_run_crosstabs_from_matrix(finished_experiment):
     table_schema='test_results'
     table_name = 'crosstabs'
     
-    for threshold_type, threshold in thresholds.items():
-        run_crosstabs_from_matrix(
-            db_engine=engine,
-            project_path=project_path,
-            model_id=model_id,
+    errors = list()
+    for threshold_type, threshold in thresholds.items():    
+        df = run_crosstabs_from_matrix(
+            db_engine=finished_experiment.db_engine,
+            project_path=finished_experiment.project_path,
+            model_id=1,
             threshold_type=threshold_type,
             threshold=threshold,
             push_to_db=True,
             table_schema=table_schema,
-            table_name=table_name
+            table_name=table_name,
+            replace=True
         )
         
-        assert table_has_data(f'{table_schema}.{table_name}', engine)
-    
+        q = f'''
+            select 
+            1
+            from {table_schema}.{table_name}
+            where model_id = 1
+            and threshold_type = '{threshold_type}'
+            and threshold = {threshold}
+        '''
+        
+        df = pd.read_sql(q,finished_experiment.db_engine)
+                
+        if df.empty:
+            errors.append(threshold_type)
+ 
+    assert not errors, f"errors occured for: {errors}"    

--- a/src/tests/postmodeling_tests/test_crosstabs.py
+++ b/src/tests/postmodeling_tests/test_crosstabs.py
@@ -1,4 +1,6 @@
-from triage.component.postmodeling.crosstabs import run_crosstabs
+import pytest 
+
+from triage.component.postmodeling.crosstabs import run_crosstabs, run_crosstabs_from_matrix
 from triage.database_reflection import table_has_data
 
 
@@ -8,3 +10,33 @@ def test_run_crosstabs(finished_experiment, crosstabs_config):
         crosstabs_config.output["schema"] + "." + crosstabs_config.output["table"]
     )
     table_has_data(expected_table_name, finished_experiment.db_engine)
+
+
+def test_run_crosstabs_from_matrix(finished_experiment):
+    """assert that crosstabs table is populated for all threshold types"""
+    project_path = finished_experiment.project_storage.project_path
+    engine=finished_experiment.db_engine
+    model_id = 1
+    thresholds = {
+        'rank_abs_no_ties': 50,
+        'rank_abs_with_ties': 50, 
+        'rank_pct_no_ties': 0.1,
+        'rank_pct_with_ties': 0.1
+    }
+    table_schema='test_results'
+    table_name = 'crosstabs'
+    
+    for threshold_type, threshold in thresholds.items():
+        run_crosstabs_from_matrix(
+            db_engine=engine,
+            project_path=project_path,
+            model_id=model_id,
+            threshold_type=threshold_type,
+            threshold=threshold,
+            push_to_db=True,
+            table_schema=table_schema,
+            table_name=table_name
+        )
+        
+        assert table_has_data(f'{table_schema}.{table_name}', engine)
+    

--- a/src/tests/utils.py
+++ b/src/tests/utils.py
@@ -388,13 +388,13 @@ def sample_config(query_source="filepath"):
         "feature_start_time": "2010-01-01",
         "feature_end_time": "2014-01-01",
         "label_start_time": "2011-01-01",
-        "label_end_time": "2014-01-01",
+        "label_end_time": "2015-01-01",
         "model_update_frequency": "1year",
-        "training_label_timespans": ["6months"],
-        "test_label_timespans": ["6months"],
+        "training_label_timespans": ["12months"],
+        "test_label_timespans": ["12months"],
         "training_as_of_date_frequencies": "1day",
-        "test_as_of_date_frequencies": "3months",
-        "max_training_histories": ["6months"],
+        "test_as_of_date_frequencies": "3day",
+        "max_training_histories": ["10years"],
         "test_durations": ["1months"],
     }
 
@@ -433,7 +433,7 @@ def sample_config(query_source="filepath"):
             "knowledge_date_column": "as_of_date",
             "aggregates_imputation": {"all": {"type": "constant", "value": 0}},
             "aggregates": [{"quantity": "cat_sightings", "metrics": ["count", "avg"]}],
-            "intervals": ["1year"],
+            "intervals": ["all"],
         },
         {
             "prefix": "zip_code_features",
@@ -441,7 +441,7 @@ def sample_config(query_source="filepath"):
             "knowledge_date_column": "as_of_date",
             "aggregates_imputation": {"all": {"type": "constant", "value": 0}},
             "aggregates": [{"quantity": "num_events", "metrics": ["max", "min"]}],
-            "intervals": ["1year"],
+            "intervals": ["all"],
         },
     ]
 
@@ -477,14 +477,14 @@ def sample_config(query_source="filepath"):
             "parameters",
         ],
         "feature_aggregations": feature_config,
-        "cohort_config": cohort_config,
+        # "cohort_config": cohort_config,
         "temporal_config": temporal_config,
         "grid_config": grid_config,
         "bias_audit_config": bias_audit_config,
         "prediction": {"rank_tiebreaker": "random"},
         "scoring": scoring_config,
         "user_metadata": {"custom_key": "custom_value"},
-        "individual_importance": {"n_ranks": 2},
+        # "individual_importance": {"n_ranks": 2},
     }
 
 

--- a/src/triage/component/architect/builders.py
+++ b/src/triage/component/architect/builders.py
@@ -644,14 +644,16 @@ class MatrixBuilder(BuilderBase):
         generate_gzip(path_, matrix_uuid)
 
         # if matrix store is S3 
+        store_is_s3 = False
         if isinstance(matrix_store.matrix_base_store, S3Store):
             logger.debug(f"storing {matrix_uuid}.csv.gz on S3")
             matrix_store._save(path_, matrix_store.matrix_base_store.path)
+            store_is_s3 = True
 
         logger.debug(f"removing csvs files for matrix {matrix_uuid}")
         # addinig _sorted and _fixed files to list of files to rm 
         rm_filenames = generate_list_of_files_to_remove(filenames, matrix_uuid)
-        remove_unnecessary_files(rm_filenames, path_, matrix_uuid)
+        remove_unnecessary_files(rm_filenames, path_, matrix_uuid, store_is_s3)
 
         return df, labels_series
 

--- a/src/triage/component/architect/utils.py
+++ b/src/triage/component/architect/utils.py
@@ -350,7 +350,7 @@ def generate_gzip(path, matrix_uuid):
         logger.error(f"An error occurred while generating gzip: {e}")
 
 
-def remove_unnecessary_files(filenames, path_, matrix_uuid):
+def remove_unnecessary_files(filenames, path_, matrix_uuid, storage_is_s3):
     """
     Removes the csvs generated for each feature, the label csv file,
     and the csv with all the features and label stitched togheter. 
@@ -360,6 +360,7 @@ def remove_unnecessary_files(filenames, path_, matrix_uuid):
         filenames (list): list of filenames to remove from disk
         path_ (string): Path 
         matrix_uuid (string): ID of the matrix
+        storage_is_s3 (bool): Whether the project store is a S3 bucket
     """
     # deleting features and label csvs
     for filename_ in filenames:
@@ -379,7 +380,7 @@ def remove_unnecessary_files(filenames, path_, matrix_uuid):
         logger.error(f"Error removing file {path_}/{matrix_uuid}.csv: {e}")
     
     # deleting the compressed CSV when the project path is S3
-    if path_.startswith('/tmp'):
+    if storage_is_s3:
         filename_ = f"{path_}/{matrix_uuid}.csv.gz"
         cmd_line = ['rm', filename_]
         logger.debug(f"About to remove gzip file with command {cmd_line}")

--- a/src/triage/component/postmodeling/crosstabs.py
+++ b/src/triage/component/postmodeling/crosstabs.py
@@ -320,9 +320,9 @@ def run_crosstabs_from_matrix(db_engine, project_path, model_id, threshold_type,
             
             if not df.empty:
                 if replace: 
-                    logging.info('Exsiting crosstabs found for model {model_id} and matrix {matrix_uuid}. Replace is True. Deleting.')
+                    logging.info(f'Exsiting crosstabs found for model {model_id} and matrix {matrix_uuid}. Replace is True. Deleting.')
                 else:
-                    logging.info('Existing crosstabs found for model {model_id} and matrix {matrix_uuid}. Replace flag is not set. Skipping')
+                    logging.info(f'Existing crosstabs found for model {model_id} and matrix {matrix_uuid}. Replace flag is not set. Skipping')
                     continue
             
             crosstab_tasks.append(matrix_uuid)

--- a/src/triage/component/postmodeling/crosstabs.py
+++ b/src/triage/component/postmodeling/crosstabs.py
@@ -253,6 +253,24 @@ def run_crosstabs(db_engine, crosstabs_config):
 
 
 def run_crosstabs_from_matrix(db_engine, project_path, model_id, threshold_type, threshold, matrix_uuid=None, push_to_db=True, table_schema='test_results', table_name='crosstabs', return_as_dataframe=True, replace=False):
+    """ Calculate crosstabs for a model based on the matrix. 
+        
+        Args: 
+            db_engine: Database engine
+            project_path (str): Path where the experiment artifacts (models and matrices) are stored
+            thresholds (Dict{str: Union[float, int}]): A dictionary that maps threhold type to the threshold
+                                                    The threshold type can be one of the rank columns in the test_results.predictions_table
+           
+            matrix_uuid (str, optional): To run crosstabs for a different matrix than the validation matrix from the experiment
+
+            push_to_db (bool, optional): Whether to write the results to the database. Defaults to True
+            
+            table_schame (str, optional): Database schema to store the crosstabs table. Defaults to `test_results`
+            table_name (str, optional): Table name to use. Defaults to `crosstabs`. If the table exists, results are appended
+
+        return:
+            Dataframe of crosstabs
+    """
     
     logging.info('Fetching predictions')
     


### PR DESCRIPTION
Adds a function to `crosstabs.py` for generating crosstabs from the saved matrix without having to rely on the `features` schema. When trying to add tests to the testing suite, had to make a couple of additional changes. 

- If the project folder is an S3 bucket, when we create matrices, we use a /tmp folder to store temporary matrices. Then, once the matrices are moved to S3, we delete the files in the /tmp folder. In the test suite, the mock experiment uses a /tmp folder as the `project_folder`, and our current process would delete everything from the project folder, removing the matrices needed for model building. To fix this, this PR passes an explicit s3 flag to the `remove_unnecessary_files()` without relying on the path starting with `/tmp`. This change affects triage experiments, not post-modeling. 
- OHIO does not work with our current version of SQLAlchemy and can't simply copy the dataframe to the DB. Using psycopg2 copy to copy the dataframe with an explicit `create table` statement as a workaround.  
- Expanded the timechop to create slightly bigger matrices for the mock experiments.
- Had to remove csvkit from the test requirements as it was forcing the installation of a newer SQLAlchemy version. It doesn't look like we use csvkit in the test suite, and we can't use SQLAlchemy > 1.3.18

Closes #979