### PR TITLE
Hotfix issue 983

### DIFF
--- a/src/triage/component/timechop/plotting.py
+++ b/src/triage/component/timechop/plotting.py
@@ -1,13 +1,13 @@
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.dates as md
 import numpy as np
-from triage.util.conf import convert_str_to_relativedelta
 import matplotlib.pyplot as plt
-import plotly.express as px
-from plotly.subplots import make_subplots
 import plotly.graph_objects as go
+matplotlib.use('Agg')
+
 from datetime import datetime
+from plotly.subplots import make_subplots
+from triage.util.conf import convert_str_to_relativedelta
 
 
 FIG_SIZE = (32, 16)

--- a/src/triage/experiments/base.py
+++ b/src/triage/experiments/base.py
@@ -242,7 +242,7 @@ class ExperimentBase(ABC):
                 "tested and evaluated everytime that you run this experiment configuration"
             )
 
-        self.random_seed = self.config.pop("random_seed", random.randint(1, 1e7))
+        self.random_seed = self.config.pop("random_seed", random.randint(1, 10000000))
 
         logger.verbose(
             f"Using random seed [{self.random_seed}] for running the experiment"


### PR DESCRIPTION
This pull request fixes 2 errors identified in Colab: 

- The latest Colab version uses Python 3.12 as the default version. In that version, the scientific notation in `random.randint` has been deprecated. We changed the scientific notation to an integer number. Present in `base.py` line **245**
- We are using `plotly` to visualize the timechops generated by Triage in the summary report. The extension `plotly.express` requires to have newer versions of numpy than the one we are using in Triage. We aren't using that extension on any of the plots, but still have the conflicting import. We deleted that unused import, which fixes the rest of the Colab. 

Closes issue #983 